### PR TITLE
Sync init prompt with upstream Codex (resolves #12)

### DIFF
--- a/packages/pi-agentsmd/CHANGELOG.md
+++ b/packages/pi-agentsmd/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Fixed
+
+- Sync init prompt with upstream Codex to refuse overwriting an existing AGENTS.md (resolves #12)
+
 ## [0.1.1] - 2026-06-08
 
 ### Fixed

--- a/packages/pi-agentsmd/prompts/init.md
+++ b/packages/pi-agentsmd/prompts/init.md
@@ -1,4 +1,5 @@
 Generate a file named AGENTS.md that serves as a contributor guide for this repository.
+Before writing, check whether AGENTS.md already exists in the current working directory. If it does, do not overwrite or modify it.
 Your goal is to produce a clear, concise, and well-structured document with descriptive headings and actionable explanations for each section.
 Follow the outline below, but adapt as needed — add sections if relevant, and omit those that do not apply to this project.
 


### PR DESCRIPTION
Mirrors the upstream change in `openai/codex`'s `codex-rs/tui/prompt_for_init_command.md`: the model is now told to refuse overwriting or modifying an existing `AGENTS.md` in the working directory.

### Changes
- `packages/pi-agentsmd/prompts/init.md`: insert the upstream-added line instructing the model to check for an existing `AGENTS.md` and not overwrite or modify it.
- `packages/pi-agentsmd/CHANGELOG.md`: note the sync under `[Unreleased] > Fixed`.

### Verification
- `diff` between local `prompts/init.md` and the upstream file at `https://raw.githubusercontent.com/openai/codex/main/codex-rs/tui/prompt_for_init_command.md` is empty (local now matches upstream).
- `npm run check` (tsc --noEmit) passes.
- `npm run pack:dry-run` shows the expected file set.

Fixes #12