### PR TITLE
Fix npm 12 install recovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4035,7 +4035,7 @@
       "license": "MIT"
     },
     "packages/pi-compound-engineering": {
-      "version": "3.19.0",
+      "version": "3.19.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/packages/pi-compound-engineering/AGENTS.md
+++ b/packages/pi-compound-engineering/AGENTS.md
@@ -2,7 +2,7 @@
 
 `pi-compound-engineering` ships Every Inc.'s [compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) (CE) for Pi. The package is a **recipe-only** loader: it commits the glue code (extension, telemetry, dependency detection, `/ce-status` command) and a pure-Node port of the upstream CE-to-Pi converter. At `npm install` time, a `preinstall` script fetches the pinned CE release from GitHub, verifies its SHA256, and stages the resulting `skills/` in a temp dir. A `postinstall` script then commits the staged content into the package's install directory.
 
-The package tracks the upstream `compound-engineering` component version exactly (e.g. CE `3.13.0` → `pi-compound-engineering@3.13.0`) so a user can read the upstream changelog and know what they have.
+The package normally tracks the upstream `compound-engineering` component version (e.g. CE `3.13.0` → `pi-compound-engineering@3.13.0`). A Pi-specific hotfix may increment the package patch while retaining the upstream version in `package.json` → `ceVersion`, so users can identify the mirrored CE release.
 
 ## Project Structure & Module Organization
 
@@ -98,7 +98,7 @@ This is by design: see `README.md` for the rationale. The implementation rules:
 
 When CE upstream tags a new release (e.g. `compound-engineering-v3.19.0`):
 
-1. Bump `CE_VERSION` in `src/ce-version.ts` **and** the `"version"` field in `package.json` to the new upstream version string. The version of `pi-compound-engineering` is identical to the upstream CE component version; the dual write is the lockstep contract.
+1. Bump `CE_VERSION` in `src/ce-version.ts`, `PACKAGE_VERSION` in the same file, and the `"version"` and `"ceVersion"` fields in `package.json` to the new upstream version string. For a Pi-only hotfix, increment only the package version and `PACKAGE_VERSION`; retain the existing `CE_VERSION` and `ceVersion`.
 2. Compute the new SHA256 locally:
    ```bash
    curl -sL "https://codeload.github.com/EveryInc/compound-engineering-plugin/tar.gz/refs/tags/compound-engineering-v<NEW_VERSION>" | sha256sum

--- a/packages/pi-compound-engineering/CHANGELOG.md
+++ b/packages/pi-compound-engineering/CHANGELOG.md
@@ -5,9 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-The package version tracks the upstream [`compound-engineering`](https://github.com/EveryInc/compound-engineering-plugin) component version exactly (see `src/ce-version.ts`). The package has **no independent hotfix counter** — a release of `compound-engineering` is a release of `pi-compound-engineering`. Pi-specific divergence notes appear under `## [Unreleased]`.
+The package normally tracks the upstream [`compound-engineering`](https://github.com/EveryInc/compound-engineering-plugin) component version. Pi-specific hotfixes may increment the package patch while retaining the pinned upstream version; see `package.json` → `ceVersion` and `src/ce-version.ts`.
 
 ## [Unreleased]
+
+## [3.19.1] - 2026-07-12
+
+Mirrors [`compound-engineering-plugin` v3.19.0](https://github.com/EveryInc/compound-engineering-plugin/releases/tag/compound-engineering-v3.19.0) with a Pi-specific npm 12 installation hotfix.
+
+### Changed
+
+- Documented npm 12's dependency-script approval requirement and updated the missing-skills warning with scoped approval and rebuild recovery commands.
+- Decoupled the package version from the pinned upstream CE version so install scripts continue to fetch `compound-engineering-v3.19.0` for this hotfix release.
 
 ## [3.19.0] - 2026-07-12
 

--- a/packages/pi-compound-engineering/CONTRIBUTING.md
+++ b/packages/pi-compound-engineering/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Then run `/ce-status` inside Pi and verify the `[Skills]` list shows 29 `ce-*` e
 To exercise the install-time scripts in isolation:
 
 ```bash
-# Stage into $TMP/pi-compound-engineering-staging-<pid>/
+# Stage into ~/.pi-compound-engineering-staging/run-<random>/
 node scripts/stage.mjs
 
 # Move the staged content into the install dir
@@ -54,7 +54,7 @@ Before opening a pull request:
 
 This is the most common contribution. When CE upstream tags a new release (e.g. `compound-engineering-v3.19.0`):
 
-1. Bump `CE_VERSION` in `src/ce-version.ts` **and** the `"version"` field in `package.json` to the new upstream version string. The version of `pi-compound-engineering` is identical to the upstream CE component version; the dual write is the lockstep contract.
+1. Bump `CE_VERSION` and `PACKAGE_VERSION` in `src/ce-version.ts`, plus the `"version"` and `"ceVersion"` fields in `package.json`, to the new upstream version string. For a Pi-only hotfix, increment only the package version and `PACKAGE_VERSION`; retain the pinned upstream `CE_VERSION` and `ceVersion`.
 2. Compute the new SHA256 locally:
    ```bash
    curl -sL "https://codeload.github.com/EveryInc/compound-engineering-plugin/tar.gz/refs/tags/compound-engineering-v<NEW_VERSION>" | sha256sum

--- a/packages/pi-compound-engineering/README.md
+++ b/packages/pi-compound-engineering/README.md
@@ -13,7 +13,7 @@
 - **Skills-only upstream alignment** — CE v3.14.0+ packages specialist prompts inside their owning skills. Pi follows that model and keeps the installed surface aligned with upstream.
 - **`/ce-status`** — a slash command that reports the synced CE version, skill count, and detected peer packages.
 - **One-shot dependency warnings** — gentle notifications on first session start when peer packages are missing.
-- **Skipped-postinstall warning** — fires when the `skills/` directory is empty (the `--ignore-scripts` failure mode) and tells you exactly how to recover.
+- **Install-script warning** — fires when the `skills/` directory is empty and provides recovery steps for skipped or npm-blocked lifecycle scripts.
 - **Skill resource paths** — bundled CE skill resources like `scripts/`, `references/`, and `assets/` are rewritten at conversion time to resolve under `skills/<skill-name>/...`, matching the package-root base path Pi injects for package-sourced skills. No runtime guidance is needed.
 
 The exact skill list is visible in Pi's startup `[Skills]` list after install.
@@ -50,10 +50,13 @@ pi -e /path/to/pi-mono/packages/pi-compound-engineering
 
 The install runs two lifecycle scripts:
 
-1. `preinstall` (`scripts/stage.mjs`) downloads the pinned CE release tarball, verifies its SHA256, extracts it, runs the pure-Node converter, and stages the result in `$TMP/`.
+1. `preinstall` (`scripts/stage.mjs`) downloads the pinned CE release tarball, verifies its SHA256, extracts it, runs the pure-Node converter, and stages the result in `~/.pi-compound-engineering-staging/`.
 2. `postinstall` (`scripts/commit.mjs`) moves the staged content into the install directory.
 
 Skills are available on the next Pi launch. The `tar` binary is required (universally available on macOS, Linux, and WSL; not native Windows). A working network connection is required at install time.
+
+> [!IMPORTANT]
+> npm 12 blocks dependency lifecycle scripts until the **Pi-managed npm install root** approves them. After reviewing this package's install scripts, approve `pi-compound-engineering` there and rebuild it. This package cannot approve itself because npm blocks its scripts before they run.
 
 ## Usage
 
@@ -105,13 +108,16 @@ At conversion time, the converter rewrites each skill's backtick-wrapped `refere
 
 ### `skills/` is empty after install
 
-If you used `npm install --ignore-scripts`, the postinstall is skipped. Re-run the install without the flag:
+`pi-compound-engineering` must run its `preinstall` and `postinstall` scripts to generate `skills/`. With npm 12, approve this reviewed package in Pi's npm install root, then rebuild it:
 
 ```bash
-pi install npm:pi-compound-engineering
+npm install-scripts approve pi-compound-engineering --prefix ~/.pi/agent/npm
+npm rebuild pi-compound-engineering --prefix ~/.pi/agent/npm
 ```
 
-The lifecycle is idempotent — re-running is safe and will populate the install dir.
+For a project-local Pi package, replace `~/.pi/agent/npm` with `.pi/npm`. On npm versions before 12, ensure `ignore-scripts` is disabled and run the same `npm rebuild` command. Restart Pi after a successful rebuild.
+
+Avoid approving all dependencies or enabling `dangerously-allow-all-scripts`; only this package needs approval.
 
 ### Behind a corporate proxy or offline
 

--- a/packages/pi-compound-engineering/package.json
+++ b/packages/pi-compound-engineering/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pi-compound-engineering",
-  "version": "3.19.0",
+  "version": "3.19.1",
+  "ceVersion": "3.19.0",
   "description": "Compound Engineering for Pi: brainstorm, plan, work, review, and compound.",
   "type": "module",
   "license": "MIT",

--- a/packages/pi-compound-engineering/scripts/stage.mjs
+++ b/packages/pi-compound-engineering/scripts/stage.mjs
@@ -103,17 +103,17 @@ function isOfflineEnv() {
 }
 
 /**
- * @returns {Promise<{ version: string, packageJson: any }>}
+ * @returns {Promise<{ ceVersion: string, packageJson: any }>}
  */
 async function readCeVersion() {
 	const packageJsonPath = join(PACKAGE_ROOT, "package.json");
 	const raw = await readFile(packageJsonPath, "utf8");
 	const packageJson = JSON.parse(raw);
-	const version = packageJson.version;
-	if (typeof version !== "string" || version.length === 0) {
-		fatal("package.json is missing a version string");
+	const ceVersion = packageJson.ceVersion;
+	if (typeof ceVersion !== "string" || ceVersion.length === 0) {
+		fatal("package.json is missing a ceVersion string");
 	}
-	return { version, packageJson };
+	return { ceVersion, packageJson };
 }
 
 /**
@@ -313,12 +313,12 @@ async function main() {
 		return;
 	}
 
-	const { version } = await readCeVersion();
+	const { ceVersion } = await readCeVersion();
 	const expectedSha = await readExpectedSha256();
 	const stagingDir = await createStagingDir();
 	log(`Staging dir: ${stagingDir}`);
 
-	const tarballPath = join(stagingDir, `compound-engineering-plugin-v${version}.tar.gz`);
+	const tarballPath = join(stagingDir, `compound-engineering-plugin-v${ceVersion}.tar.gz`);
 	const localTarball = process.env.CE_TARBALL_PATH;
 	if (localTarball) {
 		log(`Using local tarball from CE_TARBALL_PATH: ${localTarball}`);
@@ -330,7 +330,7 @@ async function main() {
 		}
 	} else {
 		try {
-			await downloadTarball(tarballUrl(version), tarballPath);
+			await downloadTarball(tarballUrl(ceVersion), tarballPath);
 		} catch (err) {
 			await rm(stagingDir, { recursive: true, force: true });
 			// A network/transport failure (offline, no DNS, no egress,
@@ -365,7 +365,7 @@ async function main() {
 
 	const { pluginRoot, extractedRoot } = await extractTarball(tarballPath, stagingDir);
 
-	const { outputDir, skillCount } = await runConverter(pluginRoot, stagingDir, version);
+	const { outputDir, skillCount } = await runConverter(pluginRoot, stagingDir, ceVersion);
 
 	try {
 		await verifyStructure(outputDir);
@@ -388,7 +388,7 @@ async function main() {
 	await rm(extractedRoot, { recursive: true, force: true });
 	await rm(tarballPath, { force: true });
 
-	log(`Staged ${skillCount} skills from compound-engineering-plugin@${version} (sha256:${sha256.slice(0, 16)}…)`);
+	log(`Staged ${skillCount} skills from compound-engineering-plugin@${ceVersion} (sha256:${sha256.slice(0, 16)}…)`);
 }
 
 main().catch((err) => {

--- a/packages/pi-compound-engineering/scripts/verify.mjs
+++ b/packages/pi-compound-engineering/scripts/verify.mjs
@@ -9,8 +9,8 @@
  * downloads the tarball, verifies the SHA, extracts it, runs the
  * converter, and asserts structure on the staging output.
  *
- * The script reads `CE_VERSION` from `package.json` and the expected
- * counts from `src/ce-version.ts` (parses them as a sanity check).
+ * The script reads the npm package version and upstream `ceVersion` from
+ * `package.json`, then checks them against `src/ce-version.ts`.
  *
  * Exit code 0 = all checks passed. Exit code 1 = at least one check failed.
  *
@@ -61,10 +61,12 @@ async function readPackageJson() {
 async function readCeVersionTs() {
 	const ceVersionPath = join(PACKAGE_ROOT, "src", "ce-version.ts");
 	const raw = await readFile(ceVersionPath, "utf8");
-	const versionMatch = raw.match(/export const CE_VERSION\s*=\s*"([^"]+)"/);
+	const packageVersionMatch = raw.match(/export const PACKAGE_VERSION\s*=\s*"([^"]+)"/);
+	const ceVersionMatch = raw.match(/export const CE_VERSION\s*=\s*"([^"]+)"/);
 	const skillMatch = raw.match(/export const EXPECTED_SKILL_COUNT\s*=\s*(\d+)/);
 	return {
-		version: versionMatch?.[1] ?? null,
+		packageVersion: packageVersionMatch?.[1] ?? null,
+		ceVersion: ceVersionMatch?.[1] ?? null,
 		skillCount: skillMatch ? Number(skillMatch[1]) : null,
 	};
 }
@@ -121,12 +123,20 @@ async function main() {
 	const expectedSha = await readExpectedSha();
 
 	section("Version checks");
-	if (packageJson.version === ceVersion.version) {
-		pass(`package.json version (${packageJson.version}) matches CE_VERSION (${ceVersion.version})`);
+	if (packageJson.version === ceVersion.packageVersion) {
+		pass(`package.json version (${packageJson.version}) matches PACKAGE_VERSION (${ceVersion.packageVersion})`);
 	} else {
 		fail(
-			"package.json version does not match CE_VERSION",
-			`package.json=${packageJson.version} CE_VERSION=${ceVersion.version}`,
+			"package.json version does not match PACKAGE_VERSION",
+			`package.json=${packageJson.version} PACKAGE_VERSION=${ceVersion.packageVersion}`,
+		);
+	}
+	if (packageJson.ceVersion === ceVersion.ceVersion) {
+		pass(`package.json ceVersion (${packageJson.ceVersion}) matches CE_VERSION (${ceVersion.ceVersion})`);
+	} else {
+		fail(
+			"package.json ceVersion does not match CE_VERSION",
+			`package.json=${packageJson.ceVersion} CE_VERSION=${ceVersion.ceVersion}`,
 		);
 	}
 	if (ceVersion.skillCount !== null && ceVersion.skillCount > 0) {
@@ -146,7 +156,7 @@ async function main() {
 	const stagingDir = await mkdtemp(join(STAGING_BASE_DIR, STAGING_PREFIX));
 
 	const tarballPath = join(stagingDir, "ce.tar.gz");
-	const url = `https://codeload.github.com/EveryInc/compound-engineering-plugin/tar.gz/refs/tags/compound-engineering-v${ceVersion.version}`;
+	const url = `https://codeload.github.com/EveryInc/compound-engineering-plugin/tar.gz/refs/tags/compound-engineering-v${ceVersion.ceVersion}`;
 	try {
 		await downloadTarball(url, tarballPath);
 		pass(`downloaded ${url}`);
@@ -182,7 +192,7 @@ async function main() {
 	section("Convert + structure");
 	const outputDir = join(stagingDir, "output");
 	try {
-		await convert(pluginsDir, outputDir, ceVersion.version);
+		await convert(pluginsDir, outputDir, ceVersion.ceVersion);
 		pass("converter returned");
 
 		const skills = await readdir(join(outputDir, "skills"));

--- a/packages/pi-compound-engineering/src/ce-version.ts
+++ b/packages/pi-compound-engineering/src/ce-version.ts
@@ -1,17 +1,15 @@
 /**
  * The Compound Engineering (CE) version this package mirrors.
  *
- * The package version is **identical** to the upstream CE `compound-engineering`
- * component version, as recorded in CE's
- * `.github/.release-please-manifest.json` (the root-native `compound-engineering` component).
- * Users reading the upstream changelog or release notes can match the version
- * they have installed with a one-to-one mapping.
+ * `CE_VERSION` identifies the pinned upstream `compound-engineering`
+ * component release. `PACKAGE_VERSION` identifies this npm package. They
+ * normally match; a Pi-specific hotfix may increment the package patch while
+ * retaining the same pinned upstream CE release.
  *
- * Both `scripts/stage.mjs` and `scripts/commit.mjs` read `CE_VERSION` from
- * `package.json` (not from this file) to avoid a dual source of truth at
- * install time. This file is the API surface for the extension and the
- * structure check.
+ * `scripts/stage.mjs` reads the upstream `ceVersion` from `package.json`,
+ * while this file is the extension API and verification contract.
  */
+export const PACKAGE_VERSION = "3.19.1";
 export const CE_VERSION = "3.19.0";
 
 /**

--- a/packages/pi-compound-engineering/src/dependency-check.ts
+++ b/packages/pi-compound-engineering/src/dependency-check.ts
@@ -66,7 +66,7 @@ const ASK_USER_WARNING =
 	"pi-compound-engineering: pi-ask-user is not installed. Interactive skills (ce-plan, ce-brainstorm, ce-debug, ce-compound, ce-worktree, ce-promote, ce-sessions, ce-ideate) will fall back to numbered options in chat. Install with: pi install npm:pi-ask-user";
 
 const POSTINSTALL_SKIPPED_WARNING =
-	"pi-compound-engineering: postinstall was skipped or failed. CE skills are not installed. Re-run `pi install npm:pi-compound-engineering` (without --ignore-scripts) and restart Pi.";
+	"pi-compound-engineering: install scripts did not run, so CE skills are not installed. npm 12+ blocks unapproved dependency scripts: run `npm install-scripts approve pi-compound-engineering --prefix ~/.pi/agent/npm`, then `npm rebuild pi-compound-engineering --prefix ~/.pi/agent/npm`; otherwise, ensure scripts are enabled and rebuild the package. Restart Pi afterward.";
 
 /**
  * Per-session dedupe sets for the three one-shot warnings. Module-scope
@@ -117,7 +117,11 @@ export function isInstallComplete(installDir: string = getPackageInstallDir()): 
  * call multiple times — dedupes by session file path (or cwd if no
  * session file is associated).
  */
-export function maybeWarnAboutDependencies(pi: ExtensionAPI, ctx: ExtensionContext): void {
+export function maybeWarnAboutDependencies(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	installDir: string = getPackageInstallDir(),
+): void {
 	const sessionId = ctx.sessionManager.getSessionFile() ?? ctx.cwd;
 	const result = runDependencyCheck(pi);
 
@@ -131,7 +135,7 @@ export function maybeWarnAboutDependencies(pi: ExtensionAPI, ctx: ExtensionConte
 		ctx.ui.notify(ASK_USER_WARNING, "warning");
 	}
 
-	if (!isInstallComplete() && !warnedPostinstallSessions.has(sessionId)) {
+	if (!isInstallComplete(installDir) && !warnedPostinstallSessions.has(sessionId)) {
 		warnedPostinstallSessions.add(sessionId);
 		ctx.ui.notify(POSTINSTALL_SKIPPED_WARNING, "warning");
 	}

--- a/packages/pi-compound-engineering/src/dependency-check.ts
+++ b/packages/pi-compound-engineering/src/dependency-check.ts
@@ -65,8 +65,18 @@ const SUBAGENT_WARNING =
 const ASK_USER_WARNING =
 	"pi-compound-engineering: pi-ask-user is not installed. Interactive skills (ce-plan, ce-brainstorm, ce-debug, ce-compound, ce-worktree, ce-promote, ce-sessions, ce-ideate) will fall back to numbered options in chat. Install with: pi install npm:pi-ask-user";
 
-const POSTINSTALL_SKIPPED_WARNING =
-	"pi-compound-engineering: install scripts did not run, so CE skills are not installed. npm 12+ blocks unapproved dependency scripts: run `npm install-scripts approve pi-compound-engineering --prefix ~/.pi/agent/npm`, then `npm rebuild pi-compound-engineering --prefix ~/.pi/agent/npm`; otherwise, ensure scripts are enabled and rebuild the package. Restart Pi afterward.";
+/**
+ * Build the skipped-install warning with the correct npm `--prefix` for the
+ * actual install location. The package install dir is
+ * `<npm-root>/node_modules/pi-compound-engineering`, so two `dirname` levels
+ * up yields the npm root (`~/.pi/agent/npm` for global, `.pi/npm` for
+ * project-local). Deriving the prefix here keeps the recovery command correct
+ * for both global and `pi install -l` installs.
+ */
+function buildPostinstallWarning(installDir: string): string {
+	const npmPrefix = dirname(dirname(installDir));
+	return `pi-compound-engineering: install scripts did not run, so CE skills are not installed. npm 12+ blocks unapproved dependency scripts: run \`npm install-scripts approve pi-compound-engineering --prefix ${npmPrefix}\`, then \`npm rebuild pi-compound-engineering --prefix ${npmPrefix}\`; otherwise, ensure scripts are enabled and rebuild the package. Restart Pi afterward.`;
+}
 
 /**
  * Per-session dedupe sets for the three one-shot warnings. Module-scope
@@ -137,7 +147,7 @@ export function maybeWarnAboutDependencies(
 
 	if (!isInstallComplete(installDir) && !warnedPostinstallSessions.has(sessionId)) {
 		warnedPostinstallSessions.add(sessionId);
-		ctx.ui.notify(POSTINSTALL_SKIPPED_WARNING, "warning");
+		ctx.ui.notify(buildPostinstallWarning(installDir), "warning");
 	}
 }
 

--- a/packages/pi-compound-engineering/src/index.ts
+++ b/packages/pi-compound-engineering/src/index.ts
@@ -1,4 +1,4 @@
-export { CE_VERSION, EXPECTED_SKILL_COUNT, getCeVersion, getCeRepoUrl, getCeReleaseTag, getCeTarballUrl } from "./ce-version.js";
+export { CE_VERSION, EXPECTED_SKILL_COUNT, PACKAGE_VERSION, getCeVersion, getCeRepoUrl, getCeReleaseTag, getCeTarballUrl } from "./ce-version.js";
 export { AGENTS_BLOCK_BODY, AGENTS_BLOCK_END, AGENTS_BLOCK_START, upsertAgentsBlock } from "./agents-block.js";
 export { buildCeStatusReport, registerCeStatusCommand } from "./status-command.js";
 export { getPackageInstallDir, isInstallComplete, maybeWarnAboutDependencies, runDependencyCheck } from "./dependency-check.js";

--- a/packages/pi-compound-engineering/src/status-command.ts
+++ b/packages/pi-compound-engineering/src/status-command.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { CE_VERSION, getCeRepoUrl } from "./ce-version.js";
+import { CE_VERSION, PACKAGE_VERSION, getCeRepoUrl } from "./ce-version.js";
 import {
 	formatSourceLabel,
 	getPackageInstallDir,
@@ -43,10 +43,10 @@ export function buildCeStatusReport(pi: ExtensionAPI, cwd: string): string {
 	const skillCount = countEntries(join(installDir, "skills"));
 	const installStatus = isInstallComplete(installDir)
 		? "complete"
-		: "incomplete (postinstall was skipped or failed)";
+		: "incomplete (install scripts did not run or failed)";
 
 	const lines = [
-		`pi-compound-engineering@${CE_VERSION}`,
+		`pi-compound-engineering@${PACKAGE_VERSION}`,
 		"",
 		`Mirrors compound-engineering-plugin@${CE_VERSION}`,
 		`Upstream: ${getCeRepoUrl()}`,

--- a/packages/pi-compound-engineering/tests/dependency-check.test.mjs
+++ b/packages/pi-compound-engineering/tests/dependency-check.test.mjs
@@ -27,7 +27,10 @@ test("missing generated skills warns once with npm 12 recovery steps", () => {
 	const pi = makePi();
 	const ctx = makeContext(notifications);
 
-	const missingInstallDir = "/tmp/pi-compound-engineering-missing-skills";
+	// Simulate a global install dir with an empty/missing skills dir.
+	const missingInstallDir = "/home/user/.pi/agent/npm/node_modules/pi-compound-engineering";
+	const expectedPrefix = "/home/user/.pi/agent/npm";
+
 	maybeWarnAboutDependencies(pi, ctx, missingInstallDir);
 	maybeWarnAboutDependencies(pi, ctx, missingInstallDir);
 
@@ -36,4 +39,11 @@ test("missing generated skills warns once with npm 12 recovery steps", () => {
 	assert.match(notifications[0].message, /npm 12\+ blocks unapproved dependency scripts/);
 	assert.match(notifications[0].message, /npm install-scripts approve pi-compound-engineering/);
 	assert.match(notifications[0].message, /npm rebuild pi-compound-engineering/);
+	// The prefix must be derived from the install dir so project-local
+	// installs get the correct `.pi/npm` prefix instead of the global default.
+	assert.match(notifications[0].message, new RegExp(`--prefix ${escapeRegex(expectedPrefix)}`));
 });
+
+function escapeRegex(s) {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/pi-compound-engineering/tests/dependency-check.test.mjs
+++ b/packages/pi-compound-engineering/tests/dependency-check.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { _resetWarningState, maybeWarnAboutDependencies } from "../src/dependency-check.ts";
+
+function makePi() {
+	return {
+		getAllTools: () => [
+			{ name: "subagent", sourceInfo: { source: "pi-subagents" } },
+			{ name: "ask_user", sourceInfo: { source: "pi-ask-user" } },
+		],
+	};
+}
+
+function makeContext(notifications) {
+	return {
+		cwd: "/tmp/project",
+		sessionManager: { getSessionFile: () => "/tmp/session.jsonl" },
+		ui: {
+			notify: (message, type) => notifications.push({ message, type }),
+		},
+	};
+}
+
+test("missing generated skills warns once with npm 12 recovery steps", () => {
+	_resetWarningState();
+	const notifications = [];
+	const pi = makePi();
+	const ctx = makeContext(notifications);
+
+	const missingInstallDir = "/tmp/pi-compound-engineering-missing-skills";
+	maybeWarnAboutDependencies(pi, ctx, missingInstallDir);
+	maybeWarnAboutDependencies(pi, ctx, missingInstallDir);
+
+	assert.equal(notifications.length, 1);
+	assert.equal(notifications[0].type, "warning");
+	assert.match(notifications[0].message, /npm 12\+ blocks unapproved dependency scripts/);
+	assert.match(notifications[0].message, /npm install-scripts approve pi-compound-engineering/);
+	assert.match(notifications[0].message, /npm rebuild pi-compound-engineering/);
+});


### PR DESCRIPTION
## Summary
- release `pi-compound-engineering@3.19.1` as a Pi-specific npm 12 recovery hotfix while retaining the CE 3.19.0 pin
- document scoped npm script approval and rebuild recovery, and surface it in the runtime warning
- verify package and upstream version independently so lifecycle scripts fetch CE 3.19.0 for the 3.19.1 package

## Validation
- `npm test --workspace packages/pi-compound-engineering`
- `npm run check --workspace packages/pi-compound-engineering`
- `npm run verify --workspace packages/pi-compound-engineering`
- `npm run pack:dry-run --workspace packages/pi-compound-engineering`
- `npm ci --dry-run`
- clean-room local Pi test: npm 12 blocks scripts, scoped approval plus rebuild generates 29 skills, and Pi discovers `ce-plan`