### PR TITLE
fix: preserve hidden skill settings

### DIFF
--- a/packages/pi-skillful/.gitignore
+++ b/packages/pi-skillful/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.test-dist/
 *.tgz
 *.tsbuildinfo
 .DS_Store

--- a/packages/pi-skillful/CHANGELOG.md
+++ b/packages/pi-skillful/CHANGELOG.md
@@ -10,6 +10,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve configured hidden skills at session start. Skillful no longer treats a temporarily incomplete loaded-skill list as authoritative and removes global or project visibility settings.
+
 ## [0.3.10] - 2026-07-01
 
 ### Fixed

--- a/packages/pi-skillful/package.json
+++ b/packages/pi-skillful/package.json
@@ -53,6 +53,7 @@
   "scripts": {
     "check": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
+    "test": "rm -rf .test-dist && tsc --noEmit false --outDir .test-dist && node --test tests/*.test.mjs",
     "pack:dry-run": "npm pack --dry-run"
   },
   "publishConfig": {

--- a/packages/pi-skillful/src/extensions/skill-visibility.ts
+++ b/packages/pi-skillful/src/extensions/skill-visibility.ts
@@ -83,9 +83,8 @@ interface SettingsListSelectionView {
 export default function skillVisibility(pi: ExtensionAPI) {
   installStartupSkillListPatch();
 
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", (_event, ctx) => {
     store.theme = ctx.ui.theme;
-    await pruneStaleHiddenSkills(pi, ctx.cwd);
   });
 
   pi.on("before_agent_start", async (event, ctx) => {
@@ -146,25 +145,6 @@ export default function skillVisibility(pi: ExtensionAPI) {
       );
     },
   });
-}
-
-async function pruneStaleHiddenSkills(pi: ExtensionAPI, cwd: string): Promise<void> {
-  const installedNames = new Set(getSkillItems(pi).map((s) => s.name));
-  const scoped = await readScopedSkillfulSettings(cwd);
-
-  await Promise.all(
-    SCOPES.map(async (scope) => {
-      const currentHidden = scoped[scope].hiddenSkills;
-      const prunedHidden = currentHidden.filter((name) => installedNames.has(name));
-      if (prunedHidden.length < currentHidden.length) {
-        scoped[scope] = await writeHiddenSkills(scope, cwd, prunedHidden);
-      }
-    }),
-  );
-
-  const hidden = new Set(scoped.project.hiddenSkillsDefined ? scoped.project.hiddenSkills : scoped.global.hiddenSkills);
-  store.hiddenSkillsByCwd.set(cwd, hidden);
-  store.lastHiddenSkills = hidden;
 }
 
 async function refreshHiddenSkillCache(cwd: string): Promise<Set<string>> {

--- a/packages/pi-skillful/src/extensions/skill-visibility.ts
+++ b/packages/pi-skillful/src/extensions/skill-visibility.ts
@@ -83,8 +83,9 @@ interface SettingsListSelectionView {
 export default function skillVisibility(pi: ExtensionAPI) {
   installStartupSkillListPatch();
 
-  pi.on("session_start", (_event, ctx) => {
+  pi.on("session_start", async (_event, ctx) => {
     store.theme = ctx.ui.theme;
+    await refreshHiddenSkillCache(ctx.cwd);
   });
 
   pi.on("before_agent_start", async (event, ctx) => {

--- a/packages/pi-skillful/tests/skill-visibility.test.mjs
+++ b/packages/pi-skillful/tests/skill-visibility.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const home = await mkdtemp(join(tmpdir(), "pi-skillful-test-"));
+process.env.HOME = home;
+
+const { default: skillVisibility } = await import("../.test-dist/src/extensions/skill-visibility.js");
+
+test("session start preserves global hidden skills when no skills are loaded", async () => {
+  const settingsPath = join(home, ".pi", "agent", "settings.json");
+  await mkdir(join(home, ".pi", "agent"), { recursive: true });
+  await writeFile(
+    settingsPath,
+    `${JSON.stringify({ skillful: { hiddenSkills: ["user-skill"] } }, null, 2)}\n`,
+    "utf-8",
+  );
+
+  const handlers = new Map();
+  skillVisibility({
+    getCommands: () => [],
+    on: (event, handler) => handlers.set(event, handler),
+    registerCommand: () => undefined,
+  });
+
+  await handlers.get("session_start")({}, { cwd: home, ui: { theme: {} } });
+
+  const settings = JSON.parse(await readFile(settingsPath, "utf-8"));
+  assert.deepEqual(settings.skillful.hiddenSkills, ["user-skill"]);
+});
+
+test.after(async () => {
+  await rm(home, { recursive: true, force: true });
+});

--- a/packages/pi-skillful/tsconfig.json
+++ b/packages/pi-skillful/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["index.ts", "src/**/*.ts", "extensions/**/*.ts"]
+  "include": ["index.ts", "src/**/*.ts", "extensions/**/*.ts", "tests/**/*.mjs"]
 }


### PR DESCRIPTION
## Summary

Hidden skill selections now survive Pi startup and reload while the loaded-skill list is incomplete. Previously, Skillful could observe no skills during startup and reset global or project visibility settings, re-enabling skills the user had disabled. A regression test covers that empty-list path.

## Validation

- `npm test --workspace packages/pi-skillful`
- `npm run check --workspace packages/pi-skillful`
- `npm run pack:dry-run --workspace packages/pi-skillful`
- Isolated Pi startup smoke test confirming `hiddenSkills` remains unchanged

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
