### PR TITLE
fix(agentsmd): honor force overwrite

### DIFF
--- a/packages/pi-agentsmd/.gitignore
+++ b/packages/pi-agentsmd/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.test-dist/
 *.tgz
 *.tsbuildinfo
 .DS_Store

--- a/packages/pi-agentsmd/CHANGELOG.md
+++ b/packages/pi-agentsmd/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Fixed
+
+- Make `/init --force` and `/init -f` explicitly authorize replacing `AGENTS.md`.
+
 ## [0.1.2] - 2026-07-01
 
 ### Changed

--- a/packages/pi-agentsmd/package.json
+++ b/packages/pi-agentsmd/package.json
@@ -46,6 +46,7 @@
   "scripts": {
     "check": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
+    "test": "rm -rf .test-dist && tsc --noEmit false --outDir .test-dist && cp -R prompts .test-dist/prompts && node --test tests/*.test.mjs",
     "pack:dry-run": "npm pack --dry-run"
   },
   "peerDependencies": {

--- a/packages/pi-agentsmd/src/index.ts
+++ b/packages/pi-agentsmd/src/index.ts
@@ -1,3 +1,3 @@
 export { handleInitCommand } from "./init.js";
 export { reportInstallTelemetry } from "./install-telemetry.js";
-export { INIT_PROMPT } from "./prompt.js";
+export { FORCE_INIT_PROMPT, INIT_PROMPT } from "./prompt.js";

--- a/packages/pi-agentsmd/src/init.ts
+++ b/packages/pi-agentsmd/src/init.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { INIT_PROMPT } from "./prompt.js";
+import { FORCE_INIT_PROMPT, INIT_PROMPT } from "./prompt.js";
 
 const DEFAULT_AGENTS_MD_FILENAME = "AGENTS.md";
 
@@ -23,5 +23,5 @@ export async function handleInitCommand(
     return;
   }
 
-  pi.sendUserMessage(INIT_PROMPT);
+  pi.sendUserMessage(force ? FORCE_INIT_PROMPT : INIT_PROMPT);
 }

--- a/packages/pi-agentsmd/src/prompt.ts
+++ b/packages/pi-agentsmd/src/prompt.ts
@@ -3,8 +3,21 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const NO_OVERWRITE_INSTRUCTION =
+  "Before writing, check whether AGENTS.md already exists in the current working directory. If it does, do not overwrite or modify it.";
+const FORCE_OVERWRITE_INSTRUCTION =
+  "The user explicitly invoked /init with --force. Replace AGENTS.md in the current working directory, even if it already exists. Do not modify any other existing files.";
 
 export const INIT_PROMPT = readFileSync(
   join(__dirname, "../prompts/init.md"),
   "utf8",
 );
+
+export const FORCE_INIT_PROMPT = INIT_PROMPT.replace(
+  NO_OVERWRITE_INSTRUCTION,
+  FORCE_OVERWRITE_INSTRUCTION,
+);
+
+if (FORCE_INIT_PROMPT === INIT_PROMPT) {
+  throw new Error("Init prompt no-overwrite instruction is missing.");
+}

--- a/packages/pi-agentsmd/tests/init.test.mjs
+++ b/packages/pi-agentsmd/tests/init.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const { handleInitCommand } = await import("../.test-dist/src/init.js");
+const { FORCE_INIT_PROMPT, INIT_PROMPT } = await import("../.test-dist/src/prompt.js");
+
+async function runInit(args, existing) {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-agentsmd-test-"));
+  const messages = [];
+  const notifications = [];
+
+  if (existing) {
+    await writeFile(join(cwd, "AGENTS.md"), "existing guide\n", "utf8");
+  }
+
+  try {
+    await handleInitCommand(
+      { sendUserMessage: (message) => messages.push(message) },
+      args,
+      {
+        cwd,
+        ui: {
+          notify: (message, type) => notifications.push({ message, type }),
+        },
+      },
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+
+  return { messages, notifications };
+}
+
+test("/init sends normal prompt when AGENTS.md is missing", async () => {
+  const result = await runInit("", false);
+
+  assert.deepEqual(result.messages, [INIT_PROMPT]);
+  assert.deepEqual(result.notifications, []);
+});
+
+test("/init warns without sending prompt when AGENTS.md exists", async () => {
+  const result = await runInit("", true);
+
+  assert.deepEqual(result.messages, []);
+  assert.deepEqual(result.notifications, [
+    {
+      message: "AGENTS.md already exists here. Use /init --force to overwrite.",
+      type: "warning",
+    },
+  ]);
+});
+
+for (const args of ["--force", "-f"]) {
+  test(`/init ${args} sends force prompt when AGENTS.md is missing`, async () => {
+    const result = await runInit(args, false);
+
+    assert.deepEqual(result.messages, [FORCE_INIT_PROMPT]);
+    assert.deepEqual(result.notifications, []);
+  });
+
+  test(`/init ${args} sends force prompt when AGENTS.md exists`, async () => {
+    const result = await runInit(args, true);
+
+    assert.deepEqual(result.messages, [FORCE_INIT_PROMPT]);
+    assert.deepEqual(result.notifications, []);
+  });
+}
+
+test("force prompt explicitly authorizes replacement without no-overwrite instruction", () => {
+  assert.match(FORCE_INIT_PROMPT, /explicitly invoked \/init with --force/);
+  assert.match(FORCE_INIT_PROMPT, /Replace AGENTS\.md/);
+  assert.doesNotMatch(FORCE_INIT_PROMPT, /do not overwrite or modify it/);
+});

--- a/packages/pi-agentsmd/tsconfig.json
+++ b/packages/pi-agentsmd/tsconfig.json
@@ -8,5 +8,5 @@
     "types": ["node"],
     "noEmit": true
   },
-  "include": ["index.ts", "src/**/*.ts", "extensions/**/*.ts"]
+  "include": ["index.ts", "src/**/*.ts", "extensions/**/*.ts", "tests/**/*.mjs"]
 }


### PR DESCRIPTION
## Summary
- Send an explicit overwrite prompt for `/init --force` and `/init -f`
- Keep upstream Codex no-overwrite prompt unchanged for normal `/init`
- Add command-path tests for existing and missing `AGENTS.md`

## Validation
- npm run -w packages/pi-agentsmd check
- npm run -w packages/pi-agentsmd test
- npm run -w packages/pi-agentsmd pack:dry-run
- npm ci --dry-run

Closes #38