### PR TITLE
Fix pi-goal time and version accounting

### DIFF
--- a/packages/pi-goal/CHANGELOG.md
+++ b/packages/pi-goal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- Preserve accumulated wall-clock time when `/goal resume` is used on an already-active goal.
+- Derive persisted `piGoalVersion` metadata from the package version so release versions cannot drift.
+- Ignore malformed persisted mutations instead of allowing invalid status, budget, or accounting data to corrupt reconstructed goal state.
+
 ## 0.1.10 - 2026-07-01
 
 ### Changed

--- a/packages/pi-goal/src/commands.ts
+++ b/packages/pi-goal/src/commands.ts
@@ -94,9 +94,10 @@ async function editGoal(pi: ExtensionAPI, ctx: ExtensionCommandContext, runtime:
 function setGoalStatus(pi: ExtensionAPI, ctx: ExtensionCommandContext, runtime: CommandRuntime, status: "paused" | "active"): void {
   const current = accountCurrent(pi, ctx, runtime.getGoal());
   if (!current) return ctx.ui.notify("No goal set.", "error");
-  const time = status === "active" ? current.timeUsedSeconds : realizedTimeUsed(current);
-  const activeStartedAt = status === "active" ? nowIso() : undefined;
-  const mutation = statusMutation(current, status, time, activeStartedAt, transitionMeta(status === "active" ? "command:/goal resume" : "command:/goal pause", current, time, nowIso()));
+  const transitionedAt = nowIso();
+  const time = realizedTimeUsed(current, Date.parse(transitionedAt));
+  const activeStartedAt = status === "active" ? transitionedAt : undefined;
+  const mutation = statusMutation(current, status, time, activeStartedAt, transitionMeta(status === "active" ? "command:/goal resume" : "command:/goal pause", current, time, transitionedAt));
   appendGoalMutation(pi, mutation);
   runtime.setGoal(applyGoalMutation(current, mutation));
   runtime.afterGoalChanged(ctx, status === "active" ? "Goal resumed." : "Goal paused.");

--- a/packages/pi-goal/src/metadata.ts
+++ b/packages/pi-goal/src/metadata.ts
@@ -1,7 +1,15 @@
+import { createRequire } from "node:module";
 import type { BranchEntry, GoalMutationMeta, GoalState } from "./types.js";
 import { secondsBetween } from "./utils.js";
 
-export const PI_GOAL_VERSION = "0.1.7";
+const packageJson = createRequire(import.meta.url)("../package.json") as { version?: unknown };
+
+if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
+  throw new Error("pi-goal package version is missing or invalid.");
+}
+
+/** Package version that produced the persisted metadata; schema versioning is separate. */
+export const PI_GOAL_VERSION = packageJson.version;
 
 export function withPiGoalVersion(meta: GoalMutationMeta = {}): GoalMutationMeta {
   return { piGoalVersion: PI_GOAL_VERSION, ...meta };

--- a/packages/pi-goal/src/state.ts
+++ b/packages/pi-goal/src/state.ts
@@ -70,10 +70,50 @@ export function applyGoalMutation(current: GoalState | null, mutation: GoalMutat
 }
 
 function isKnownMutation(value: Partial<GoalMutation> | undefined): value is GoalMutation {
-  if (!value || value.schemaVersion !== GOAL_SCHEMA_VERSION || typeof value.kind !== "string" || typeof value.at !== "string") return false;
-  if (["create", "replace"].includes(value.kind)) return typeof value.goalId === "string" && typeof (value as any).objective === "string";
-  if (["edit", "status", "budget", "account"].includes(value.kind)) return typeof value.goalId === "string";
-  return value.kind === "clear";
+  if (!value || value.schemaVersion !== GOAL_SCHEMA_VERSION || typeof value.kind !== "string" || !validTimestamp(value.at)) return false;
+  const mutation = value as Record<string, unknown>;
+  if (value.kind === "clear") return optionalNonNegativeInteger(mutation.timeUsedSeconds);
+  if (typeof mutation.goalId !== "string" || mutation.goalId.length === 0) return false;
+  switch (value.kind) {
+    case "create":
+    case "replace":
+      return typeof mutation.objective === "string" && optionalPositiveInteger(mutation.tokenBudget);
+    case "edit":
+      return typeof mutation.objective === "string" && (mutation.status === undefined || isGoalStatus(mutation.status));
+    case "status":
+      return isGoalStatus(mutation.status)
+        && optionalNonNegativeInteger(mutation.timeUsedSeconds)
+        && (mutation.activeStartedAt === undefined || validTimestamp(mutation.activeStartedAt));
+    case "budget":
+      return optionalPositiveInteger(mutation.tokenBudget);
+    case "account":
+      return nonNegativeInteger(mutation.tokens)
+        && Array.isArray(mutation.entryIds)
+        && mutation.entryIds.every((id) => typeof id === "string");
+    default:
+      return false;
+  }
+}
+
+function isGoalStatus(value: unknown): value is GoalStatus {
+  return typeof value === "string" && ["active", "paused", "blocked", "usage_limited", "budget_limited", "complete"].includes(value);
+}
+
+function validTimestamp(value: unknown): value is string {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value >= 0;
+}
+
+function optionalNonNegativeInteger(value: unknown): boolean {
+  return value === undefined || nonNegativeInteger(value);
+}
+
+function optionalPositiveInteger(value: unknown): boolean {
+  return value === undefined
+    || (typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value > 0);
 }
 
 export function statusMutation(goal: GoalState, status: GoalStatus, timeUsedSeconds: number, activeStartedAt?: string, meta?: GoalMutationMeta): GoalMutation {

--- a/packages/pi-goal/tests/commands-tools-scheduler.test.mjs
+++ b/packages/pi-goal/tests/commands-tools-scheduler.test.mjs
@@ -76,6 +76,33 @@ test("/goal creates, pauses, resumes, budgets, and clears", async () => {
   assert.equal(pi.entries.at(-1).data.kind, "clear");
 });
 
+test("/goal resume preserves elapsed time for an already-active goal", async () => {
+  const pi = makePi();
+  const ctx = makeCtx();
+  const startedAt = new Date(Date.now() - 100_000).toISOString();
+  const goal = {
+    goalId: "g1",
+    objective: "ship",
+    status: "active",
+    tokensUsed: 0,
+    timeUsedSeconds: 7,
+    createdAt: startedAt,
+    updatedAt: startedAt,
+    activeStartedAt: startedAt,
+    accountedUsage: { tokens: 0, entryIds: [] },
+  };
+  const runtime = makeCommandRuntime(goal);
+
+  await handleGoalCommand(pi, "resume", ctx, runtime);
+
+  const resumed = runtime.getGoal();
+  const mutation = pi.entries.at(-1).data;
+  assert.ok(resumed.timeUsedSeconds >= 106, `expected at least 106 seconds, got ${resumed.timeUsedSeconds}`);
+  assert.equal(mutation.meta.time.elapsedDeltaSeconds, resumed.timeUsedSeconds - 7);
+  assert.equal(mutation.meta.time.realizedTimeUsedSeconds, resumed.timeUsedSeconds);
+  assert.equal(resumed.activeStartedAt, mutation.meta.time.endedAt);
+});
+
 test("/goal replacement requires confirmation for non-terminal goals", async () => {
   const pi = makePi();
   const ctx = makeCtx();

--- a/packages/pi-goal/tests/core.test.mjs
+++ b/packages/pi-goal/tests/core.test.mjs
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { accountUsageFromBranch, assistantUsageTokens, buildGoalContextMessage, classifyAssistantError, createGoalMutation, formatElapsed, formatTokensCompact, parseGoalCommand, realizedTimeUsed, reconstructGoalState, validateObjective, validateTokenBudget } from "../src/index.ts";
+import { readFile } from "node:fs/promises";
+import { accountUsageFromBranch, assistantUsageTokens, buildGoalContextMessage, classifyAssistantError, createGoalMutation, formatElapsed, formatTokensCompact, parseGoalCommand, PI_GOAL_VERSION, realizedTimeUsed, reconstructGoalState, validateObjective, validateTokenBudget } from "../src/index.ts";
+
+test("persisted metadata version matches the package version", async () => {
+  const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+  assert.equal(PI_GOAL_VERSION, packageJson.version);
+});
 
 test("validation rejects empty and long objectives", () => {
   assert.equal(validateObjective("  ").ok, false);
@@ -37,6 +43,14 @@ test("reconstructs branch state from custom entries", () => {
   assert.equal(goal.tokenBudget, 1000);
 });
 
+test("reconstruction preserves all budgets accepted by public validation", () => {
+  const tokenBudget = Number.MAX_SAFE_INTEGER + 1;
+  assert.equal(validateTokenBudget(tokenBudget).ok, true);
+  const create = createGoalMutation("ship it", tokenBudget);
+  const goal = reconstructGoalState([{ type: "custom", customType: "pi-goal", id: "1", data: create }]);
+  assert.equal(goal.tokenBudget, tokenBudget);
+});
+
 test("accounts assistant usage once", () => {
   const create = createGoalMutation("ship it");
   const goal = reconstructGoalState([{ type: "custom", customType: "pi-goal", id: "1", timestamp: create.at, data: create }]);
@@ -63,6 +77,24 @@ test("accounting does not compound active elapsed time", () => {
   const twice = accountUsageFromBranch(once, branch, start + 20_000).goal;
   assert.equal(twice.timeUsedSeconds, 0);
   assert.equal(realizedTimeUsed(twice, start + 20_000), 20);
+});
+
+test("malformed persisted mutations are ignored without corrupting state", () => {
+  const create = createGoalMutation("ship it");
+  const malformed = [
+    { schemaVersion: 1, kind: "status", goalId: create.goalId, status: "unknown", at: create.at },
+    { schemaVersion: 1, kind: "account", goalId: create.goalId, tokens: 10, at: create.at },
+    { schemaVersion: 1, kind: "budget", goalId: create.goalId, tokenBudget: -1, at: create.at },
+  ];
+  const diagnostics = [];
+  const goal = reconstructGoalState([
+    { type: "custom", customType: "pi-goal", id: "create", data: create },
+    ...malformed.map((data, index) => ({ type: "custom", customType: "pi-goal", id: `bad-${index}`, data })),
+  ], diagnostics);
+  assert.equal(goal.status, "active");
+  assert.equal(goal.tokensUsed, 0);
+  assert.equal(goal.tokenBudget, undefined);
+  assert.equal(diagnostics.length, malformed.length);
 });
 
 test("legacy account mutations with elapsed time do not inflate reconstructed time", () => {


### PR DESCRIPTION
## Summary

- preserve realized wall-clock time when an active goal is resumed
- derive persisted `piGoalVersion` metadata from `package.json`
- validate persisted mutations before reconstruction so malformed session entries are ignored safely
- add regression coverage for time deltas, package-version synchronization, and malformed entries

## Codex comparison

Reviewed the current `openai/codex` goal extension and state store. Its implementation emphasizes monotonic wall-clock accounting, version-independent typed state, and validated/atomic state transitions. The changes here apply the high-signal equivalents that fit Pi's append-only session model without changing pi-goal's public status or token-budget semantics.

Closes #46
Closes #47

## Validation

- `npm run -w packages/pi-goal check`
- `npm test -w packages/pi-goal`
- `npm run -w packages/pi-goal pack:dry-run`
- `npm audit --omit=dev`
- `npm ci --dry-run`
- `git diff --check`
