### PR TITLE
Add pi-dcg command guard package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Monorepo for Pi-related projects: installable Pi packages, skills, prompt templa
 | [pi-agentsmd](./packages/pi-agentsmd) | Generate AGENTS.md contributor guides for Pi repositories. |
 | [pi-codex-image-gen](./packages/pi-codex-image-gen) | Image generation for Pi using the ChatGPT Images 2.0 model. |
 | [pi-compound-engineering](./packages/pi-compound-engineering) | Compound Engineering for Pi: brainstorm, plan, work, review, and compound. |
+| [pi-dcg](./packages/pi-dcg) | Guard Pi shell commands with Destructive Command Guard. |
 | [pi-goal](./packages/pi-goal) | Persistent long-running goals for Pi. |
 | [pi-insomnia](./packages/pi-insomnia) | Prevent macOS idle sleep while Pi agents are working. |
 | [pi-scout](./packages/pi-scout) | Register local reference codebases for Pi agent exploration. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -2361,6 +2361,10 @@
       "resolved": "packages/pi-compound-engineering",
       "link": true
     },
+    "node_modules/pi-dcg": {
+      "resolved": "packages/pi-dcg",
+      "link": true
+    },
     "node_modules/pi-insomnia": {
       "resolved": "packages/pi-insomnia",
       "link": true
@@ -2635,6 +2639,22 @@
     "packages/pi-compound-engineering": {
       "version": "3.19.1",
       "hasInstallScript": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@earendil-works/pi-coding-agent": "^0.80.0",
+        "@types/node": "^26.1.0",
+        "tsx": "^4.23.0",
+        "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "*"
+      }
+    },
+    "packages/pi-dcg": {
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.80.0",

--- a/packages/pi-dcg/.editorconfig
+++ b/packages/pi-dcg/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/pi-dcg/.gitignore
+++ b/packages/pi-dcg/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+*.tgz
+*.tsbuildinfo
+.DS_Store
+.env
+.env.*
+!.env.example
+npm-debug.log*

--- a/packages/pi-dcg/AGENTS.md
+++ b/packages/pi-dcg/AGENTS.md
@@ -1,0 +1,61 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+`pi-dcg` is a source-distributed TypeScript Pi extension. Pi loads the TypeScript entry point directly.
+
+- `extensions/index.ts` wires Pi lifecycle, `tool_call`, `user_bash`, and `/dcg` handlers.
+- `src/dcg-client.ts` owns bounded child-process execution and hook requests.
+- `src/protocol.ts` validates and formats dcg hook responses.
+- `src/config.ts` parses bridge environment variables.
+- `src/install-telemetry.ts` contains best-effort install/update telemetry.
+- `tests/*.test.mjs` cover protocol, process, client, and extension behavior.
+
+## Build, Test, and Development Commands
+
+Use npm from the monorepo root:
+
+```bash
+npm install
+npm run -w packages/pi-dcg check
+npm run -w packages/pi-dcg test
+npm run -w packages/pi-dcg pack:dry-run
+```
+
+For a local Pi smoke test:
+
+```bash
+pi -e /path/to/pi-mono/packages/pi-dcg
+```
+
+## Coding Style & Invariants
+
+Use ESM TypeScript, 2-space indentation, and explicit `.js` specifiers for local imports.
+
+Security-critical invariants:
+
+- Never pass command text through a shell when invoking dcg.
+- Always run dcg in Pi's current working directory.
+- Keep stdout/stderr and user-visible denial output bounded.
+- Treat unknown or malformed hook decisions as bridge errors, never implicit allows.
+- A dcg `deny` must remain a block; only dcg `ask` may open a Pi confirmation dialog.
+- A cancelled check must block the associated command even in fail-open mode.
+- Do not add one-click permanent allowlisting or an LLM-callable bypass tool.
+- Do not log command text, dcg stderr, environment contents, or policy files.
+- Keep `DCG_NO_SELF_HEAL=1` scoped to dcg child processes so Pi checks cannot rewrite Claude settings.
+
+Keep `extensions/index.ts` focused on event wiring. Put reusable process/protocol behavior under `src/` and dependency-inject it for tests.
+
+## Testing Guidelines
+
+Every decision or process change needs tests for safe, denied, warning, malformed, timeout/cancel, and configured error-mode behavior as applicable. Tests must use deterministic fake responses or local Node child fixtures; do not require dcg, network access, or user configuration.
+
+Before release, inspect `npm pack --dry-run` and ensure tests, AGENTS.md, and machine-specific files are excluded.
+
+## Documentation and Security
+
+Document changes to environment variables, failure defaults, event coverage, process spawning, telemetry, or command data flow in README and SECURITY. Keep the dcg license boundary explicit: dcg is an external prerequisite and must not be copied or bundled into this MIT package.
+
+## Git
+
+Use concise imperative commit subjects. Keep package code, tests, docs, root package listing, and lockfile changes focused on `pi-dcg`. Do not push unless requested.

--- a/packages/pi-dcg/CHANGELOG.md
+++ b/packages/pi-dcg/CHANGELOG.md
@@ -24,4 +24,5 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ### Security
 
+- Sealed approved agent `bash` commands so later Pi handlers cannot replace them after the dcg check.
 - Documented that Pi's RPC control-channel `bash` command does not emit an extension event and therefore cannot be guarded by `pi-dcg`.

--- a/packages/pi-dcg/CHANGELOG.md
+++ b/packages/pi-dcg/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoided empty stdin writes for probe commands, which could race with fast-exiting dcg binaries and falsely report that dcg was unavailable.
+
+### Security
+
+- Documented that Pi's RPC control-channel `bash` command does not emit an extension event and therefore cannot be guarded by `pi-dcg`.
+
 ## [0.1.0] - 2026-07-16
 
 ### Added

--- a/packages/pi-dcg/CHANGELOG.md
+++ b/packages/pi-dcg/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning for releases.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-07-16
+
+### Added
+
+- Initial `pi-dcg` Pi package.
+- Guarding for agent `bash` calls and user `!`/`!!` commands through dcg's hook protocol.
+- Pi-native handling for allow, deny, and ask decisions.
+- Bounded, cancellable dcg subprocess execution with configurable bridge error behavior.
+- Startup health status and `/dcg` diagnostics command.
+- Best-effort install/update telemetry following monorepo policy.
+- Unit and integration coverage for protocol, process, client, and extension behavior.

--- a/packages/pi-dcg/CHANGELOG.md
+++ b/packages/pi-dcg/CHANGELOG.md
@@ -6,15 +6,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
-### Fixed
-
-- Avoided empty stdin writes for probe commands, which could race with fast-exiting dcg binaries and falsely report that dcg was unavailable.
-
-### Security
-
-- Documented that Pi's RPC control-channel `bash` command does not emit an extension event and therefore cannot be guarded by `pi-dcg`.
-
-## [0.1.0] - 2026-07-16
+## [0.1.0] - 2026-07-17
 
 ### Added
 
@@ -25,3 +17,11 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 - Startup health status and `/dcg` diagnostics command.
 - Best-effort install/update telemetry following monorepo policy.
 - Unit and integration coverage for protocol, process, client, and extension behavior.
+
+### Fixed
+
+- Avoided empty stdin writes for probe commands, which could race with fast-exiting dcg binaries and falsely report that dcg was unavailable.
+
+### Security
+
+- Documented that Pi's RPC control-channel `bash` command does not emit an extension event and therefore cannot be guarded by `pi-dcg`.

--- a/packages/pi-dcg/CHANGELOG.md
+++ b/packages/pi-dcg/CHANGELOG.md
@@ -24,5 +24,6 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ### Security
 
-- Sealed approved agent `bash` commands so later Pi handlers cannot replace them after the dcg check.
+- Sealed approved agent `bash` commands and their input references so later Pi handlers cannot replace them after the dcg check.
+- Kept dcg allow-once commands out of model-visible denial results while retaining user-only UI guidance.
 - Documented that Pi's RPC control-channel `bash` command does not emit an extension event and therefore cannot be guarded by `pi-dcg`.

--- a/packages/pi-dcg/CHANGELOG.md
+++ b/packages/pi-dcg/CHANGELOG.md
@@ -20,6 +20,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ### Fixed
 
+- Made checked-command sealing idempotent when the package is loaded at more than one Pi scope.
 - Avoided empty stdin writes for probe commands, which could race with fast-exiting dcg binaries and falsely report that dcg was unavailable.
 
 ### Security

--- a/packages/pi-dcg/CODE_OF_CONDUCT.md
+++ b/packages/pi-dcg/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing these standards and may remove, edit, or reject contributions that are not aligned with this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers through GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/packages/pi-dcg/CONTRIBUTING.md
+++ b/packages/pi-dcg/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for your interest in contributing to `pi-dcg`.
+
+## Development setup
+
+```bash
+npm install
+npm run -w packages/pi-dcg check
+npm run -w packages/pi-dcg test
+```
+
+This package is source-distributed: Pi loads its TypeScript extension files directly. There is no runtime build step.
+
+## Local testing
+
+Install the checkout into a temporary Pi project:
+
+```bash
+mkdir -p <test-project>
+cd <test-project>
+pi install -l /path/to/pi-mono/packages/pi-dcg
+pi
+```
+
+Run `/dcg` to verify binary discovery. Exercise safe and destructive fixtures only through `dcg test` or a disposable sandbox; do not run genuinely destructive commands to test the bridge.
+
+## Pull request checklist
+
+- Run `npm run -w packages/pi-dcg check`.
+- Run `npm run -w packages/pi-dcg test`.
+- Run `npm audit --omit=dev`.
+- Run `npm run -w packages/pi-dcg pack:dry-run` and inspect included files.
+- Update README and SECURITY for behavior, environment, process, or data-flow changes.
+- Update CHANGELOG for notable changes.
+- Keep examples free of credentials, command secrets, machine-specific paths, and local policy content.
+
+## Coding guidelines
+
+- Keep extension wiring in `extensions/index.ts` and reusable behavior in `src/`.
+- Start dcg directly; never interpolate command text into a shell command.
+- Preserve hard-deny, cancellation, output-bound, cwd, and child-environment invariants documented in AGENTS.md.
+- Treat environment variable names and defaults as public API.
+- Keep tests independent of a real dcg installation.
+
+## Code of conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).

--- a/packages/pi-dcg/LICENSE
+++ b/packages/pi-dcg/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jose Mocito
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-dcg/README.md
+++ b/packages/pi-dcg/README.md
@@ -1,0 +1,143 @@
+# pi-dcg
+
+Guard Pi shell commands with [Destructive Command Guard (dcg)](https://github.com/Dicklesworthstone/destructive_command_guard) before they execute.
+
+`pi-dcg` is a Pi extension bridge. It does not bundle dcg, replace dcg policy, or provide a sandbox.
+
+## Requirements
+
+- Node.js 20.6 or newer
+- Pi 0.80 or newer
+- A separately installed `dcg` executable; dcg 0.6.8 or newer is recommended
+
+Install dcg using its [upstream installation instructions](https://github.com/Dicklesworthstone/destructive_command_guard#installation), review its release-verification guidance, and confirm that the binary is visible in the same environment as Pi:
+
+```bash
+dcg --version
+```
+
+> **Separate license:** dcg is external software with its own nonstandard license, including an OpenAI/Anthropic rider. It is not included in this package. Review the [dcg license](https://github.com/Dicklesworthstone/destructive_command_guard/blob/main/LICENSE) before installing or using it.
+
+## Install
+
+```bash
+pi install npm:pi-dcg
+```
+
+For project-local installation:
+
+```bash
+pi install -l npm:pi-dcg
+```
+
+For a one-off checkout test:
+
+```bash
+pi -e /path/to/pi-mono/packages/pi-dcg
+```
+
+## What it guards
+
+By default, the extension checks both Pi shell entry points:
+
+- agent calls to Pi's built-in `bash` tool;
+- user `!command` and `!!command` invocations.
+
+For every non-empty command, the extension starts dcg directly without a shell, sends a Claude-compatible `PreToolUse` payload on stdin, and waits for dcg's decision before Pi executes the command.
+
+| dcg response | Pi behavior |
+| --- | --- |
+| Empty stdout / explicit `allow` | Execute the command |
+| `permissionDecision: "deny"` | Block and show bounded rule/remediation details |
+| `permissionDecision: "ask"` | Ask for confirmation when UI is available; otherwise block |
+| Bridge failure | Allow by default, visibly marking dcg unavailable; configurable to block |
+
+Hard denials are never converted into one-click approvals. When dcg provides an allow-once code, the blocked result shows the exact `dcg allow-once ...` command so the user can review and run it explicitly.
+
+Run `/dcg` to probe the binary and show the active bridge configuration.
+
+## Why this uses hook mode
+
+The short upstream Pi recipe calls `dcg --robot test`. `pi-dcg` deliberately uses dcg's normal hook protocol instead because the current hook path provides the behavior expected from an agent integration:
+
+- Pi-specific agent profiles and their pack/allowlist changes;
+- hook policy and confidence handling;
+- scoped allow-once checks and pending exception records;
+- history/audit integration;
+- structured rule, severity, explanation, and remediation fields.
+
+The bridge sets `PI_CODING_AGENT=true` so dcg resolves `[agents.pi]` policy. It also sets `DCG_NO_SELF_HEAL=1` only for the child process: dcg's default hook self-healing targets Claude settings and should not rewrite those files merely because Pi asked for a decision.
+
+## Configuration
+
+`pi-dcg` uses environment variables for bridge behavior. dcg's own `DCG_*` variables and TOML files continue to control policy.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PI_DCG_BIN` | `DCG_BIN`, then `dcg` | Executable name or path. Leading `~/` is expanded. |
+| `PI_DCG_TIMEOUT_MS` | `5000` | Whole child-process timeout, from 100 to 60000 ms. |
+| `PI_DCG_ON_ERROR` | `allow` | `allow` (fail open) or `block` when the bridge cannot obtain a valid decision. |
+| `PI_DCG_GUARD_USER_BASH` | `1` | Set to `0`, `false`, `no`, or `off` to skip user `!`/`!!` commands. |
+
+Examples:
+
+```bash
+PI_DCG_BIN="$HOME/.local/bin/dcg" pi
+PI_DCG_ON_ERROR=block pi
+PI_DCG_GUARD_USER_BASH=0 pi
+```
+
+`PI_DCG_ON_ERROR=block` covers bridge failures such as a missing executable, timeout, malformed output, or oversized output. It cannot turn dcg's own intentional fail-open analysis decisions into failures. Configure dcg itself for stricter heredoc and hook behavior.
+
+### Pi-specific dcg policy
+
+Current dcg releases recognize the `pi` agent profile:
+
+```toml
+# ~/.config/dcg/config.toml or .dcg.toml
+[agents.pi]
+trust_level = "medium"
+extra_packs = ["database", "containers"]
+```
+
+Use real pack or category IDs reported by `dcg packs`.
+
+## Process and data handling
+
+- The command is sent only to the local dcg child process over stdin.
+- The extension never invokes a shell to start dcg.
+- dcg runs with Pi's current working directory, preserving project policy and allow-once scope.
+- Captured stdout and stderr share a 512 KiB limit.
+- dcg's human stderr output is captured rather than copied into Pi logs or model context.
+- Denial text sent back to Pi is bounded to prevent context flooding.
+
+On startup, this package also sends the monorepo-standard best-effort install/update telemetry ping to `mocito.dev`, once per package version. It is disabled in CI and respects Pi offline and telemetry settings. It contains the package name/version and platform/runtime/architecture only—never commands, paths, dcg output, or policy.
+
+## Limitations
+
+This extension intercepts Pi events, not operating-system process execution. It cannot see:
+
+- custom tools that execute commands under another tool name;
+- `pi.exec()` or child processes started internally by another extension;
+- destructive behavior performed directly through non-shell tools;
+- the contents of an opaque script invoked only as `./script.sh` unless dcg can infer or inspect the payload;
+- commands that dcg itself intentionally allows after a parse, size, or deadline fallback.
+
+`user_bash` handlers are first-result-wins in Pi. An earlier extension that fully handles `!` commands can prevent later handlers, including `pi-dcg`, from seeing them.
+
+Use a container, VM, sandbox, restricted credentials, backups, and review controls when a hard security boundary is required.
+
+## Development
+
+```bash
+npm install
+npm run -w packages/pi-dcg check
+npm run -w packages/pi-dcg test
+npm run -w packages/pi-dcg pack:dry-run
+```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) and [SECURITY.md](./SECURITY.md).
+
+## License
+
+`pi-dcg` is MIT licensed. dcg is separate external software and is not covered by this package's MIT license. See [THIRD-PARTY-NOTICES](./THIRD-PARTY-NOTICES).

--- a/packages/pi-dcg/README.md
+++ b/packages/pi-dcg/README.md
@@ -47,7 +47,7 @@ Pi's separate RPC control-channel `{"type":"bash"}` command does not emit either
 
 For every non-empty command, the extension starts dcg directly without a shell, sends a Claude-compatible `PreToolUse` payload on stdin, and waits for dcg's decision before Pi executes the command.
 
-Pi allows `tool_call` handlers to rewrite tool arguments in sequence. `pi-dcg` checks mutations made by earlier handlers, then seals the approved `command` value. If a later handler attempts to replace it, Pi blocks the tool call rather than executing a command dcg did not check.
+Pi allows `tool_call` handlers to rewrite tool arguments in sequence. `pi-dcg` checks mutations made by earlier handlers, then seals both the approved `command` value and its input reference. If a later handler attempts to replace either one, Pi blocks the tool call rather than executing a command dcg did not check.
 
 | dcg response | Pi behavior |
 | --- | --- |
@@ -56,7 +56,7 @@ Pi allows `tool_call` handlers to rewrite tool arguments in sequence. `pi-dcg` c
 | `permissionDecision: "ask"` | Ask for confirmation when UI is available; otherwise block |
 | Bridge failure | Allow by default, visibly marking dcg unavailable; configurable to block |
 
-Hard denials are never converted into one-click approvals. When dcg provides an allow-once code, the blocked result shows the exact `dcg allow-once ...` command so the user can review and run it explicitly.
+Hard denials are never converted into one-click approvals. When dcg provides an allow-once code, `pi-dcg` shows the exact `dcg allow-once ...` command only in a user-facing UI notification. It is deliberately excluded from the model-visible blocked tool result so an agent cannot redeem the exception itself.
 
 Run `/dcg` to probe the binary and show the active bridge configuration.
 

--- a/packages/pi-dcg/README.md
+++ b/packages/pi-dcg/README.md
@@ -38,10 +38,12 @@ pi -e /path/to/pi-mono/packages/pi-dcg
 
 ## What it guards
 
-By default, the extension checks both Pi shell entry points:
+By default, the extension checks both Pi shell events available to extensions:
 
 - agent calls to Pi's built-in `bash` tool;
 - user `!command` and `!!command` invocations.
+
+Pi's separate RPC control-channel `{"type":"bash"}` command does not emit either event in current Pi releases and cannot be intercepted by `pi-dcg`; see [Limitations](#limitations).
 
 For every non-empty command, the extension starts dcg directly without a shell, sends a Claude-compatible `PreToolUse` payload on stdin, and waits for dcg's decision before Pi executes the command.
 
@@ -118,6 +120,7 @@ On startup, this package also sends the monorepo-standard best-effort install/up
 This extension intercepts Pi events, not operating-system process execution. It cannot see:
 
 - custom tools that execute commands under another tool name;
+- Pi's RPC control-channel `{"type":"bash"}` command, which does not emit a `user_bash` event;
 - `pi.exec()` or child processes started internally by another extension;
 - destructive behavior performed directly through non-shell tools;
 - the contents of an opaque script invoked only as `./script.sh` unless dcg can infer or inspect the payload;

--- a/packages/pi-dcg/README.md
+++ b/packages/pi-dcg/README.md
@@ -47,6 +47,8 @@ Pi's separate RPC control-channel `{"type":"bash"}` command does not emit either
 
 For every non-empty command, the extension starts dcg directly without a shell, sends a Claude-compatible `PreToolUse` payload on stdin, and waits for dcg's decision before Pi executes the command.
 
+Pi allows `tool_call` handlers to rewrite tool arguments in sequence. `pi-dcg` checks mutations made by earlier handlers, then seals the approved `command` value. If a later handler attempts to replace it, Pi blocks the tool call rather than executing a command dcg did not check.
+
 | dcg response | Pi behavior |
 | --- | --- |
 | Empty stdout / explicit `allow` | Execute the command |

--- a/packages/pi-dcg/SECURITY.md
+++ b/packages/pi-dcg/SECURITY.md
@@ -37,6 +37,7 @@ This setting cannot detect dcg's internal intentional fail-open paths, which may
 The extension cannot intercept arbitrary process creation. Important bypasses include:
 
 - custom tools with other names;
+- Pi's RPC control-channel `{"type":"bash"}` command, which does not emit a `user_bash` event;
 - `pi.exec()` and child processes started inside another extension;
 - non-shell file, database, cloud, or API operations;
 - opaque generated scripts and dynamic payloads dcg cannot inspect;

--- a/packages/pi-dcg/SECURITY.md
+++ b/packages/pi-dcg/SECURITY.md
@@ -19,7 +19,8 @@ The bridge:
 - sends command text to that local child process on stdin;
 - sets the child cwd to Pi's current working directory;
 - validates dcg's structured stdout decision;
-- seals an approved agent `bash` command so later `tool_call` handlers cannot replace it unchecked;
+- seals an approved agent `bash` command and its input reference so later `tool_call` handlers cannot replace them unchecked;
+- keeps allow-once commands out of model-visible denial results and shows them only through user-facing UI notifications;
 - captures but does not log or forward dcg stderr;
 - bounds child output and denial text;
 - blocks a command when its check is cancelled;

--- a/packages/pi-dcg/SECURITY.md
+++ b/packages/pi-dcg/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the latest released version of `pi-dcg`.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability. Report privately through the repository maintainer's GitHub security contact. Include a description, reproduction steps, affected versions, and suggested mitigation when available.
+
+## Security model
+
+`pi-dcg` is a local guardrail bridge, not a sandbox or authorization boundary. Pi extensions execute with the same permissions as the user running Pi, and dcg is a separately installed executable with those permissions.
+
+The bridge:
+
+- intercepts Pi's built-in agent `bash` calls and, by default, user `!`/`!!` commands;
+- starts the configured dcg executable directly without a shell;
+- sends command text to that local child process on stdin;
+- sets the child cwd to Pi's current working directory;
+- validates dcg's structured stdout decision;
+- captures but does not log or forward dcg stderr;
+- bounds child output and denial text;
+- blocks a command when its check is cancelled;
+- preserves hard dcg denials without a one-click bypass.
+
+The child receives Pi's environment because dcg policy is intentionally configured through `DCG_*` variables. `pi-dcg` additionally sets `PI_CODING_AGENT=true`, `DCG_NO_SELF_HEAL=1`, and no-color flags for that child. Environment values are never logged or sent over the network by this package.
+
+### Failure behavior
+
+Bridge failures default to visible fail-open behavior to match dcg's integration philosophy. Set `PI_DCG_ON_ERROR=block` to block when the bridge cannot start dcg, times out, exceeds output limits, receives a nonzero exit, or cannot validate stdout.
+
+This setting cannot detect dcg's internal intentional fail-open paths, which may return a valid allow after size, parse, AST, or deadline fallback. Configure dcg itself for stricter analysis where supported.
+
+### Known bypasses
+
+The extension cannot intercept arbitrary process creation. Important bypasses include:
+
+- custom tools with other names;
+- `pi.exec()` and child processes started inside another extension;
+- non-shell file, database, cloud, or API operations;
+- opaque generated scripts and dynamic payloads dcg cannot inspect;
+- earlier Pi `user_bash` handlers that fully replace execution;
+- dcg rules, packs, safe patterns, allowlists, bypass variables, and fail-open analysis behavior.
+
+Use least-privilege credentials, version control, backups, containers/VMs, and OS-level sandboxing when destructive operations must be prevented rather than merely guarded.
+
+## External dcg dependency and license
+
+`pi-dcg` does not bundle or redistribute Destructive Command Guard. Users install it separately and are responsible for reviewing its code, releases, provenance, and nonstandard license, including its OpenAI/Anthropic rider. This package's MIT license does not apply to dcg.
+
+## Telemetry
+
+On startup, the package sends a best-effort install/update telemetry ping to `mocito.dev` once per package version unless disabled by CI, `PI_OFFLINE`, `PI_TELEMETRY`, or Pi's `enableInstallTelemetry` setting. The ping includes only package name/version and platform/runtime/architecture. It never includes commands, paths, dcg decisions, stderr, configuration, environment variables, prompts, credentials, or policy.

--- a/packages/pi-dcg/SECURITY.md
+++ b/packages/pi-dcg/SECURITY.md
@@ -19,6 +19,7 @@ The bridge:
 - sends command text to that local child process on stdin;
 - sets the child cwd to Pi's current working directory;
 - validates dcg's structured stdout decision;
+- seals an approved agent `bash` command so later `tool_call` handlers cannot replace it unchecked;
 - captures but does not log or forward dcg stderr;
 - bounds child output and denial text;
 - blocks a command when its check is cancelled;

--- a/packages/pi-dcg/THIRD-PARTY-NOTICES
+++ b/packages/pi-dcg/THIRD-PARTY-NOTICES
@@ -1,0 +1,9 @@
+THIRD-PARTY NOTICES
+
+pi-dcg interoperates with Destructive Command Guard (dcg), maintained by Jeffrey Emanuel and contributors:
+https://github.com/Dicklesworthstone/destructive_command_guard
+
+Destructive Command Guard is NOT included, copied, linked, or redistributed in the pi-dcg npm package. It is a separately installed executable governed by its own nonstandard license, including an OpenAI/Anthropic rider:
+https://github.com/Dicklesworthstone/destructive_command_guard/blob/main/LICENSE
+
+The MIT license distributed with pi-dcg applies only to pi-dcg's independently authored bridge code and documentation. Users are responsible for reviewing and complying with dcg's separate license before installing or using dcg.

--- a/packages/pi-dcg/extensions/index.ts
+++ b/packages/pi-dcg/extensions/index.ts
@@ -205,7 +205,9 @@ export default function piDcg(
       try {
         const probe = await client.probe(ctx.cwd);
         markHealthy(ctx, probe.version);
-        const coverage = config.guardUserBash ? "agent bash and user !/!! commands" : "agent bash commands";
+        const coverage = config.guardUserBash
+          ? "agent bash and user !/!! commands (RPC bash excluded)"
+          : "agent bash commands";
         notify(
           ctx,
           `pi-dcg is active\nBinary: ${config.binary}\nVersion: ${probe.version}\nCoverage: ${coverage}\nBridge errors: ${config.onError}`,

--- a/packages/pi-dcg/extensions/index.ts
+++ b/packages/pi-dcg/extensions/index.ts
@@ -36,6 +36,17 @@ function errorMessage(error: unknown): string {
   return "dcg failed for an unknown reason";
 }
 
+function sealCheckedBashCommand(input: { command: string }, command: string): void {
+  Object.defineProperty(input, "command", {
+    configurable: false,
+    enumerable: true,
+    get: () => command,
+    set: () => {
+      throw new Error("pi-dcg blocked a bash command mutation after its safety check");
+    },
+  });
+}
+
 function notify(
   ctx: ExtensionContext,
   message: string,
@@ -176,8 +187,14 @@ export default function piDcg(
 
   pi.on("tool_call", async (event, ctx) => {
     if (!isToolCallEventType("bash", event)) return undefined;
-    const outcome = await guard(event.input.command, ctx.cwd, ctx);
-    return outcome.block ? { block: true, reason: outcome.reason } : undefined;
+    const command = event.input.command;
+    const outcome = await guard(command, ctx.cwd, ctx);
+    if (outcome.block) return { block: true, reason: outcome.reason };
+
+    // Pi executes this same input object after all tool_call handlers finish.
+    // Seal the checked value so a later extension cannot replace it unchecked.
+    sealCheckedBashCommand(event.input, command);
+    return undefined;
   });
 
   if (config.guardUserBash) {

--- a/packages/pi-dcg/extensions/index.ts
+++ b/packages/pi-dcg/extensions/index.ts
@@ -16,6 +16,7 @@ import { formatDcgDecision, getDcgAllowOnceCommand } from "../src/protocol.js";
 
 const STATUS_KEY = "pi-dcg";
 const MAX_COMMAND_PREVIEW_CHARS = 4_000;
+const CHECKED_BASH_SEAL = Symbol.for("pi-dcg.checked-bash-seal");
 
 type GuardOutcome = { block: false } | { block: true; reason: string };
 type Health = "active" | "degraded" | "unknown";
@@ -41,6 +42,21 @@ function sealCheckedBashCommand(
   command: string,
 ): void {
   const input = event.input;
+  const seal = (event as unknown as Record<PropertyKey, unknown>)[CHECKED_BASH_SEAL];
+  if (seal !== undefined) {
+    if (
+      typeof seal === "object"
+      && seal !== null
+      && "input" in seal
+      && "command" in seal
+      && seal.input === input
+      && seal.command === command
+    ) {
+      return;
+    }
+    throw new Error("pi-dcg found an inconsistent existing bash command seal");
+  }
+
   Object.defineProperty(input, "command", {
     configurable: false,
     enumerable: true,
@@ -56,6 +72,12 @@ function sealCheckedBashCommand(
     set: () => {
       throw new Error("pi-dcg blocked a bash arguments replacement after its safety check");
     },
+  });
+  Object.defineProperty(event, CHECKED_BASH_SEAL, {
+    configurable: false,
+    enumerable: false,
+    value: { input, command },
+    writable: false,
   });
 }
 

--- a/packages/pi-dcg/extensions/index.ts
+++ b/packages/pi-dcg/extensions/index.ts
@@ -12,7 +12,7 @@ import {
   type DcgClientLike,
 } from "../src/dcg-client.js";
 import { reportInstallTelemetry } from "../src/install-telemetry.js";
-import { formatDcgDecision } from "../src/protocol.js";
+import { formatDcgDecision, getDcgAllowOnceCommand } from "../src/protocol.js";
 
 const STATUS_KEY = "pi-dcg";
 const MAX_COMMAND_PREVIEW_CHARS = 4_000;
@@ -36,13 +36,25 @@ function errorMessage(error: unknown): string {
   return "dcg failed for an unknown reason";
 }
 
-function sealCheckedBashCommand(input: { command: string }, command: string): void {
+function sealCheckedBashCommand(
+  event: { input: { command: string } },
+  command: string,
+): void {
+  const input = event.input;
   Object.defineProperty(input, "command", {
     configurable: false,
     enumerable: true,
     get: () => command,
     set: () => {
       throw new Error("pi-dcg blocked a bash command mutation after its safety check");
+    },
+  });
+  Object.defineProperty(event, "input", {
+    configurable: false,
+    enumerable: true,
+    get: () => input,
+    set: () => {
+      throw new Error("pi-dcg blocked a bash arguments replacement after its safety check");
     },
   });
 }
@@ -148,7 +160,13 @@ export default function piDcg(
 
     if (result.decision === "allow") return { block: false };
     const reason = formatDcgDecision(result);
-    if (result.decision === "deny") return { block: true, reason };
+    if (result.decision === "deny") {
+      const allowOnce = getDcgAllowOnceCommand(result);
+      if (allowOnce) {
+        notify(ctx, `dcg blocked the command. To authorize this exact command manually: ${allowOnce}`, "warning");
+      }
+      return { block: true, reason };
+    }
 
     if (!ctx.hasUI) {
       return { block: true, reason: `${reason}\n\nNo interactive UI is available to confirm this warning.` };
@@ -193,7 +211,7 @@ export default function piDcg(
 
     // Pi executes this same input object after all tool_call handlers finish.
     // Seal the checked value so a later extension cannot replace it unchecked.
-    sealCheckedBashCommand(event.input, command);
+    sealCheckedBashCommand(event, command);
     return undefined;
   });
 

--- a/packages/pi-dcg/extensions/index.ts
+++ b/packages/pi-dcg/extensions/index.ts
@@ -1,0 +1,223 @@
+import {
+  isToolCallEventType,
+  type ExtensionAPI,
+  type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { loadDcgBridgeConfig, type DcgBridgeConfig } from "../src/config.js";
+import {
+  DcgClient,
+  DcgProcessError,
+  isRecommendedDcgVersion,
+  MINIMUM_RECOMMENDED_DCG_VERSION,
+  type DcgClientLike,
+} from "../src/dcg-client.js";
+import { reportInstallTelemetry } from "../src/install-telemetry.js";
+import { formatDcgDecision } from "../src/protocol.js";
+
+const STATUS_KEY = "pi-dcg";
+const MAX_COMMAND_PREVIEW_CHARS = 4_000;
+
+type GuardOutcome = { block: false } | { block: true; reason: string };
+type Health = "active" | "degraded" | "unknown";
+
+export interface PiDcgDependencies {
+  client?: DcgClientLike;
+  config?: DcgBridgeConfig;
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof DcgProcessError) return error.message;
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return "dcg failed for an unknown reason";
+}
+
+function notify(
+  ctx: ExtensionContext,
+  message: string,
+  type: "info" | "warning" | "error",
+): void {
+  if (!ctx.hasUI) return;
+  try {
+    ctx.ui.notify(message, type);
+  } catch {
+    // UI failures must never alter a dcg decision.
+  }
+}
+
+function setStatus(
+  ctx: ExtensionContext,
+  health: Health,
+  config: DcgBridgeConfig,
+  version?: string,
+): void {
+  if (!ctx.hasUI) return;
+  try {
+    if (health === "active") {
+      const label = version ? `dcg ${version}` : "dcg active";
+      ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("success", `shield ${label}`));
+      return;
+    }
+    if (health === "degraded") {
+      const behavior = config.onError === "block" ? "blocking" : "fail-open";
+      ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("warning", `shield dcg unavailable (${behavior})`));
+      return;
+    }
+    ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("muted", "shield dcg checking"));
+  } catch {
+    // Status rendering is advisory and must never alter a dcg decision.
+  }
+}
+
+function clearStatus(ctx: ExtensionContext): void {
+  if (!ctx.hasUI) return;
+  try {
+    ctx.ui.setStatus(STATUS_KEY, undefined);
+  } catch {
+    // The session is already shutting down.
+  }
+}
+
+export default function piDcg(
+  pi: ExtensionAPI,
+  dependencies: PiDcgDependencies = {},
+): void {
+  reportInstallTelemetry();
+
+  const config = dependencies.config ?? loadDcgBridgeConfig();
+  const client = dependencies.client ?? new DcgClient(config);
+  let version: string | undefined;
+  let lastNotifiedError: string | undefined;
+  let warnedAboutVersion = false;
+
+  const markHealthy = (ctx: ExtensionContext, detectedVersion = version): void => {
+    version = detectedVersion;
+    lastNotifiedError = undefined;
+    setStatus(ctx, "active", config, version);
+  };
+
+  const markDegraded = (ctx: ExtensionContext, error: unknown): void => {
+    const message = errorMessage(error);
+    setStatus(ctx, "degraded", config, version);
+    if (ctx.hasUI && message !== lastNotifiedError) {
+      lastNotifiedError = message;
+      const behavior = config.onError === "block" ? "Commands will be blocked." : "Commands will be allowed (fail-open).";
+      notify(ctx, `pi-dcg: ${message} ${behavior}`, "warning");
+    }
+  };
+
+  const guard = async (
+    command: string,
+    cwd: string,
+    ctx: ExtensionContext,
+  ): Promise<GuardOutcome> => {
+    if (!command.trim()) return { block: false };
+
+    let result;
+    try {
+      result = await client.check(command, cwd, ctx.signal);
+      markHealthy(ctx);
+    } catch (error) {
+      if (error instanceof DcgProcessError && error.code === "aborted") {
+        return { block: true, reason: "dcg check was cancelled; the command was not run." };
+      }
+      markDegraded(ctx, error);
+      if (config.onError === "block") {
+        return {
+          block: true,
+          reason: `dcg could not evaluate this command: ${errorMessage(error)} Blocking because PI_DCG_ON_ERROR=block.`,
+        };
+      }
+      return { block: false };
+    }
+
+    if (result.decision === "allow") return { block: false };
+    const reason = formatDcgDecision(result);
+    if (result.decision === "deny") return { block: true, reason };
+
+    if (!ctx.hasUI) {
+      return { block: true, reason: `${reason}\n\nNo interactive UI is available to confirm this warning.` };
+    }
+
+    let approved = false;
+    try {
+      approved = await ctx.ui.confirm(
+        "dcg requires confirmation",
+        `Command:\n${truncate(command, MAX_COMMAND_PREVIEW_CHARS)}\n\n${reason}`,
+      );
+    } catch {
+      return { block: true, reason: `${reason}\n\nThe confirmation dialog failed, so the command was blocked.` };
+    }
+    return approved ? { block: false } : { block: true, reason: `${reason}\n\nThe command was not approved.` };
+  };
+
+  pi.on("session_start", async (_event, ctx) => {
+    if (!ctx.hasUI) return;
+    setStatus(ctx, "unknown", config);
+    try {
+      const probe = await client.probe(ctx.cwd);
+      markHealthy(ctx, probe.version);
+      if (!isRecommendedDcgVersion(probe.version) && !warnedAboutVersion) {
+        warnedAboutVersion = true;
+        notify(
+          ctx,
+          `pi-dcg: found dcg ${probe.version}; dcg ${MINIMUM_RECOMMENDED_DCG_VERSION} or newer is recommended.`,
+          "warning",
+        );
+      }
+    } catch (error) {
+      markDegraded(ctx, error);
+    }
+  });
+
+  pi.on("tool_call", async (event, ctx) => {
+    if (!isToolCallEventType("bash", event)) return undefined;
+    const outcome = await guard(event.input.command, ctx.cwd, ctx);
+    return outcome.block ? { block: true, reason: outcome.reason } : undefined;
+  });
+
+  if (config.guardUserBash) {
+    pi.on("user_bash", async (event, ctx) => {
+      const outcome = await guard(event.command, event.cwd, ctx);
+      if (!outcome.block) return undefined;
+      return {
+        result: {
+          output: outcome.reason,
+          exitCode: 1,
+          cancelled: false,
+          truncated: false,
+        },
+      };
+    });
+  }
+
+  pi.registerCommand("dcg", {
+    description: "Show pi-dcg status and configuration",
+    handler: async (args, ctx) => {
+      if (args.trim()) {
+        notify(ctx, "Usage: /dcg", "warning");
+        return;
+      }
+      try {
+        const probe = await client.probe(ctx.cwd);
+        markHealthy(ctx, probe.version);
+        const coverage = config.guardUserBash ? "agent bash and user !/!! commands" : "agent bash commands";
+        notify(
+          ctx,
+          `pi-dcg is active\nBinary: ${config.binary}\nVersion: ${probe.version}\nCoverage: ${coverage}\nBridge errors: ${config.onError}`,
+          "info",
+        );
+      } catch (error) {
+        markDegraded(ctx, error);
+      }
+    },
+  });
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    clearStatus(ctx);
+  });
+}

--- a/packages/pi-dcg/index.ts
+++ b/packages/pi-dcg/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./extensions/index.js";

--- a/packages/pi-dcg/package.json
+++ b/packages/pi-dcg/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "pi-dcg",
+  "version": "0.1.0",
+  "description": "Guard Pi shell commands with Destructive Command Guard.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Jose Mocito",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jvm/pi-mono.git",
+    "directory": "packages/pi-dcg"
+  },
+  "bugs": {
+    "url": "https://github.com/jvm/pi-mono/issues"
+  },
+  "homepage": "https://github.com/jvm/pi-mono/tree/main/packages/pi-dcg#readme",
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi",
+    "dcg",
+    "destructive-command-guard",
+    "command-safety",
+    "guardrails"
+  ],
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "files": [
+    "index.ts",
+    "extensions",
+    "src",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "SECURITY.md",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md",
+    "THIRD-PARTY-NOTICES"
+  ],
+  "scripts": {
+    "check": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test tests/*.test.mjs",
+    "pack:dry-run": "npm pack --dry-run"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.80.0",
+    "@types/node": "^26.1.0",
+    "tsx": "^4.23.0",
+    "typescript": "^6.0.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20.6.0"
+  }
+}

--- a/packages/pi-dcg/src/config.ts
+++ b/packages/pi-dcg/src/config.ts
@@ -1,0 +1,57 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const DEFAULT_DCG_TIMEOUT_MS = 5_000;
+export const MIN_DCG_TIMEOUT_MS = 100;
+export const MAX_DCG_TIMEOUT_MS = 60_000;
+export const MAX_DCG_OUTPUT_BYTES = 512 * 1024;
+
+export type DcgErrorMode = "allow" | "block";
+
+export interface DcgBridgeConfig {
+  binary: string;
+  timeoutMs: number;
+  maxOutputBytes: number;
+  onError: DcgErrorMode;
+  guardUserBash: boolean;
+}
+
+function isFalseEnvValue(value: string): boolean {
+  return ["0", "false", "no", "off", "n"].includes(value.trim().toLowerCase());
+}
+
+function parseTimeout(value: string | undefined): number {
+  if (value === undefined || value.trim() === "") return DEFAULT_DCG_TIMEOUT_MS;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < MIN_DCG_TIMEOUT_MS || parsed > MAX_DCG_TIMEOUT_MS) {
+    return DEFAULT_DCG_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
+function expandHome(path: string, home: string): string {
+  if (path === "~") return home;
+  if (path.startsWith("~/") || path.startsWith("~\\")) {
+    return join(home, path.slice(2));
+  }
+  return path;
+}
+
+export function loadDcgBridgeConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+): DcgBridgeConfig {
+  const configuredBinary = env.PI_DCG_BIN?.trim() || env.DCG_BIN?.trim() || "dcg";
+  const onError = env.PI_DCG_ON_ERROR?.trim().toLowerCase() === "block" ? "block" : "allow";
+  const guardUserBash = env.PI_DCG_GUARD_USER_BASH === undefined
+    ? true
+    : !isFalseEnvValue(env.PI_DCG_GUARD_USER_BASH);
+
+  return {
+    binary: expandHome(configuredBinary, home),
+    timeoutMs: parseTimeout(env.PI_DCG_TIMEOUT_MS),
+    maxOutputBytes: MAX_DCG_OUTPUT_BYTES,
+    onError,
+    guardUserBash,
+  };
+}

--- a/packages/pi-dcg/src/dcg-client.ts
+++ b/packages/pi-dcg/src/dcg-client.ts
@@ -1,0 +1,202 @@
+import { spawn } from "node:child_process";
+import type { DcgBridgeConfig } from "./config.js";
+import { parseDcgHookResponse, type DcgDecision } from "./protocol.js";
+
+export const MINIMUM_RECOMMENDED_DCG_VERSION = "0.6.8";
+
+export type DcgProcessErrorCode =
+  | "aborted"
+  | "output_limit"
+  | "spawn_failed"
+  | "timed_out";
+
+export class DcgProcessError extends Error {
+  constructor(
+    message: string,
+    public readonly code: DcgProcessErrorCode,
+  ) {
+    super(message);
+    this.name = "DcgProcessError";
+  }
+}
+
+export interface ProcessRequest {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  input?: string;
+  timeoutMs: number;
+  maxOutputBytes: number;
+  signal?: AbortSignal;
+}
+
+export interface ProcessResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+export type ProcessExecutor = (request: ProcessRequest) => Promise<ProcessResult>;
+
+export const executeProcess: ProcessExecutor = (request) => new Promise((resolve, reject) => {
+  if (request.signal?.aborted) {
+    reject(new DcgProcessError("dcg check was cancelled", "aborted"));
+    return;
+  }
+
+  const child = spawn(request.command, request.args, {
+    cwd: request.cwd,
+    env: request.env,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  let settled = false;
+  let stdout = "";
+  let stderr = "";
+  let outputBytes = 0;
+
+  const cleanup = (): void => {
+    clearTimeout(timeout);
+    request.signal?.removeEventListener("abort", onAbort);
+  };
+
+  const rejectOnce = (error: Error, kill = false): void => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    if (kill && child.exitCode === null) child.kill();
+    reject(error);
+  };
+
+  const append = (stream: "stdout" | "stderr", chunk: Buffer): void => {
+    if (settled) return;
+    outputBytes += chunk.byteLength;
+    if (outputBytes > request.maxOutputBytes) {
+      rejectOnce(new DcgProcessError("dcg output exceeded the bridge limit", "output_limit"), true);
+      return;
+    }
+    if (stream === "stdout") stdout += chunk.toString("utf8");
+    else stderr += chunk.toString("utf8");
+  };
+
+  const onAbort = (): void => {
+    rejectOnce(new DcgProcessError("dcg check was cancelled", "aborted"), true);
+  };
+
+  const timeout = setTimeout(() => {
+    rejectOnce(new DcgProcessError(`dcg did not finish within ${request.timeoutMs}ms`, "timed_out"), true);
+  }, request.timeoutMs);
+
+  request.signal?.addEventListener("abort", onAbort, { once: true });
+  child.stdout.on("data", (chunk: Buffer) => append("stdout", chunk));
+  child.stderr.on("data", (chunk: Buffer) => append("stderr", chunk));
+  child.once("error", (error) => {
+    rejectOnce(new DcgProcessError(`could not start dcg: ${error.message}`, "spawn_failed"));
+  });
+  child.stdin.once("error", (error) => {
+    rejectOnce(new DcgProcessError(`could not send the command to dcg: ${error.message}`, "spawn_failed"), true);
+  });
+  child.once("close", (exitCode) => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    resolve({ stdout, stderr, exitCode });
+  });
+
+  child.stdin.end(request.input ?? "", "utf8");
+});
+
+export interface DcgProbeResult {
+  version: string;
+}
+
+export interface DcgClientLike {
+  check(command: string, cwd: string, signal?: AbortSignal): Promise<DcgDecision>;
+  probe(cwd: string, signal?: AbortSignal): Promise<DcgProbeResult>;
+}
+
+function processEnvironment(environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...environment,
+    PI_CODING_AGENT: "true",
+    DCG_NO_SELF_HEAL: "1",
+    DCG_NO_COLOR: "1",
+    NO_COLOR: "1",
+  };
+}
+
+function parseVersion(stdout: string): string {
+  const match = stdout.match(/(?:^|\s)v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)/);
+  if (match?.[1]) return match[1];
+  const firstLine = stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean);
+  if (!firstLine) throw new Error("dcg --version returned no version");
+  return firstLine.replace(/^dcg\s+/i, "");
+}
+
+function parseSemver(value: string): [number, number, number] | undefined {
+  const match = value.match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return undefined;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function isRecommendedDcgVersion(version: string): boolean {
+  const actual = parseSemver(version);
+  const minimum = parseSemver(MINIMUM_RECOMMENDED_DCG_VERSION);
+  if (!actual || !minimum) return false;
+  for (let index = 0; index < actual.length; index += 1) {
+    if (actual[index] !== minimum[index]) return actual[index] > minimum[index];
+  }
+  return true;
+}
+
+export class DcgClient implements DcgClientLike {
+  constructor(
+    public readonly config: DcgBridgeConfig,
+    private readonly processExecutor: ProcessExecutor = executeProcess,
+    private readonly environment: NodeJS.ProcessEnv = process.env,
+  ) {}
+
+  async check(command: string, cwd: string, signal?: AbortSignal): Promise<DcgDecision> {
+    const input = `${JSON.stringify({
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command },
+      cwd,
+    })}\n`;
+    const result = await this.processExecutor({
+      command: this.config.binary,
+      args: [],
+      cwd,
+      env: processEnvironment(this.environment),
+      input,
+      timeoutMs: this.config.timeoutMs,
+      maxOutputBytes: this.config.maxOutputBytes,
+      signal,
+    });
+
+    if (result.exitCode !== 0) {
+      const exit = result.exitCode === null ? "a signal" : `exit code ${result.exitCode}`;
+      throw new Error(`dcg hook failed with ${exit}`);
+    }
+    return parseDcgHookResponse(result.stdout);
+  }
+
+  async probe(cwd: string, signal?: AbortSignal): Promise<DcgProbeResult> {
+    const result = await this.processExecutor({
+      command: this.config.binary,
+      args: ["--version"],
+      cwd,
+      env: processEnvironment(this.environment),
+      timeoutMs: Math.min(this.config.timeoutMs, 1_500),
+      maxOutputBytes: this.config.maxOutputBytes,
+      signal,
+    });
+    if (result.exitCode !== 0) {
+      const exit = result.exitCode === null ? "a signal" : `exit code ${result.exitCode}`;
+      throw new Error(`dcg --version failed with ${exit}`);
+    }
+    return { version: parseVersion(result.stdout) };
+  }
+}

--- a/packages/pi-dcg/src/dcg-client.ts
+++ b/packages/pi-dcg/src/dcg-client.ts
@@ -48,7 +48,7 @@ export const executeProcess: ProcessExecutor = (request) => new Promise((resolve
   const child = spawn(request.command, request.args, {
     cwd: request.cwd,
     env: request.env,
-    stdio: ["pipe", "pipe", "pipe"],
+    stdio: [request.input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
     windowsHide: true,
   });
 
@@ -90,13 +90,10 @@ export const executeProcess: ProcessExecutor = (request) => new Promise((resolve
   }, request.timeoutMs);
 
   request.signal?.addEventListener("abort", onAbort, { once: true });
-  child.stdout.on("data", (chunk: Buffer) => append("stdout", chunk));
-  child.stderr.on("data", (chunk: Buffer) => append("stderr", chunk));
+  child.stdout?.on("data", (chunk: Buffer) => append("stdout", chunk));
+  child.stderr?.on("data", (chunk: Buffer) => append("stderr", chunk));
   child.once("error", (error) => {
     rejectOnce(new DcgProcessError(`could not start dcg: ${error.message}`, "spawn_failed"));
-  });
-  child.stdin.once("error", (error) => {
-    rejectOnce(new DcgProcessError(`could not send the command to dcg: ${error.message}`, "spawn_failed"), true);
   });
   child.once("close", (exitCode) => {
     if (settled) return;
@@ -105,7 +102,16 @@ export const executeProcess: ProcessExecutor = (request) => new Promise((resolve
     resolve({ stdout, stderr, exitCode });
   });
 
-  child.stdin.end(request.input ?? "", "utf8");
+  if (request.input !== undefined) {
+    if (!child.stdin) {
+      rejectOnce(new DcgProcessError("could not open dcg stdin", "spawn_failed"), true);
+      return;
+    }
+    child.stdin.once("error", (error) => {
+      rejectOnce(new DcgProcessError(`could not send the command to dcg: ${error.message}`, "spawn_failed"), true);
+    });
+    child.stdin.end(request.input, "utf8");
+  }
 });
 
 export interface DcgProbeResult {

--- a/packages/pi-dcg/src/index.ts
+++ b/packages/pi-dcg/src/index.ts
@@ -1,0 +1,5 @@
+export const PACKAGE_NAME = "pi-dcg";
+
+export * from "./config.js";
+export * from "./dcg-client.js";
+export * from "./protocol.js";

--- a/packages/pi-dcg/src/install-telemetry.ts
+++ b/packages/pi-dcg/src/install-telemetry.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+const PACKAGE_NAME = "pi-dcg";
+const INSTALL_TELEMETRY_URL = "https://mocito.dev/api/report-install";
+const INSTALL_TELEMETRY_TIMEOUT_MS = 5000;
+const CI_ENVIRONMENT_VARIABLES = [
+  "APPVEYOR",
+  "BITBUCKET_BUILD_NUMBER",
+  "BUILDKITE",
+  "CIRCLECI",
+  "CODESPACES",
+  "DRONE",
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "JENKINS_URL",
+  "NETLIFY",
+  "TEAMCITY_VERSION",
+  "TF_BUILD",
+  "TRAVIS",
+  "VERCEL",
+];
+
+interface InstallTelemetryState {
+  lastReportedVersion?: string;
+}
+
+interface PiSettingsDocument {
+  enableInstallTelemetry?: unknown;
+}
+
+function readJsonFile(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as unknown;
+  } catch {
+    return {};
+  }
+}
+
+function isTruthyEnvFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
+}
+
+function isPresentEnvFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized !== "0" && normalized !== "false" && normalized !== "no";
+}
+
+function isCiEnvironment(): boolean {
+  if (isTruthyEnvFlag(process.env.CI)) return true;
+  return CI_ENVIRONMENT_VARIABLES.some((name) => isPresentEnvFlag(process.env[name]));
+}
+
+function isInstallTelemetryEnabled(): boolean {
+  if (isCiEnvironment()) return false;
+  if (isTruthyEnvFlag(process.env.PI_OFFLINE)) return false;
+  if (process.env.PI_TELEMETRY !== undefined) return isTruthyEnvFlag(process.env.PI_TELEMETRY);
+
+  const settings = readJsonFile(join(getAgentDir(), "settings.json")) as PiSettingsDocument;
+  return settings.enableInstallTelemetry !== false;
+}
+
+function getPackageVersion(): string {
+  const packageJson = readJsonFile(fileURLToPath(new URL("../package.json", import.meta.url))) as { version?: unknown };
+  return typeof packageJson.version === "string" && packageJson.version.length > 0 ? packageJson.version : "0.0.0";
+}
+
+function getInstallTelemetryUserAgent(version: string): string {
+  const runtimeVersions = process.versions as NodeJS.ProcessVersions & { bun?: string };
+  const runtime = runtimeVersions.bun ? `bun/${runtimeVersions.bun}` : `node/${process.version}`;
+  return `${PACKAGE_NAME}/${version} (${process.platform}; ${runtime}; ${process.arch})`;
+}
+
+async function reportInstallTelemetryAsync(): Promise<void> {
+  try {
+    if (!isInstallTelemetryEnabled()) return;
+
+    const version = getPackageVersion();
+    const extensionsDir = join(getAgentDir(), "extensions");
+    const statePath = join(extensionsDir, "pi-dcg-install.json");
+    const state = readJsonFile(statePath) as InstallTelemetryState;
+    if (state.lastReportedVersion === version) return;
+
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+
+    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+    });
+  } catch {
+    // Best-effort telemetry: ignore settings, filesystem, and network failures.
+  }
+}
+
+export function reportInstallTelemetry(): void {
+  void reportInstallTelemetryAsync();
+}

--- a/packages/pi-dcg/src/protocol.ts
+++ b/packages/pi-dcg/src/protocol.ts
@@ -88,6 +88,10 @@ function truncate(value: string, maxChars: number): string {
   return `${value.slice(0, Math.max(0, maxChars - 1))}…`;
 }
 
+function redactAllowOnceCommands(value: string): string {
+  return value.replace(/\bdcg\s+allow-once\b[^\r\n]*/gi, "[manual authorization command hidden]");
+}
+
 function extractReason(message: string | undefined): string | undefined {
   if (!message) return undefined;
   const match = message.match(/(?:^|\n)Reason:\s*([^\n]*(?:\n(?!\s*(?:Explanation|Rule|Pack|Command):)[^\n]*)*)/i);
@@ -99,6 +103,14 @@ function metadata(hook: DcgHookOutput): string | undefined {
   const fields = [hook.severity, hook.ruleId ?? hook.packId].filter(Boolean);
   if (hook.confidence !== undefined) fields.push(`confidence ${hook.confidence.toFixed(2)}`);
   return fields.length > 0 ? fields.join(" · ") : undefined;
+}
+
+export function getDcgAllowOnceCommand(
+  result: Exclude<DcgDecision, { decision: "allow" }>,
+): string | undefined {
+  const command = result.hook.remediation?.allowOnceCommand
+    ?? (result.hook.allowOnceCode ? `dcg allow-once ${result.hook.allowOnceCode}` : undefined);
+  return command ? truncate(command.trim(), MAX_FIELD_CHARS) : undefined;
 }
 
 export function formatDcgDecision(result: Exclude<DcgDecision, { decision: "allow" }>): string {
@@ -118,9 +130,5 @@ export function formatDcgDecision(result: Exclude<DcgDecision, { decision: "allo
   const alternative = hook.remediation?.safeAlternative?.trim();
   if (alternative) lines.push(`Safer alternative: ${truncate(alternative, MAX_FIELD_CHARS)}`);
 
-  const allowOnce = hook.remediation?.allowOnceCommand
-    ?? (hook.allowOnceCode ? `dcg allow-once ${hook.allowOnceCode}` : undefined);
-  if (allowOnce) lines.push(`To authorize this exact command: ${allowOnce}`);
-
-  return truncate(lines.join("\n\n"), MAX_REASON_CHARS);
+  return truncate(redactAllowOnceCommands(lines.join("\n\n")), MAX_REASON_CHARS);
 }

--- a/packages/pi-dcg/src/protocol.ts
+++ b/packages/pi-dcg/src/protocol.ts
@@ -1,0 +1,126 @@
+const MAX_REASON_CHARS = 12_000;
+const MAX_FIELD_CHARS = 8_000;
+
+interface DcgRemediation {
+  safeAlternative?: string;
+  explanation?: string;
+  allowOnceCommand?: string;
+}
+
+interface DcgHookOutput {
+  permissionDecision: "allow" | "deny" | "ask";
+  permissionDecisionReason?: string;
+  allowOnceCode?: string;
+  allowOnceFullHash?: string;
+  ruleId?: string;
+  packId?: string;
+  severity?: string;
+  confidence?: number;
+  remediation?: DcgRemediation;
+}
+
+export type DcgDecision =
+  | { decision: "allow" }
+  | { decision: "deny" | "ask"; hook: DcgHookOutput };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseRemediation(value: unknown): DcgRemediation | undefined {
+  if (!isRecord(value)) return undefined;
+  const remediation = {
+    safeAlternative: optionalString(value.safeAlternative),
+    explanation: optionalString(value.explanation),
+    allowOnceCommand: optionalString(value.allowOnceCommand),
+  };
+  return Object.values(remediation).some((field) => field !== undefined) ? remediation : undefined;
+}
+
+export function parseDcgHookResponse(stdout: string): DcgDecision {
+  const trimmed = stdout.trim().replace(/^\uFEFF/, "");
+  if (trimmed === "") return { decision: "allow" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed) as unknown;
+  } catch {
+    throw new Error("dcg returned malformed JSON");
+  }
+
+  if (!isRecord(parsed) || !isRecord(parsed.hookSpecificOutput)) {
+    throw new Error("dcg returned an unsupported hook response");
+  }
+
+  const raw = parsed.hookSpecificOutput;
+  const permissionDecision = raw.permissionDecision;
+  if (permissionDecision !== "allow" && permissionDecision !== "deny" && permissionDecision !== "ask") {
+    throw new Error("dcg hook response has an unknown permission decision");
+  }
+  if (permissionDecision === "allow") return { decision: "allow" };
+
+  return {
+    decision: permissionDecision,
+    hook: {
+      permissionDecision,
+      permissionDecisionReason: optionalString(raw.permissionDecisionReason),
+      allowOnceCode: optionalString(raw.allowOnceCode),
+      allowOnceFullHash: optionalString(raw.allowOnceFullHash),
+      ruleId: optionalString(raw.ruleId),
+      packId: optionalString(raw.packId),
+      severity: optionalString(raw.severity),
+      confidence: optionalNumber(raw.confidence),
+      remediation: parseRemediation(raw.remediation),
+    },
+  };
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function extractReason(message: string | undefined): string | undefined {
+  if (!message) return undefined;
+  const match = message.match(/(?:^|\n)Reason:\s*([^\n]*(?:\n(?!\s*(?:Explanation|Rule|Pack|Command):)[^\n]*)*)/i);
+  const reason = match?.[1]?.trim();
+  return reason || truncate(message.trim(), MAX_FIELD_CHARS);
+}
+
+function metadata(hook: DcgHookOutput): string | undefined {
+  const fields = [hook.severity, hook.ruleId ?? hook.packId].filter(Boolean);
+  if (hook.confidence !== undefined) fields.push(`confidence ${hook.confidence.toFixed(2)}`);
+  return fields.length > 0 ? fields.join(" · ") : undefined;
+}
+
+export function formatDcgDecision(result: Exclude<DcgDecision, { decision: "allow" }>): string {
+  const { hook } = result;
+  const lines = [result.decision === "deny" ? "Blocked by dcg." : "dcg requires confirmation."];
+  const meta = metadata(hook);
+  if (meta) lines.push(meta);
+
+  const reason = extractReason(hook.permissionDecisionReason);
+  if (reason) lines.push(`Reason: ${truncate(reason, MAX_FIELD_CHARS)}`);
+
+  const explanation = hook.remediation?.explanation?.trim();
+  if (explanation && explanation !== reason) {
+    lines.push(`Details: ${truncate(explanation, MAX_FIELD_CHARS)}`);
+  }
+
+  const alternative = hook.remediation?.safeAlternative?.trim();
+  if (alternative) lines.push(`Safer alternative: ${truncate(alternative, MAX_FIELD_CHARS)}`);
+
+  const allowOnce = hook.remediation?.allowOnceCommand
+    ?? (hook.allowOnceCode ? `dcg allow-once ${hook.allowOnceCode}` : undefined);
+  if (allowOnce) lines.push(`To authorize this exact command: ${allowOnce}`);
+
+  return truncate(lines.join("\n\n"), MAX_REASON_CHARS);
+}

--- a/packages/pi-dcg/tests/client.test.mjs
+++ b/packages/pi-dcg/tests/client.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DcgClient,
+  isRecommendedDcgVersion,
+  MINIMUM_RECOMMENDED_DCG_VERSION,
+} from "../src/dcg-client.ts";
+
+function makeConfig(overrides = {}) {
+  return {
+    binary: "/opt/dcg",
+    timeoutMs: 5000,
+    maxOutputBytes: 1024,
+    onError: "allow",
+    guardUserBash: true,
+    ...overrides,
+  };
+}
+
+test("sends a Pi-identified, cwd-aware hook request", async () => {
+  let request;
+  const executor = async (value) => {
+    request = value;
+    return { stdout: "", stderr: "", exitCode: 0 };
+  };
+  const client = new DcgClient(makeConfig(), executor, {
+    DCG_PACKS: "database",
+    DCG_SELF_HEAL_HOOK: "true",
+  });
+
+  assert.deepEqual(await client.check("git status", "/work/project"), { decision: "allow" });
+  assert.equal(request.command, "/opt/dcg");
+  assert.deepEqual(request.args, []);
+  assert.equal(request.cwd, "/work/project");
+  assert.equal(request.env.PI_CODING_AGENT, "true");
+  assert.equal(request.env.DCG_NO_SELF_HEAL, "1");
+  assert.equal(request.env.DCG_NO_COLOR, "1");
+  assert.equal(request.env.DCG_PACKS, "database");
+  assert.equal(request.env.DCG_SELF_HEAL_HOOK, "true");
+
+  const payload = JSON.parse(request.input);
+  assert.deepEqual(payload, {
+    hook_event_name: "PreToolUse",
+    tool_name: "Bash",
+    tool_input: { command: "git status" },
+    cwd: "/work/project",
+  });
+});
+
+test("parses a hook denial from stdout even though hook exit is zero", async () => {
+  const executor = async () => ({
+    stdout: JSON.stringify({
+      hookSpecificOutput: {
+        permissionDecision: "deny",
+        ruleId: "core.git:reset-hard",
+      },
+    }),
+    stderr: "human warning that must not be parsed",
+    exitCode: 0,
+  });
+  const result = await new DcgClient(makeConfig(), executor).check("git reset --hard", "/work");
+  assert.equal(result.decision, "deny");
+  assert.equal(result.hook.ruleId, "core.git:reset-hard");
+});
+
+test("treats nonzero hook exit as a bridge failure", async () => {
+  const executor = async () => ({ stdout: "", stderr: "secret command text", exitCode: 4 });
+  await assert.rejects(
+    new DcgClient(makeConfig(), executor).check("command", "/work"),
+    /exit code 4/,
+  );
+});
+
+test("probes a bounded version command", async () => {
+  let request;
+  const executor = async (value) => {
+    request = value;
+    return { stdout: "dcg v0.6.8\n", stderr: "artwork", exitCode: 0 };
+  };
+  const client = new DcgClient(makeConfig({ timeoutMs: 9000 }), executor);
+  assert.deepEqual(await client.probe("/work"), { version: "0.6.8" });
+  assert.deepEqual(request.args, ["--version"]);
+  assert.equal(request.timeoutMs, 1500);
+});
+
+test("recognizes the recommended dcg version floor", () => {
+  assert.equal(MINIMUM_RECOMMENDED_DCG_VERSION, "0.6.8");
+  assert.equal(isRecommendedDcgVersion("0.6.7"), false);
+  assert.equal(isRecommendedDcgVersion("0.6.8"), true);
+  assert.equal(isRecommendedDcgVersion("v0.7.0"), true);
+  assert.equal(isRecommendedDcgVersion("unknown"), false);
+});

--- a/packages/pi-dcg/tests/config.test.mjs
+++ b/packages/pi-dcg/tests/config.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_DCG_TIMEOUT_MS,
+  MAX_DCG_OUTPUT_BYTES,
+  loadDcgBridgeConfig,
+} from "../src/config.ts";
+
+test("loads secure bridge defaults", () => {
+  const config = loadDcgBridgeConfig({}, "/home/tester");
+  assert.deepEqual(config, {
+    binary: "dcg",
+    timeoutMs: DEFAULT_DCG_TIMEOUT_MS,
+    maxOutputBytes: MAX_DCG_OUTPUT_BYTES,
+    onError: "allow",
+    guardUserBash: true,
+  });
+});
+
+test("prefers PI_DCG_BIN, expands home, and accepts block mode", () => {
+  const config = loadDcgBridgeConfig({
+    PI_DCG_BIN: "~/.local/bin/dcg",
+    DCG_BIN: "/ignored/dcg",
+    PI_DCG_TIMEOUT_MS: "9000",
+    PI_DCG_ON_ERROR: "BLOCK",
+    PI_DCG_GUARD_USER_BASH: "false",
+  }, "/home/tester");
+
+  assert.equal(config.binary, "/home/tester/.local/bin/dcg");
+  assert.equal(config.timeoutMs, 9000);
+  assert.equal(config.onError, "block");
+  assert.equal(config.guardUserBash, false);
+});
+
+test("falls back to DCG_BIN and keeps literal command names", () => {
+  assert.equal(loadDcgBridgeConfig({ DCG_BIN: "custom-dcg" }, "/home/tester").binary, "custom-dcg");
+});
+
+test("uses safe defaults for invalid values", () => {
+  const config = loadDcgBridgeConfig({
+    PI_DCG_TIMEOUT_MS: "99",
+    PI_DCG_ON_ERROR: "explode",
+    PI_DCG_GUARD_USER_BASH: "yes",
+  }, "/home/tester");
+
+  assert.equal(config.timeoutMs, DEFAULT_DCG_TIMEOUT_MS);
+  assert.equal(config.onError, "allow");
+  assert.equal(config.guardUserBash, true);
+});

--- a/packages/pi-dcg/tests/extension.test.mjs
+++ b/packages/pi-dcg/tests/extension.test.mjs
@@ -223,7 +223,7 @@ test("probes on UI session start, exposes diagnostics, and clears status", async
   assert.match(context.statuses.at(-1).value, /dcg 0\.6\.8/);
 
   await pi.commands.get("dcg").handler("", context);
-  assert.match(context.notifications.at(-1).message, /Coverage: agent bash and user !\/!! commands/);
+  assert.match(context.notifications.at(-1).message, /Coverage: agent bash and user !\/!! commands \(RPC bash excluded\)/);
 
   await pi.handlers.get("session_shutdown")[0]({ type: "session_shutdown", reason: "quit" }, context);
   assert.equal(context.statuses.at(-1).value, undefined);

--- a/packages/pi-dcg/tests/extension.test.mjs
+++ b/packages/pi-dcg/tests/extension.test.mjs
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.CI = "1";
+
+const { default: piDcg } = await import("../extensions/index.ts");
+const { DcgProcessError } = await import("../src/dcg-client.ts");
+
+function makeConfig(overrides = {}) {
+  return {
+    binary: "dcg",
+    timeoutMs: 5000,
+    maxOutputBytes: 1024,
+    onError: "allow",
+    guardUserBash: true,
+    ...overrides,
+  };
+}
+
+function makePi() {
+  const handlers = new Map();
+  const commands = new Map();
+  return {
+    handlers,
+    commands,
+    on(event, handler) {
+      const eventHandlers = handlers.get(event) ?? [];
+      eventHandlers.push(handler);
+      handlers.set(event, eventHandlers);
+    },
+    registerCommand(name, command) {
+      commands.set(name, command);
+    },
+  };
+}
+
+function makeContext({ hasUI = false, confirm = false } = {}) {
+  const notifications = [];
+  const statuses = [];
+  return {
+    cwd: "/work/project",
+    hasUI,
+    mode: hasUI ? "tui" : "print",
+    signal: undefined,
+    notifications,
+    statuses,
+    ui: {
+      theme: { fg: (_color, text) => text },
+      notify: (message, type) => notifications.push({ message, type }),
+      setStatus: (key, value) => statuses.push({ key, value }),
+      confirm: async () => confirm,
+    },
+  };
+}
+
+function makeClient({ decision = { decision: "allow" }, version = "0.6.8", error } = {}) {
+  return {
+    checks: [],
+    probes: [],
+    async check(command, cwd, signal) {
+      this.checks.push({ command, cwd, signal });
+      if (error) throw error;
+      return decision;
+    },
+    async probe(cwd) {
+      this.probes.push(cwd);
+      if (error) throw error;
+      return { version };
+    },
+  };
+}
+
+function bashEvent(command = "git status") {
+  return { type: "tool_call", toolCallId: "call-1", toolName: "bash", input: { command } };
+}
+
+test("guards agent bash in Pi's cwd and ignores non-bash tools", async () => {
+  const pi = makePi();
+  const client = makeClient();
+  const context = makeContext();
+  piDcg(pi, { client, config: makeConfig() });
+
+  const handler = pi.handlers.get("tool_call")[0];
+  assert.equal(await handler({ type: "tool_call", toolCallId: "read-1", toolName: "read", input: { path: "x" } }, context), undefined);
+  assert.equal(await handler(bashEvent(), context), undefined);
+  assert.deepEqual(client.checks[0], { command: "git status", cwd: "/work/project", signal: undefined });
+});
+
+test("hard dcg denial always blocks with structured guidance", async () => {
+  const pi = makePi();
+  const client = makeClient({
+    decision: {
+      decision: "deny",
+      hook: {
+        permissionDecision: "deny",
+        permissionDecisionReason: "Reason: destructive reset",
+        ruleId: "core.git:reset-hard",
+        severity: "critical",
+        allowOnceCode: "123456",
+      },
+    },
+  });
+  const context = makeContext({ hasUI: true, confirm: true });
+  piDcg(pi, { client, config: makeConfig() });
+
+  const result = await pi.handlers.get("tool_call")[0](bashEvent("git reset --hard"), context);
+  assert.equal(result.block, true);
+  assert.match(result.reason, /Blocked by dcg/);
+  assert.match(result.reason, /core\.git:reset-hard/);
+  assert.match(result.reason, /dcg allow-once 123456/);
+});
+
+test("advisory UI failures cannot turn a denial into an allow", async () => {
+  const pi = makePi();
+  const client = makeClient({
+    decision: {
+      decision: "deny",
+      hook: { permissionDecision: "deny", permissionDecisionReason: "Reason: destructive" },
+    },
+  });
+  const context = makeContext({ hasUI: true });
+  context.ui.setStatus = () => {
+    throw new Error("status unavailable");
+  };
+  piDcg(pi, { client, config: makeConfig() });
+
+  const result = await pi.handlers.get("tool_call")[0](bashEvent("git reset --hard"), context);
+  assert.equal(result.block, true);
+  assert.match(result.reason, /Blocked by dcg/);
+});
+
+test("asks only for dcg warning decisions", async () => {
+  const warning = {
+    decision: "ask",
+    hook: {
+      permissionDecision: "ask",
+      permissionDecisionReason: "DCG warn: review",
+      ruleId: "custom:warning",
+    },
+  };
+
+  const approvedPi = makePi();
+  piDcg(approvedPi, { client: makeClient({ decision: warning }), config: makeConfig() });
+  assert.equal(
+    await approvedPi.handlers.get("tool_call")[0](bashEvent("risky"), makeContext({ hasUI: true, confirm: true })),
+    undefined,
+  );
+
+  const rejectedPi = makePi();
+  piDcg(rejectedPi, { client: makeClient({ decision: warning }), config: makeConfig() });
+  const rejected = await rejectedPi.handlers.get("tool_call")[0](bashEvent("risky"), makeContext({ hasUI: true, confirm: false }));
+  assert.equal(rejected.block, true);
+  assert.match(rejected.reason, /not approved/);
+
+  const headlessPi = makePi();
+  piDcg(headlessPi, { client: makeClient({ decision: warning }), config: makeConfig() });
+  const headless = await headlessPi.handlers.get("tool_call")[0](bashEvent("risky"), makeContext());
+  assert.equal(headless.block, true);
+  assert.match(headless.reason, /No interactive UI/);
+});
+
+test("guards user bash with a synthetic failed result", async () => {
+  const pi = makePi();
+  const client = makeClient({
+    decision: {
+      decision: "deny",
+      hook: { permissionDecision: "deny", permissionDecisionReason: "Reason: destructive" },
+    },
+  });
+  piDcg(pi, { client, config: makeConfig() });
+
+  const result = await pi.handlers.get("user_bash")[0]({
+    type: "user_bash",
+    command: "git reset --hard",
+    cwd: "/other/project",
+    excludeFromContext: false,
+  }, makeContext());
+  assert.equal(result.result.exitCode, 1);
+  assert.match(result.result.output, /Blocked by dcg/);
+  assert.equal(client.checks[0].cwd, "/other/project");
+});
+
+test("can disable user bash coverage", () => {
+  const pi = makePi();
+  piDcg(pi, { client: makeClient(), config: makeConfig({ guardUserBash: false }) });
+  assert.equal(pi.handlers.has("user_bash"), false);
+});
+
+test("fails open visibly by default and can fail closed", async () => {
+  const error = new Error("dcg unavailable");
+
+  const openPi = makePi();
+  piDcg(openPi, { client: makeClient({ error }), config: makeConfig({ onError: "allow" }) });
+  const openContext = makeContext({ hasUI: true });
+  assert.equal(await openPi.handlers.get("tool_call")[0](bashEvent(), openContext), undefined);
+  assert.match(openContext.notifications[0].message, /allowed \(fail-open\)/);
+
+  const closedPi = makePi();
+  piDcg(closedPi, { client: makeClient({ error }), config: makeConfig({ onError: "block" }) });
+  const closed = await closedPi.handlers.get("tool_call")[0](bashEvent(), makeContext());
+  assert.equal(closed.block, true);
+  assert.match(closed.reason, /PI_DCG_ON_ERROR=block/);
+});
+
+test("a cancelled check blocks even in fail-open mode", async () => {
+  const pi = makePi();
+  const error = new DcgProcessError("dcg check was cancelled", "aborted");
+  piDcg(pi, { client: makeClient({ error }), config: makeConfig({ onError: "allow" }) });
+
+  const result = await pi.handlers.get("tool_call")[0](bashEvent(), makeContext());
+  assert.equal(result.block, true);
+  assert.match(result.reason, /cancelled/);
+});
+
+test("probes on UI session start, exposes diagnostics, and clears status", async () => {
+  const pi = makePi();
+  const client = makeClient();
+  const context = makeContext({ hasUI: true });
+  piDcg(pi, { client, config: makeConfig() });
+
+  await pi.handlers.get("session_start")[0]({ type: "session_start", reason: "startup" }, context);
+  assert.deepEqual(client.probes, ["/work/project"]);
+  assert.match(context.statuses.at(-1).value, /dcg 0\.6\.8/);
+
+  await pi.commands.get("dcg").handler("", context);
+  assert.match(context.notifications.at(-1).message, /Coverage: agent bash and user !\/!! commands/);
+
+  await pi.handlers.get("session_shutdown")[0]({ type: "session_shutdown", reason: "quit" }, context);
+  assert.equal(context.statuses.at(-1).value, undefined);
+});
+
+test("warns when the installed dcg is older than the recommended floor", async () => {
+  const pi = makePi();
+  const context = makeContext({ hasUI: true });
+  piDcg(pi, { client: makeClient({ version: "0.6.7" }), config: makeConfig() });
+
+  await pi.handlers.get("session_start")[0]({ type: "session_start", reason: "startup" }, context);
+  assert.match(context.notifications[0].message, /0\.6\.8 or newer is recommended/);
+});

--- a/packages/pi-dcg/tests/extension.test.mjs
+++ b/packages/pi-dcg/tests/extension.test.mjs
@@ -128,6 +128,15 @@ test("checks earlier command mutations and blocks later unchecked mutations", as
     emitToolCall(replacementPi, bashEvent(), makeContext()),
     /blocked a bash arguments replacement after its safety check/,
   );
+
+  const duplicatePi = makePi();
+  const firstClient = makeClient();
+  const secondClient = makeClient();
+  piDcg(duplicatePi, { client: firstClient, config: makeConfig() });
+  piDcg(duplicatePi, { client: secondClient, config: makeConfig() });
+  await emitToolCall(duplicatePi, bashEvent(), makeContext());
+  assert.equal(firstClient.checks.length, 1);
+  assert.equal(secondClient.checks.length, 1);
 });
 
 test("hard dcg denial always blocks with structured guidance", async () => {

--- a/packages/pi-dcg/tests/extension.test.mjs
+++ b/packages/pi-dcg/tests/extension.test.mjs
@@ -117,6 +117,17 @@ test("checks earlier command mutations and blocks later unchecked mutations", as
     /blocked a bash command mutation after its safety check/,
   );
   assert.equal(event.input.command, "git status");
+
+  const replacementPi = makePi();
+  piDcg(replacementPi, { client: makeClient(), config: makeConfig() });
+  replacementPi.on("tool_call", (replacementEvent) => {
+    replacementEvent.input = { command: "git reset --hard HEAD~1" };
+  });
+
+  await assert.rejects(
+    emitToolCall(replacementPi, bashEvent(), makeContext()),
+    /blocked a bash arguments replacement after its safety check/,
+  );
 });
 
 test("hard dcg denial always blocks with structured guidance", async () => {
@@ -140,7 +151,8 @@ test("hard dcg denial always blocks with structured guidance", async () => {
   assert.equal(result.block, true);
   assert.match(result.reason, /Blocked by dcg/);
   assert.match(result.reason, /core\.git:reset-hard/);
-  assert.match(result.reason, /dcg allow-once 123456/);
+  assert.doesNotMatch(result.reason, /allow-once/);
+  assert.match(context.notifications.at(-1).message, /manually: dcg allow-once 123456/);
 });
 
 test("advisory UI failures cannot turn a denial into an allow", async () => {

--- a/packages/pi-dcg/tests/extension.test.mjs
+++ b/packages/pi-dcg/tests/extension.test.mjs
@@ -74,6 +74,14 @@ function bashEvent(command = "git status") {
   return { type: "tool_call", toolCallId: "call-1", toolName: "bash", input: { command } };
 }
 
+async function emitToolCall(pi, event, context) {
+  for (const handler of pi.handlers.get("tool_call") ?? []) {
+    const result = await handler(event, context);
+    if (result?.block) return result;
+  }
+  return undefined;
+}
+
 test("guards agent bash in Pi's cwd and ignores non-bash tools", async () => {
   const pi = makePi();
   const client = makeClient();
@@ -84,6 +92,31 @@ test("guards agent bash in Pi's cwd and ignores non-bash tools", async () => {
   assert.equal(await handler({ type: "tool_call", toolCallId: "read-1", toolName: "read", input: { path: "x" } }, context), undefined);
   assert.equal(await handler(bashEvent(), context), undefined);
   assert.deepEqual(client.checks[0], { command: "git status", cwd: "/work/project", signal: undefined });
+});
+
+test("checks earlier command mutations and blocks later unchecked mutations", async () => {
+  const earlierPi = makePi();
+  const earlierClient = makeClient();
+  earlierPi.on("tool_call", (event) => {
+    event.input.command = "git reset --hard HEAD~1";
+  });
+  piDcg(earlierPi, { client: earlierClient, config: makeConfig() });
+
+  await emitToolCall(earlierPi, bashEvent(), makeContext());
+  assert.equal(earlierClient.checks[0].command, "git reset --hard HEAD~1");
+
+  const laterPi = makePi();
+  piDcg(laterPi, { client: makeClient(), config: makeConfig() });
+  laterPi.on("tool_call", (event) => {
+    event.input.command = "git reset --hard HEAD~1";
+  });
+  const event = bashEvent();
+
+  await assert.rejects(
+    emitToolCall(laterPi, event, makeContext()),
+    /blocked a bash command mutation after its safety check/,
+  );
+  assert.equal(event.input.command, "git status");
 });
 
 test("hard dcg denial always blocks with structured guidance", async () => {

--- a/packages/pi-dcg/tests/process.test.mjs
+++ b/packages/pi-dcg/tests/process.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DcgProcessError, executeProcess } from "../src/dcg-client.ts";
+
+const cwd = process.cwd();
+const baseRequest = {
+  command: process.execPath,
+  cwd,
+  env: { ...process.env, PI_DCG_PROCESS_TEST: "present" },
+  timeoutMs: 2_000,
+  maxOutputBytes: 32 * 1024,
+};
+
+test("executes directly with stdin, cwd, and environment", async () => {
+  const script = [
+    "let input = '';",
+    "process.stdin.setEncoding('utf8');",
+    "process.stdin.on('data', chunk => input += chunk);",
+    "process.stdin.on('end', () => process.stdout.write(JSON.stringify({ input, cwd: process.cwd(), marker: process.env.PI_DCG_PROCESS_TEST })));",
+  ].join("");
+  const result = await executeProcess({
+    ...baseRequest,
+    args: ["-e", script],
+    input: "payload",
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(JSON.parse(result.stdout), { input: "payload", cwd, marker: "present" });
+});
+
+test("enforces the process timeout", async () => {
+  await assert.rejects(
+    executeProcess({
+      ...baseRequest,
+      args: ["-e", "setTimeout(() => {}, 1000)"],
+      timeoutMs: 30,
+    }),
+    (error) => error instanceof DcgProcessError && error.code === "timed_out",
+  );
+});
+
+test("enforces the combined output limit", async () => {
+  await assert.rejects(
+    executeProcess({
+      ...baseRequest,
+      args: ["-e", "process.stdout.write('x'.repeat(10000))"],
+      maxOutputBytes: 100,
+    }),
+    (error) => error instanceof DcgProcessError && error.code === "output_limit",
+  );
+});
+
+test("cancels an active process", async () => {
+  const controller = new AbortController();
+  const promise = executeProcess({
+    ...baseRequest,
+    args: ["-e", "setTimeout(() => {}, 1000)"],
+    signal: controller.signal,
+  });
+  setTimeout(() => controller.abort(), 20);
+
+  await assert.rejects(
+    promise,
+    (error) => error instanceof DcgProcessError && error.code === "aborted",
+  );
+});
+
+test("reports spawn failures without invoking a shell", async () => {
+  await assert.rejects(
+    executeProcess({
+      ...baseRequest,
+      command: `missing-dcg-${process.pid}`,
+      args: [],
+    }),
+    (error) => error instanceof DcgProcessError && error.code === "spawn_failed",
+  );
+});

--- a/packages/pi-dcg/tests/process.test.mjs
+++ b/packages/pi-dcg/tests/process.test.mjs
@@ -29,6 +29,17 @@ test("executes directly with stdin, cwd, and environment", async () => {
   assert.deepEqual(JSON.parse(result.stdout), { input: "payload", cwd, marker: "present" });
 });
 
+test("does not open a stdin pipe when input is omitted", { skip: process.platform === "win32" }, async () => {
+  const script = "const { fstatSync } = require('node:fs'); process.stdout.write(String(fstatSync(0).isFIFO()));";
+  const result = await executeProcess({
+    ...baseRequest,
+    args: ["-e", script],
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "false");
+});
+
 test("enforces the process timeout", async () => {
   await assert.rejects(
     executeProcess({

--- a/packages/pi-dcg/tests/protocol.test.mjs
+++ b/packages/pi-dcg/tests/protocol.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { formatDcgDecision, parseDcgHookResponse } from "../src/protocol.ts";
+import {
+  formatDcgDecision,
+  getDcgAllowOnceCommand,
+  parseDcgHookResponse,
+} from "../src/protocol.ts";
 
 test("treats empty hook stdout as allow", () => {
   assert.deepEqual(parseDcgHookResponse(" \n"), { decision: "allow" });
@@ -35,7 +39,8 @@ test("parses structured denial metadata without regex extraction", () => {
   assert.match(reason, /critical · core\.git:reset-hard · confidence 0\.95/);
   assert.match(reason, /Reason: destructive reset/);
   assert.match(reason, /Safer alternative: git stash/);
-  assert.match(reason, /dcg allow-once 123456/);
+  assert.doesNotMatch(reason, /dcg allow-once/);
+  assert.equal(getDcgAllowOnceCommand(result), "dcg allow-once 123456");
   assert.doesNotMatch(reason, /Command: git reset/);
 });
 
@@ -55,14 +60,16 @@ test("parses ask and explicit allow decisions", () => {
   })), { decision: "allow" });
 });
 
-test("uses allow-once code when remediation is absent", () => {
+test("keeps fallback allow-once commands separate from model-visible denials", () => {
   const result = parseDcgHookResponse(JSON.stringify({
     hookSpecificOutput: {
       permissionDecision: "deny",
+      permissionDecisionReason: "Blocked. Run dcg allow-once leaked-code to bypass.",
       allowOnceCode: "654321",
     },
   }));
-  assert.match(formatDcgDecision(result), /dcg allow-once 654321/);
+  assert.equal(getDcgAllowOnceCommand(result), "dcg allow-once 654321");
+  assert.doesNotMatch(formatDcgDecision(result), /dcg allow-once|leaked-code/);
 });
 
 test("rejects malformed, unsupported, and unknown responses", () => {

--- a/packages/pi-dcg/tests/protocol.test.mjs
+++ b/packages/pi-dcg/tests/protocol.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatDcgDecision, parseDcgHookResponse } from "../src/protocol.ts";
+
+test("treats empty hook stdout as allow", () => {
+  assert.deepEqual(parseDcgHookResponse(" \n"), { decision: "allow" });
+});
+
+test("parses structured denial metadata without regex extraction", () => {
+  const result = parseDcgHookResponse(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "BLOCKED by dcg\n\nReason: destructive reset\n\nCommand: git reset --hard",
+      ruleId: "core.git:reset-hard",
+      packId: "core.git",
+      severity: "critical",
+      confidence: 0.95,
+      allowOnceCode: "123456",
+      remediation: {
+        safeAlternative: "git stash",
+        explanation: "The explanation can contain JSON-like braces: {safe}.",
+        allowOnceCommand: "dcg allow-once 123456",
+      },
+    },
+  }));
+
+  assert.equal(result.decision, "deny");
+  assert.equal(result.hook.ruleId, "core.git:reset-hard");
+  assert.equal(result.hook.remediation.safeAlternative, "git stash");
+
+  const reason = formatDcgDecision(result);
+  assert.match(reason, /^Blocked by dcg\./);
+  assert.match(reason, /critical · core\.git:reset-hard · confidence 0\.95/);
+  assert.match(reason, /Reason: destructive reset/);
+  assert.match(reason, /Safer alternative: git stash/);
+  assert.match(reason, /dcg allow-once 123456/);
+  assert.doesNotMatch(reason, /Command: git reset/);
+});
+
+test("parses ask and explicit allow decisions", () => {
+  const ask = parseDcgHookResponse(JSON.stringify({
+    hookSpecificOutput: {
+      permissionDecision: "ask",
+      permissionDecisionReason: "DCG warn: review this command",
+      ruleId: "example:warning",
+    },
+  }));
+  assert.equal(ask.decision, "ask");
+  assert.match(formatDcgDecision(ask), /^dcg requires confirmation\./);
+
+  assert.deepEqual(parseDcgHookResponse(JSON.stringify({
+    hookSpecificOutput: { permissionDecision: "allow" },
+  })), { decision: "allow" });
+});
+
+test("uses allow-once code when remediation is absent", () => {
+  const result = parseDcgHookResponse(JSON.stringify({
+    hookSpecificOutput: {
+      permissionDecision: "deny",
+      allowOnceCode: "654321",
+    },
+  }));
+  assert.match(formatDcgDecision(result), /dcg allow-once 654321/);
+});
+
+test("rejects malformed, unsupported, and unknown responses", () => {
+  assert.throws(() => parseDcgHookResponse("not json"), /malformed JSON/);
+  assert.throws(() => parseDcgHookResponse("{}"), /unsupported hook response/);
+  assert.throws(
+    () => parseDcgHookResponse(JSON.stringify({ hookSpecificOutput: { permissionDecision: "maybe" } })),
+    /unknown permission decision/,
+  );
+});
+
+test("bounds formatted denial text", () => {
+  const result = parseDcgHookResponse(JSON.stringify({
+    hookSpecificOutput: {
+      permissionDecision: "deny",
+      permissionDecisionReason: `Reason: ${"x".repeat(30_000)}`,
+      remediation: { explanation: "y".repeat(30_000) },
+    },
+  }));
+  assert.ok(formatDcgDecision(result).length <= 12_000);
+});

--- a/packages/pi-dcg/tsconfig.json
+++ b/packages/pi-dcg/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["index.ts", "src/**/*.ts", "extensions/**/*.ts", "tests/**/*.mjs"]
+}


### PR DESCRIPTION
## Summary

- add the `pi-dcg` package as a Pi-native bridge to the external Destructive Command Guard executable
- guard agent `bash` calls and interactive `!`/`!!` commands with allow, deny, and ask handling
- add bounded/cancellable process execution, configurable bridge failures, diagnostics, telemetry, security documentation, and licensing notices
- document Pi RPC bash and disabled-pack limitations without bundling dcg's separately licensed code

## Validation

- `npm run validate`
- `npm ci --dry-run`
- 32 deterministic `pi-dcg` tests
- real dcg 0.6.8 protocol smoke tests for allow, deny, and ask
- isolated temporary Pi install and interactive localhost SSH smoke test; safe command executed and a remote destructive command was blocked with dcg's `remote` pack enabled

