### PR TITLE
Restore pi-skillful startup skill colors

### DIFF
--- a/packages/pi-skillful/CHANGELOG.md
+++ b/packages/pi-skillful/CHANGELOG.md
@@ -20,7 +20,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 - Let an explicit project `toggleModifier: "alt"` override a non-default global modifier; unsupported explicit values now follow the documented `"alt"` fallback.
 - Consume only configured modifier-slot combinations in the prompt editor instead of registering all 54 possible shortcuts.
 - Propagate focus and custom-editor hooks through the session-toggle editor wrapper for IME and extension compatibility.
-- Remove the private `InteractiveMode.prototype` startup skill-list patch; visibility now uses only documented Pi APIs.
+- Restore red/dim coloring for hidden and visible skills in Pi's startup `[Skills]` list while preserving project-trust-aware settings.
 - Remove the stale package-local `package-lock.json` in favor of the monorepo root lockfile.
 - Preserve configured hidden skills at session start. Skillful no longer treats a temporarily incomplete loaded-skill list as authoritative and removes global or project visibility settings.
 

--- a/packages/pi-skillful/README.md
+++ b/packages/pi-skillful/README.md
@@ -33,6 +33,7 @@ Hide skills from the `<available_skills>` section of the system prompt without e
 
 Hidden skills:
 
+- appear in the startup `[Skills]` list in the theme's error color, while visible skills appear dimmed;
 - are not advertised to the model for automatic skill selection;
 - remain loaded by Pi;
 - remain available for explicit invocation with `/skill:name`, including inline invocation.

--- a/packages/pi-skillful/src/extensions/skill-visibility.ts
+++ b/packages/pi-skillful/src/extensions/skill-visibility.ts
@@ -1,6 +1,14 @@
-import { DynamicBorder, getSettingsListTheme, type ExtensionAPI, type Skill, type Theme } from "@earendil-works/pi-coding-agent";
+import {
+  DynamicBorder,
+  getSettingsListTheme,
+  InteractiveMode,
+  type ExtensionAPI,
+  type Skill,
+  type Theme,
+} from "@earendil-works/pi-coding-agent";
 import { type Component, Key, matchesKey, type SettingItem, SettingsList, truncateToWidth, type TUI } from "@earendil-works/pi-tui";
 import {
+  normalizeSkillName,
   normalizeSkillNames,
   readEffectiveHiddenSkills,
   readScopedSkillfulSettings,
@@ -15,6 +23,34 @@ import { replaceSkillsSection } from "../skill-prompt.js";
 import { isTopLevelSkill, listLoadedSkills, type LoadedSkillInfo } from "../skills.js";
 import { hasActiveSessionSkillToggles, refreshSessionSkillToggles } from "./session-skill-toggles.js";
 const SCOPES: SkillfulScope[] = ["global", "project"];
+const STORE_KEY = Symbol.for("pi-skillful.skillVisibilityStore");
+const STARTUP_PATCH_KEY = Symbol.for("pi-skillful.startupPatchV3");
+
+interface SkillVisibilityStore {
+  hiddenSkillsByCwd: Map<string, Set<string>>;
+  theme: Theme | null;
+}
+
+interface ExpandableTextLike {
+  getCollapsedText: () => string;
+  setText: (text: string) => void;
+}
+
+interface BoxLike {
+  children: unknown[];
+}
+
+interface InteractiveModeLike {
+  loadedResourcesContainer?: BoxLike;
+  showLoadedResources?: (options?: unknown) => void;
+  session?: { resourceLoader?: { getSkills: () => { skills: Skill[]; diagnostics: unknown[] } } };
+  sessionManager?: { getCwd?: () => string };
+}
+
+const store = (((globalThis as Record<PropertyKey, unknown>)[STORE_KEY] as SkillVisibilityStore | undefined) ??= {
+  hiddenSkillsByCwd: new Map<string, Set<string>>(),
+  theme: null,
+}) as SkillVisibilityStore;
 
 type SkillListItem = LoadedSkillInfo;
 type HiddenSkillsByScope = Record<SkillfulScope, Set<string>>;
@@ -44,14 +80,17 @@ interface SettingsListSelectionView {
 }
 
 export default function skillVisibility(pi: ExtensionAPI) {
+  installStartupSkillListPatch();
+
   pi.on("session_start", async (_event, ctx) => {
-    await readEffectiveHiddenSkills(ctx.cwd, ctx.isProjectTrusted());
+    store.theme = ctx.ui.theme;
+    await refreshHiddenSkillCache(ctx.cwd, ctx.isProjectTrusted());
   });
 
   pi.on("before_agent_start", async (event, ctx) => {
     if (hasActiveSessionSkillToggles()) return;
 
-    const hidden = await readEffectiveHiddenSkills(ctx.cwd, ctx.isProjectTrusted());
+    const hidden = await refreshHiddenSkillCache(ctx.cwd, ctx.isProjectTrusted());
     if (hidden.size === 0 || !event.systemPromptOptions.skills?.length) return;
 
     const filteredSkills: Skill[] = event.systemPromptOptions.skills.map((skill) =>
@@ -108,6 +147,76 @@ export default function skillVisibility(pi: ExtensionAPI) {
       );
     },
   });
+}
+
+async function refreshHiddenSkillCache(cwd: string, projectTrusted: boolean): Promise<Set<string>> {
+  const hidden = await readEffectiveHiddenSkills(cwd, projectTrusted);
+  store.hiddenSkillsByCwd.set(cwd, hidden);
+  return hidden;
+}
+
+// Pi has no public hook for styling the built-in startup resource list, so patch the
+// prototype from Pi's own module and keep the workaround isolated here.
+export function installStartupSkillListPatch(
+  realPrototype: InteractiveModeLike = (InteractiveMode as unknown as { prototype: InteractiveModeLike }).prototype,
+): void {
+  if (!realPrototype) return;
+
+  const patchState = realPrototype as Record<PropertyKey, unknown>;
+  if (patchState[STARTUP_PATCH_KEY]) return;
+
+  const original = realPrototype.showLoadedResources;
+  if (typeof original !== "function") return;
+
+  realPrototype.showLoadedResources = function (this: InteractiveModeLike, options?: unknown): void {
+    const loader = this.session?.resourceLoader;
+    const originalGetSkills = loader?.getSkills;
+    if (!loader || typeof originalGetSkills !== "function") {
+      original.call(this, options);
+      return;
+    }
+
+    const cwd = this.sessionManager?.getCwd?.();
+    let rawSkillNames: string[] = [];
+    loader.getSkills = () => {
+      const result = originalGetSkills.call(loader);
+      rawSkillNames = result.skills.map((skill) => normalizeSkillName(skill.name));
+      return result;
+    };
+
+    const childrenBefore = this.loadedResourcesContainer?.children.length ?? 0;
+    try {
+      original.call(this, options);
+    } finally {
+      loader.getSkills = originalGetSkills;
+    }
+
+    if (rawSkillNames.length === 0 || !cwd || !this.loadedResourcesContainer) return;
+
+    const hidden = store.hiddenSkillsByCwd.get(cwd) ?? new Set<string>();
+    const children = this.loadedResourcesContainer.children;
+    for (let index = childrenBefore; index < children.length; index++) {
+      const child = children[index] as ExpandableTextLike | undefined;
+      if (!child || typeof child.getCollapsedText !== "function") continue;
+      if (!child.getCollapsedText().includes("[Skills]")) continue;
+
+      const colorized = buildColorizedSkillList(rawSkillNames, hidden, store.theme);
+      child.getCollapsedText = () => colorized;
+      child.setText(colorized);
+      break;
+    }
+  };
+
+  patchState[STARTUP_PATCH_KEY] = true;
+}
+
+export function buildColorizedSkillList(names: string[], hidden: Set<string>, theme: Theme | null): string {
+  const sorted = [...names].sort((a, b) => a.localeCompare(b));
+  if (!theme) return `[Skills]\n  ${sorted.join(", ")}`;
+
+  const header = theme.fg("mdHeading", "[Skills]");
+  const parts = sorted.map((name) => (hidden.has(name) ? theme.fg("error", name) : theme.fg("dim", name)));
+  return `${header}\n  ${parts.join(", ")}`;
 }
 
 function getSkillItems(pi: ExtensionAPI): SkillListItem[] {
@@ -331,7 +440,7 @@ class SkillfulVisibilityMenu implements Component {
       .then(async () => {
         if (scope === "project") await this.writeProjectOverrideOrInheritance();
         else await writeHiddenSkills(scope, this.cwd, hiddenSnapshot);
-        await readEffectiveHiddenSkills(this.cwd, this.projectTrusted);
+        await refreshHiddenSkillCache(this.cwd, this.projectTrusted);
       })
       .catch((error) => {
         this.notify(`Failed to save ${scope} skill visibility: ${error instanceof Error ? error.message : String(error)}`, "error");

--- a/packages/pi-skillful/tests/skill-visibility.test.mjs
+++ b/packages/pi-skillful/tests/skill-visibility.test.mjs
@@ -3,13 +3,16 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
-import { formatSkillsForPrompt, initTheme, InteractiveMode } from "@earendil-works/pi-coding-agent";
+import { formatSkillsForPrompt, initTheme } from "@earendil-works/pi-coding-agent";
 
 const home = await mkdtemp(join(tmpdir(), "pi-skillful-visibility-test-"));
 process.env.HOME = home;
 initTheme("dark");
 
-const { default: skillVisibility } = await import("../.test-dist/src/extensions/skill-visibility.js");
+const {
+  default: skillVisibility,
+  installStartupSkillListPatch,
+} = await import("../.test-dist/src/extensions/skill-visibility.js");
 
 const globalSettingsPath = join(home, ".pi", "agent", "settings.json");
 const identityTheme = {
@@ -151,10 +154,50 @@ test("untrusted projects expose only global settings in the menu", async () => {
   assert.deepEqual(JSON.parse(await readFile(projectPath, "utf-8")), projectSettings);
 });
 
-test("registration does not patch InteractiveMode prototype", () => {
-  const original = InteractiveMode.prototype.showLoadedResources;
-  registerVisibility();
-  assert.equal(InteractiveMode.prototype.showLoadedResources, original);
+test("startup patch colors the built-in skill list from effective settings", async () => {
+  const cwd = await mkdtemp(join(home, "startup-colors-"));
+  await writeSettings(globalSettingsPath, { skillful: { hiddenSkills: ["hidden"] } });
+
+  const { handlers } = registerVisibility();
+  const theme = {
+    fg: (color, text) => `<${color}>${text}</${color}>`,
+  };
+  await handlers.get("session_start")(
+    { reason: "startup" },
+    { cwd, isProjectTrusted: () => false, ui: { theme } },
+  );
+
+  const prototype = {
+    showLoadedResources() {
+      const { skills } = this.session.resourceLoader.getSkills();
+      const names = skills.map(({ name }) => name).sort().join(", ");
+      this.loadedResourcesContainer.children.push({
+        getCollapsedText: () => `[Skills]\n  ${names}`,
+        setText(text) {
+          this.text = text;
+        },
+      });
+    },
+  };
+  installStartupSkillListPatch(prototype);
+
+  const instance = Object.assign(Object.create(prototype), {
+    loadedResourcesContainer: { children: [] },
+    session: {
+      resourceLoader: {
+        getSkills: () => ({ skills: [skill("visible"), skill("hidden")], diagnostics: [] }),
+      },
+    },
+    sessionManager: { getCwd: () => cwd },
+  });
+  instance.showLoadedResources();
+
+  const rendered = instance.loadedResourcesContainer.children[0];
+  assert.equal(
+    rendered.text,
+    "<mdHeading>[Skills]</mdHeading>\n  <error>hidden</error>, <dim>visible</dim>",
+  );
+  assert.equal(rendered.getCollapsedText(), rendered.text);
 });
 
 test.after(async () => {


### PR DESCRIPTION
## Summary
- restore hidden/visible skill coloring in startup `[Skills]` list
- preserve project-trust-aware settings in startup color cache
- add end-to-end regression coverage for startup patch behavior
- document startup coloring in package README

## Validation
- `npm run -w packages/pi-skillful check`
- `npm test -w packages/pi-skillful`
- `npm run -w packages/pi-skillful pack:dry-run`