### PR TITLE
Reconcile package changelog history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm run check
 
       - name: Test
-        run: npm test --workspaces --if-present
+        run: npm test
 
       - name: Audit production dependencies
         run: npm audit --omit=dev

--- a/.pi/extensions/release-package/changelog.ts
+++ b/.pi/extensions/release-package/changelog.ts
@@ -1,6 +1,8 @@
 export function prepareChangelogRelease(changelog: string, version: string, date: string): string {
-  const versionHeading = new RegExp(`^## \\[?${escapeRegExp(version)}\\]? - `, "m");
-  if (versionHeading.test(changelog)) return changelog;
+  const hasVersion = changelog
+    .split("\n")
+    .some((line) => line.startsWith(`## ${version} - `) || line.startsWith(`## [${version}] - `));
+  if (hasVersion) return changelog;
 
   const unreleasedHeading = /^## (\[Unreleased\]|Unreleased)$/m;
   const match = changelog.match(unreleasedHeading);
@@ -11,8 +13,4 @@ export function prepareChangelogRelease(changelog: string, version: string, date
   }
 
   return changelog.replace("# Changelog\n", `# Changelog\n\n## ${version} - ${date}\n`);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/.pi/extensions/release-package/changelog.ts
+++ b/.pi/extensions/release-package/changelog.ts
@@ -1,0 +1,18 @@
+export function prepareChangelogRelease(changelog: string, version: string, date: string): string {
+  const versionHeading = new RegExp(`^## \\[?${escapeRegExp(version)}\\]? - `, "m");
+  if (versionHeading.test(changelog)) return changelog;
+
+  const unreleasedHeading = /^## (\[Unreleased\]|Unreleased)$/m;
+  const match = changelog.match(unreleasedHeading);
+  if (match) {
+    const bracketed = match[1].startsWith("[");
+    const release = bracketed ? `## [${version}] - ${date}` : `## ${version} - ${date}`;
+    return changelog.replace(unreleasedHeading, `${match[0]}\n\n${release}`);
+  }
+
+  return changelog.replace("# Changelog\n", `# Changelog\n\n## ${version} - ${date}\n`);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/.pi/extensions/release-package/index.ts
+++ b/.pi/extensions/release-package/index.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { prepareChangelogRelease } from "./changelog.js";
 import { DynamicBorder, keyHint } from "@earendil-works/pi-coding-agent";
 import { CancellableLoader, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import type { AutocompleteItem } from "@earendil-works/pi-tui";
@@ -136,13 +137,8 @@ function prepareSuggestedVersion(cwd: string, packageInfo: PackageInfo, version:
 
   if (!existsSync(changelogPath)) return;
   const changelog = readFileSync(changelogPath, "utf8");
-  if (changelog.includes(`## ${version}`)) return;
   const today = new Date().toISOString().slice(0, 10);
-  const unreleased = "## Unreleased";
-  const next = changelog.includes(unreleased)
-    ? changelog.replace(unreleased, `## Unreleased\n\n## ${version} - ${today}`)
-    : changelog.replace("# Changelog\n", `# Changelog\n\n## ${version} - ${today}\n`);
-  writeFileSync(changelogPath, next);
+  writeFileSync(changelogPath, prepareChangelogRelease(changelog, version, today));
 }
 
 async function run(command: string, cwd: string): Promise<CommandResult> {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "check": "npm run check --workspaces --if-present",
-    "test": "npm test --workspaces --if-present",
+    "test": "node --import tsx --test tests/*.test.mjs && npm test --workspaces --if-present",
     "pack:dry-run": "npm run pack:dry-run --workspaces --if-present",
     "security:audit": "npm audit --omit=dev",
     "validate:packages": "node scripts/validate-packages.mjs",

--- a/packages/pi-agentsmd/CHANGELOG.md
+++ b/packages/pi-agentsmd/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 0.1.3 - 2026-07-17
-
 All notable changes to this project will be documented in this file.
 
 This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning for releases.
 
 ## [Unreleased]
+
+## [0.1.3] - 2026-07-17
 
 ### Fixed
 

--- a/packages/pi-codex-image-gen/CHANGELOG.md
+++ b/packages/pi-codex-image-gen/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 0.1.12 - 2026-07-17
-
 All notable changes to this project will be documented in this file.
 
 This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning for releases.
 
 ## [Unreleased]
+
+## [0.1.12] - 2026-07-17
 
 ### Added
 

--- a/packages/pi-compound-engineering/CHANGELOG.md
+++ b/packages/pi-compound-engineering/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## 3.19.2 - 2026-07-17
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
@@ -10,6 +8,12 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 The package normally tracks the upstream [`compound-engineering`](https://github.com/EveryInc/compound-engineering-plugin) component version. Pi-specific hotfixes may increment the package patch while retaining the pinned upstream version; see `package.json` → `ceVersion` and `src/ce-version.ts`.
 
 ## [Unreleased]
+
+## [3.19.2] - 2026-07-17
+
+### Changed
+
+- Refreshed shared TypeScript and Node development dependencies; runtime behavior and the pinned Compound Engineering v3.19.0 content are unchanged.
 
 ## [3.19.1] - 2026-07-12
 

--- a/packages/pi-goal/CHANGELOG.md
+++ b/packages/pi-goal/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## Unreleased
+All notable changes to this project will be documented in this file.
 
-## 0.1.11 - 2026-07-17
+This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning for releases.
+
+## [Unreleased]
+
+## [0.1.11] - 2026-07-17
 
 ### Fixed
 
@@ -10,20 +14,20 @@
 - Derive persisted `piGoalVersion` metadata from the package version so release versions cannot drift.
 - Ignore malformed persisted mutations instead of allowing invalid status, budget, or accounting data to corrupt reconstructed goal state.
 
-## 0.1.10 - 2026-07-01
+## [0.1.10] - 2026-07-01
 
 ### Changed
 
 - Update Pi core development dependencies for Pi 0.80 compatibility.
 
-## 0.1.9 - 2026-06-16
+## [0.1.9] - 2026-06-16
 
 ### Fixed
 
 - Notify the model when a goal transitions to `budget_limited` or `usage_limited` so it can stop work and call `update_goal` instead of silently continuing to spend tokens after the budget is exhausted or the provider hits a rate limit. Previously the model was only ever informed via a UI notification that it could not see, leaving the current turn to keep running for additional assistant entries and allowing `update_goal` to mark the goal `complete` long after the budget had been blown.
 - Branch the continuation prompt on the `budget_limited` reason so any future continuation of a budget-limited goal instructs the model to wrap up and call `update_goal` rather than push forward.
 
-## 0.1.8 - 2026-06-08
+## [0.1.8] - 2026-06-08
 
 ### Fixed
 
@@ -31,7 +35,7 @@
 - Reject `update_goal` when it is batched with verification/tool calls in the same assistant turn, forcing completion/blocking decisions to happen after inspecting verification results.
 - Preserve the elapsed-time fix for old sessions by ignoring legacy account mutation `timeUsedSeconds` fields during reconstruction.
 
-## 0.1.7 - 2026-06-08
+## [0.1.7] - 2026-06-08
 
 ### Fixed
 
@@ -41,7 +45,7 @@
 
 - Pause goals on assistant-surfaced provider usage/quota/billing limit errors and repeated provider failures, not only HTTP 429 response hooks.
 
-## 0.1.6 - 2026-06-06
+## [0.1.6] - 2026-06-06
 
 ### Changed
 
@@ -49,14 +53,26 @@
 - Aligned package structure with monorepo guidelines (added root `index.ts` re-export, `.editorconfig`, `.gitignore`; fixed extension entry point; removed non-canonical tsconfig flags).
 - Update `author` field to full name for monorepo consistency.
 
-## 0.1.3
+## [0.1.3] - 2026-06-06
+
+### Changed
+
+- Temporarily rename the package to unscoped `pi-goal`; this version was not published because that npm name was unavailable.
+
+## [0.1.2] - 2026-05-28
+
+### Changed
 
 - Move the extension entry point to `extensions/index.ts` so Pi displays the package extension compactly.
 
-## 0.1.1
+## [0.1.1] - 2026-05-28
+
+### Added
 
 - Add best-effort install/update telemetry, gated by Pi telemetry/offline settings and disabled in CI.
 
-## 0.1.0
+## [0.1.0] - 2026-05-28
+
+### Added
 
 - Initial `@mocito/pi-goal` package with `/goal`, goal tools, branch-scoped session persistence, usage accounting, UI status, and automatic continuation.

--- a/packages/pi-insomnia/CHANGELOG.md
+++ b/packages/pi-insomnia/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 0.1.3 - 2026-07-17
-
 All notable changes to this project will be documented in this file.
 
 This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning for releases.
 
 ## [Unreleased]
+
+## [0.1.3] - 2026-07-17
 
 ### Fixed
 
@@ -20,7 +20,11 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [0.1.1] - 2026-06-09
 
-## [0.1.0] - TBD
+### Changed
+
+- Replace the static footer icon with an animated Braille spinner while sleep inhibition is active.
+
+## [0.1.0] - 2026-06-08
 
 ### Added
 

--- a/packages/pi-scout/CHANGELOG.md
+++ b/packages/pi-scout/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 0.1.4 - 2026-07-17
-
 All notable changes to this project will be documented in this file.
 
 This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning for releases.
 
 ## [Unreleased]
+
+## [0.1.4] - 2026-07-17
 
 ### Fixed
 
@@ -25,13 +25,13 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 - Update `author` field to full name for monorepo consistency.
 
-## [0.1.1] - TBD
+## [0.1.1] - 2026-05-22
 
 ### Added
 
 - Add install/update telemetry ping to `mocito.dev`, gated by Pi telemetry/offline settings and disabled in CI.
 
-## [0.1.0] - TBD
+## [0.1.0] - 2026-05-21
 
 ### Added
 

--- a/packages/pi-skillful/CHANGELOG.md
+++ b/packages/pi-skillful/CHANGELOG.md
@@ -1,20 +1,18 @@
 # Changelog
 
-## 0.3.14 - 2026-07-17
-
-## 0.3.13 - 2026-07-17
-
-## 0.3.12 - 2026-07-12
-
-## 0.3.11 - 2026-07-01
-
-## 0.3.9 - 2026-06-14
-
 All notable changes to this project will be documented in this file.
 
 This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning for releases.
 
 ## [Unreleased]
+
+## [0.3.14] - 2026-07-17
+
+### Fixed
+
+- Restore red/dim coloring for hidden and visible skills in Pi's startup `[Skills]` list while preserving project-trust-aware settings.
+
+## [0.3.13] - 2026-07-17
 
 ### Fixed
 
@@ -22,16 +20,23 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 - Let an explicit project `toggleModifier: "alt"` override a non-default global modifier; unsupported explicit values now follow the documented `"alt"` fallback.
 - Consume only configured modifier-slot combinations in the prompt editor instead of registering all 54 possible shortcuts.
 - Propagate focus and custom-editor hooks through the session-toggle editor wrapper for IME and extension compatibility.
-- Restore red/dim coloring for hidden and visible skills in Pi's startup `[Skills]` list while preserving project-trust-aware settings.
 - Remove the stale package-local `package-lock.json` in favor of the monorepo root lockfile.
-- Preserve configured hidden skills at session start. Skillful no longer treats a temporarily incomplete loaded-skill list as authoritative and removes global or project visibility settings.
 
-## [0.3.10] - 2026-07-01
+## [0.3.12] - 2026-07-13
 
 ### Fixed
 
-- Color hidden skills in the startup `[Skills]` list on `@earendil-works/pi-coding-agent` 0.80+. The 0.80 release moved the loaded-resources container out of `chatContainer`, so the existing prototype patch walked the wrong container and the red/dim colorization no longer applied. The patch now also walks `loadedResourcesContainer`, where 0.80 actually renders the `[Skills]` section.
-- Bumped dev dependency range to `^0.80.0` to match the new floor.
+- Preserve configured hidden skills at session start instead of pruning settings from a temporarily incomplete loaded-skill list.
+
+## [0.3.11] - 2026-07-01
+
+### Fixed
+
+- Color hidden skills in the startup `[Skills]` list on Pi 0.80+, which moved the rendered resources into `loadedResourcesContainer`.
+
+### Changed
+
+- Raise the Pi development dependency floor to `^0.80.0`.
 
 ## [0.3.9] - 2026-06-14
 

--- a/packages/pi-web-kit/CHANGELOG.md
+++ b/packages/pi-web-kit/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 0.2.3 - 2026-07-17
-
 All notable changes to this project will be documented in this file.
 
 This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning for releases.
 
 ## [Unreleased]
+
+## [0.2.3] - 2026-07-17
 
 ### Fixed
 
@@ -23,6 +23,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 - Update Pi core development dependencies for Pi 0.80 compatibility.
 
 ## [0.2.1] - 2026-06-14
+
+### Changed
+
+- Simplify provider, configuration, cache, and URL handling while preserving the public tool surface.
 
 ## [0.2.0] - 2026-06-13
 

--- a/scripts/validate-packages.mjs
+++ b/scripts/validate-packages.mjs
@@ -81,6 +81,14 @@ for (const slug of slugs) {
     else sharedVersions.set(dependency, { slug, range });
   }
 
+  const changelog = entries.has("CHANGELOG.md") ? await text(new URL("CHANGELOG.md", dir)) : "";
+  const changelogHeadings = changelog.match(/^## .+$/gm) ?? [];
+  const unreleasedCount = changelogHeadings.filter((heading) => /^## (?:\[Unreleased\]|Unreleased)$/.test(heading)).length;
+  if (unreleasedCount !== 1) errors.push(`${slug}: CHANGELOG.md must contain one Unreleased heading`);
+  if (!/^## (?:\[Unreleased\]|Unreleased)$/.test(changelogHeadings[0] ?? "")) errors.push(`${slug}: Unreleased must be first CHANGELOG.md section`);
+  const currentRelease = new RegExp(`^## \\[?${manifest.version.replaceAll(".", "\\.")}\\]? - \\d{4}-\\d{2}-\\d{2}$`);
+  if (!currentRelease.test(changelogHeadings[1] ?? "")) errors.push(`${slug}: current version must be first CHANGELOG.md release`);
+
   const agents = entries.has("AGENTS.md") ? await text(new URL("AGENTS.md", dir)) : "";
   for (const heading of ["## Invariants", "## Validation"]) {
     if (!agents.includes(heading)) errors.push(`${slug}: AGENTS.md missing ${heading}`);

--- a/tests/release-package-changelog.test.mjs
+++ b/tests/release-package-changelog.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { prepareChangelogRelease } from "../.pi/extensions/release-package/changelog.ts";
+
+for (const [label, unreleased, release] of [
+  ["bracketed", "## [Unreleased]", "## [1.2.3] - 2026-07-17"],
+  ["plain", "## Unreleased", "## 1.2.3 - 2026-07-17"],
+]) {
+  test(`prepares ${label} changelog without moving pending entries`, () => {
+    const current = `# Changelog\n\nIntro.\n\n${unreleased}\n\n### Fixed\n\n- Important fix.\n`;
+    const next = prepareChangelogRelease(current, "1.2.3", "2026-07-17");
+
+    assert.equal(next, `# Changelog\n\nIntro.\n\n${unreleased}\n\n${release}\n\n### Fixed\n\n- Important fix.\n`);
+  });
+}
+
+test("does not duplicate an existing release heading", () => {
+  const current = "# Changelog\n\n## [Unreleased]\n\n## [1.2.3] - 2026-07-17\n";
+  assert.equal(prepareChangelogRelease(current, "1.2.3", "2026-07-18"), current);
+});


### PR DESCRIPTION
## Summary
- move shipped changes into their actual package release sections
- restore missing versions and dates from Git/tag history
- normalize changelog ordering and current-version placement
- fix `/release-package` for bracketed `[Unreleased]` headings
- enforce changelog structure in package validation and CI
- add release-changelog regression tests

## Validation
- `npm run validate`
- `npm ci --dry-run`
- `git diff --check`

All 205 tests pass; production dependency audit reports zero vulnerabilities.