### PR TITLE
chore(deps): bump github/codeql-action to 4.37.1 (all steps) + group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,8 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "github/codeql-action/*"
+          - "actions/*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,13 +24,13 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: javascript-typescript
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1


### PR DESCRIPTION
## What

- Bump `init`, `autobuild`, and `analyze` **together** to `7188fc3` (v4.37.1). `upload-sarif` was already at 4.37.1 on main (#87), so this also clears existing drift.
- Group `github/codeql-action/*` and `actions/*` in `.github/dependabot.yml` so future Dependabot PRs bump all codeql-action steps in lockstep instead of one per `uses:` line.

## Why

The CodeQL Action now hard-errors when `init`/`autobuild`/`analyze` are on different versions (configuration error → required `Analyze TypeScript/JavaScript` check fails). Because `.github/dependabot.yml` had no `groups` for the github-actions ecosystem, each step got its own PR (#88 autobuild, #89 analyze) — none of which could ever pass on their own (no `init` bump existed), and branch protection (`enforce_admins: true`) blocks admin override.

Supersedes and closes #88 and #89.

## Validation

- `git diff --check` clean; both YAML files parse.
- `zizmor` on `codeql.yml`: no findings.
- CI will confirm the `Analyze TypeScript/JavaScript` check goes green once all four steps share v4.37.1.