### PR TITLE
chore: ignore .compound-engineering runtime config dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ coverage/
 .env
 .env.*
 !.env.example
+
+# Compound Engineering runtime config (output of upstream CE; regenerable)
+.compound-engineering/


### PR DESCRIPTION
## What

Add `.compound-engineering/` to `.gitignore`.

## Why

`pi-compound-engineering` is a **recipe-only loader**: all CE content (skills, and the `config.local.example.yaml` template) is produced at install time from the **upstream CE release tarball** (downloaded + SHA256-verified). The package source/scripts never reference `.compound-engineering` at all.

So the root `.compound-engineering/` dir is **CE runtime output** that CE writes into consuming projects (pi-mono dogfoods CE, hence the local copy) — regenerable, just like `config.local.yaml`. Tracking it risks drifting from upstream's canonical template.

This ignores the whole dir so neither the real local config nor the regenerable example template gets committed.

## Validation

`git diff --check` clean. No package code, manifests, or workflows touched — content-only `.gitignore` change.