### PR TITLE
feat(pi-skillful): add progressive skill loading beyond git boundary

### DIFF
--- a/packages/pi-skillful/CHANGELOG.md
+++ b/packages/pi-skillful/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Added
+
+- Progressive skill loading: discover `.agents/skills/` directories from all ancestor directories (like `AGENTS.md`), not just within the git repo boundary. Uses the `resources_discover` event to contribute missed paths.
+
 ## [0.3.14] - 2026-07-17
 
 ### Fixed

--- a/packages/pi-skillful/README.md
+++ b/packages/pi-skillful/README.md
@@ -6,8 +6,9 @@
 
 Make [Pi](https://pi.dev) skills easier to invoke, curate, and control without editing their source files.
 
-`pi-skillful` provides three focused upgrades:
+`pi-skillful` provides four focused upgrades:
 
+- **Progressive skill loading**: discover `.agents/skills/` from every ancestor directory (like `AGENTS.md`), not just within the git repo boundary.
 - **Inline skill invocation**: invoke one or more skills anywhere in a prompt with `/skill:name`.
 - **Skill prompt visibility**: choose which skills are hidden from the model's automatic skill-discovery prompt while keeping them explicitly invokable.
 - **Session skill toggles**: assign up to nine skills to number slots and toggle model visibility while writing a prompt.
@@ -16,6 +17,14 @@ Make [Pi](https://pi.dev) skills easier to invoke, curate, and control without e
 > Pi packages can execute arbitrary code through extensions. Review package source before installing any third-party Pi package.
 
 ## Features
+
+### Progressive skill loading
+
+Pi discovers `.agents/skills/` directories in ancestor folders, but stops at the git repo root — skills above the repo boundary are invisible. `pi-skillful` removes that boundary by walking the full ancestor chain to the filesystem root, mirroring how `AGENTS.md` context files work.
+
+No configuration needed. When a git repo is detected, `pi-skillful` automatically contributes `.agents/skills/` directories from parent directories above the repo root (excluding `~/.agents/skills/`, which Pi already loads globally). In projects without a git repo, Pi already walks to the filesystem root and this feature has no effect.
+
+Skill name collisions follow Pi's first-wins rule: skills discovered closer to the working directory take precedence over skills with the same name found higher up.
 
 ### Inline skill invocation
 

--- a/packages/pi-skillful/SECURITY.md
+++ b/packages/pi-skillful/SECURITY.md
@@ -20,3 +20,11 @@ The maintainer will acknowledge reports as soon as practical and coordinate disc
 ## Security model
 
 `pi-skillful` is a Pi package. Pi extensions execute with the same permissions as the local user running Pi. Users should review installed Pi packages and only install packages from sources they trust.
+
+### Progressive skill loading and trust boundary
+
+`pi-skillful` extends Pi's skill discovery to ancestor directories above the git repository root, loading `.agents/skills/` from every parent directory up to the filesystem root (excluding `~/.agents/skills/`, which Pi already loads globally).
+
+This means skills placed in a shared or writable ancestor directory — for example, `/home/shared/.agents/skills/` or `/tmp/.agents/skills/` — are automatically available as skill instructions when Pi runs in any nested repository. Review the contents and ownership of `.agents/skills/` directories above your repositories, as they are now part of the effective skill set.
+
+To disable progressive loading without removing the package, uninstall `pi-skillful` or use Pi's built-in `--no-skills` flag to suppress all skill loading for a session.

--- a/packages/pi-skillful/extensions/index.ts
+++ b/packages/pi-skillful/extensions/index.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import inlineSkillInvocation from "../src/extensions/inline-skill-invocation.js";
+import progressiveSkills from "../src/extensions/progressive-skills.js";
 import { reportInstallTelemetry } from "../src/install-telemetry.js";
 import skillVisibility from "../src/extensions/skill-visibility.js";
 import sessionSkillToggles from "../src/extensions/session-skill-toggles.js";
@@ -7,6 +8,7 @@ import sessionSkillToggles from "../src/extensions/session-skill-toggles.js";
 export default function piSkillful(pi: ExtensionAPI) {
   reportInstallTelemetry();
 
+  progressiveSkills(pi);
   inlineSkillInvocation(pi);
   skillVisibility(pi);
   sessionSkillToggles(pi);

--- a/packages/pi-skillful/src/extensions/progressive-skills.ts
+++ b/packages/pi-skillful/src/extensions/progressive-skills.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+/**
+ * Walks from cwd up through all ancestor directories (no git boundary)
+ * and discovers `.agents/skills/` directories that Pi's built-in discovery
+ * misses because it stops at the git repo root.
+ *
+ * This mirrors how AGENTS.md context files are loaded from every parent
+ * directory, not just within the repo boundary.
+ */
+export default function progressiveSkills(pi: ExtensionAPI) {
+  pi.on("resources_discover", async (event) => {
+    const gitRoot = findGitRoot(event.cwd);
+
+    // No git repo — Pi already walks to filesystem root, nothing to add.
+    if (!gitRoot) return;
+
+    const resolvedGitRoot = resolve(gitRoot);
+    const homeAgentsSkills = resolve(homedir(), ".agents", "skills");
+    const skillPaths: string[] = [];
+
+    // Walk from git root's parent up to filesystem root.
+    // Order: git-parent first (closer to cwd = higher priority via first-wins).
+    let dir = dirname(resolvedGitRoot);
+    while (true) {
+      const agentsSkills = join(dir, ".agents", "skills");
+      const resolved = resolve(agentsSkills);
+
+      // Skip ~/.agents/skills (handled globally by Pi) and non-existent dirs.
+      if (resolved !== homeAgentsSkills && existsSync(resolved)) {
+        skillPaths.push(resolved);
+      }
+
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+
+    if (skillPaths.length === 0) return;
+    return { skillPaths };
+  });
+}
+
+function findGitRoot(startDir: string): string | undefined {
+  let dir = resolve(startDir);
+  while (true) {
+    if (existsSync(join(dir, ".git"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}

--- a/packages/pi-skillful/tests/progressive-skills.test.mjs
+++ b/packages/pi-skillful/tests/progressive-skills.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+
+const home = await mkdtemp(join(tmpdir(), "pi-skillful-progressive-test-"));
+process.env.HOME = home;
+
+const { default: progressiveSkills } = await import(
+  "../.test-dist/src/extensions/progressive-skills.js"
+);
+
+function registerProgressiveSkills() {
+  const handlers = new Map();
+  const pi = {
+    on: (event, handler) => handlers.set(event, handler),
+  };
+  progressiveSkills(pi);
+  return { handlers };
+}
+
+test("no git repo — returns nothing (Pi already walks to root)", async () => {
+  const cwd = await mkdtemp(join(home, "no-git-"));
+  const { handlers } = registerProgressiveSkills();
+
+  const result = await handlers.get("resources_discover")({ cwd, reason: "startup" });
+  assert.equal(result, undefined);
+});
+
+test("git repo with no ancestor .agents/skills/ — returns nothing", async () => {
+  const repoRoot = await mkdtemp(join(home, "repo-no-ancestor-"));
+  await mkdir(join(repoRoot, ".git"));
+  const cwd = join(repoRoot, "sub");
+  await mkdir(cwd);
+
+  const { handlers } = registerProgressiveSkills();
+
+  const result = await handlers.get("resources_discover")({ cwd, reason: "startup" });
+  assert.equal(result, undefined);
+});
+
+test("git repo with .agents/skills/ in ancestor above repo root", async () => {
+  const ancestor = await mkdtemp(join(home, "ancestor-"));
+  const repoRoot = join(ancestor, "repo");
+  await mkdir(repoRoot);
+  await mkdir(join(repoRoot, ".git"));
+  await mkdir(join(ancestor, ".agents", "skills"), { recursive: true });
+
+  const cwd = join(repoRoot, "sub");
+  await mkdir(cwd);
+
+  const { handlers } = registerProgressiveSkills();
+
+  const result = await handlers.get("resources_discover")({ cwd, reason: "startup" });
+  assert.ok(result);
+  assert.ok(result.skillPaths.length >= 1);
+  assert.ok(
+    result.skillPaths.some(
+      (p) => resolve(p) === resolve(join(ancestor, ".agents", "skills")),
+    ),
+  );
+});
+
+test("~/.agents/skills/ is excluded from ancestor paths", async () => {
+  const repoRoot = await mkdtemp(join(home, "repo-home-"));
+  await mkdir(join(repoRoot, ".git"));
+  const homeSkills = join(home, ".agents", "skills");
+  await mkdir(homeSkills, { recursive: true });
+
+  const cwd = join(repoRoot, "sub");
+  await mkdir(cwd);
+
+  const { handlers } = registerProgressiveSkills();
+
+  const result = await handlers.get("resources_discover")({ cwd, reason: "startup" });
+
+  // home is the parent of the temp dir, and ~/.agents/skills/ could be
+  // in the ancestor chain. Verify it's excluded.
+  if (result?.skillPaths) {
+    for (const p of result.skillPaths) {
+      assert.notEqual(resolve(p), resolve(homeSkills));
+    }
+  }
+});
+
+test("multiple ancestor .agents/skills/ dirs all discovered", async () => {
+  const grandparent = await mkdtemp(join(home, "grandparent-"));
+  const parent = join(grandparent, "parent");
+  const repoRoot = join(parent, "repo");
+
+  await mkdir(parent);
+  await mkdir(repoRoot);
+  await mkdir(join(repoRoot, ".git"));
+
+  await mkdir(join(grandparent, ".agents", "skills"), { recursive: true });
+  await mkdir(join(parent, ".agents", "skills"), { recursive: true });
+
+  const cwd = repoRoot;
+  const { handlers } = registerProgressiveSkills();
+
+  const result = await handlers.get("resources_discover")({ cwd, reason: "startup" });
+  assert.ok(result);
+  assert.ok(result.skillPaths.length >= 1);
+  assert.ok(
+    result.skillPaths.some(
+      (p) => resolve(p) === resolve(join(grandparent, ".agents", "skills")),
+    ),
+  );
+  assert.ok(
+    result.skillPaths.some(
+      (p) => resolve(p) === resolve(join(parent, ".agents", "skills")),
+    ),
+  );
+});
+
+test.after(async () => {
+  await rm(home, { recursive: true, force: true });
+});

--- a/packages/pi-skillful/tests/progressive-skills.test.mjs
+++ b/packages/pi-skillful/tests/progressive-skills.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
 import test from "node:test";
 
 const home = await mkdtemp(join(tmpdir(), "pi-skillful-progressive-test-"));


### PR DESCRIPTION
## Problem

Pi's built-in skill discovery stops `.agents/skills/` traversal at the git repo root. Skills in ancestor directories above the repo are invisible — unlike `AGENTS.md` context files which walk the full ancestor chain to filesystem root.

Example: with cwd at `/home/user/projects/repo/sub/` and git root at `/home/user/projects/repo/`, a skill at `/home/user/projects/.agents/skills/my-skill/` is never discovered.

## Solution

A new `progressive-skills` extension that hooks the `resources_discover` event to walk the full ancestor chain (past git root to filesystem root), find `.agents/skills/` directories Pi missed, and contribute them as additional skill paths.

- Only activates when a git repo exists (no-op otherwise — Pi already walks to root)
- Excludes `~/.agents/skills/` (already loaded globally)
- Ordering ensures skills closer to cwd win on name collisions (first-wins)

## Changes

| File | Change |
|---|---|
| `src/extensions/progressive-skills.ts` | New extension module |
| `extensions/index.ts` | Wire in new extension |
| `tests/progressive-skills.test.mjs` | 5 test cases |
| `README.md` | Document new feature |
| `CHANGELOG.md` | Unreleased entry |

## Verification

- `npm run check` — passes
- `npm test -w packages/pi-skillful` — all 21 tests pass (16 existing + 5 new)
- `npm run pack:dry-run` — clean
- Empirical integration test: with git repo, both in-repo and above-repo skills visible at `before_agent_start`