### PR TITLE
Add skills-lock.json for project-scoped agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ coverage/
 
 # Compound Engineering runtime config (output of upstream CE; regenerable)
 .compound-engineering/
+
+# Project-scoped agent skills (regenerable via npx skills)
+.agents/
+.claude/

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "skills": {
+    "code-security": {
+      "source": "semgrep/skills",
+      "sourceType": "github",
+      "skillPath": "skills/code-security/SKILL.md",
+      "computedHash": "56cbeeac5ccf346461e60f08fde411aa1f6e97ffed94fc83d871c2e4ce2ee4a6"
+    },
+    "codeguard": {
+      "source": "cosai-oasis/project-codeguard",
+      "sourceType": "github",
+      "skillPath": "skills/codeguard/SKILL.md",
+      "computedHash": "e91f0d77cea054c02dfee9f2befee881af94d89cc709d5847c49637a719ba098"
+    },
+    "semgrep": {
+      "source": "semgrep/skills",
+      "sourceType": "github",
+      "skillPath": "skills/semgrep/SKILL.md",
+      "computedHash": "2ea1b9502a5cebbc74b5791dcabac00090bb00fc9a67d87a54bbd895c74a1cd6"
+    }
+  }
+}


### PR DESCRIPTION
Commits `skills-lock.json` and adds `.agents/` and `.claude/` to `.gitignore`.\n\n- **skills-lock.json** — pins installed skills (code-security, codeguard, semgrep)\n- **.gitignore** — excludes regenerable project-scoped skill directories