### PR TITLE
Reword pi-web-kit prompts to raise library_docs triggering

### DIFF
--- a/packages/pi-web-kit/CHANGELOG.md
+++ b/packages/pi-web-kit/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Changed
+
+- Rewrite `library_search`, `library_docs`, `web_search`, and `code_search` prompts so `library_docs` is the default for versioned library/framework/SDK docs (even familiar libraries), `library_search` is reserved for inspecting candidate matches, and `web_search`/`code_search` defer to it. Removes the "ambiguous library" wording that suppressed calls to well-known libraries. Provider behavior and tool schemas are unchanged.
+
 ## [0.2.3] - 2026-07-17
 
 ### Fixed

--- a/packages/pi-web-kit/CHANGELOG.md
+++ b/packages/pi-web-kit/CHANGELOG.md
@@ -8,7 +8,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ### Changed
 
-- Rewrite `library_search`, `library_docs`, `web_search`, and `code_search` prompts so `library_docs` is the default for versioned library/framework/SDK docs (even familiar libraries), `library_search` is reserved for inspecting candidate matches, and `web_search`/`code_search` defer to it. Removes the "ambiguous library" wording that suppressed calls to well-known libraries. Provider behavior and tool schemas are unchanged.
+- Rewrite `library_search`, `library_docs`, `web_search`, and `code_search` prompts so `library_docs` is the default for versioned library/framework/SDK docs (even familiar libraries), `library_search` is reserved for inspecting candidate matches, and `web_search`/`code_search` defer to it. Removes the "ambiguous library" wording that suppressed calls to well-known libraries. The `web_search`/`code_search` deferrals are emitted only when Context7 is configured, so installations without `CONTEXT7_API_KEY` are unaffected. Provider behavior and tool schemas are unchanged.
 
 ## [0.2.3] - 2026-07-17
 

--- a/packages/pi-web-kit/extensions/index.ts
+++ b/packages/pi-web-kit/extensions/index.ts
@@ -38,8 +38,8 @@ function registerTools(pi: ExtensionAPI, startupConfig: ReturnType<typeof resolv
     name: "web_search",
     label: "Web Search",
     description: buildSearchDescription(startupConfig.provider_search),
-    promptSnippet: "Find current or external web information.",
-    promptGuidelines: ["Use web_search to find current or external web information."],
+    promptSnippet: "Search the live web for current events, news, and non-library topics.",
+    promptGuidelines: ["Use web_search for current events, news, and non-library topics.", "Prefer library_docs over web_search for versioned library/framework/SDK documentation."],
     parameters: buildSearchSchema(startupConfig.provider_search),
     async execute(_toolCallId, rawParams, signal, onUpdate, ctx) {
       const params = rawParams as Record<string, any>;
@@ -108,9 +108,9 @@ function registerTools(pi: ExtensionAPI, startupConfig: ReturnType<typeof resolv
     pi.registerTool({
       name: "library_search",
       label: "Library Search",
-      description: "Resolve library, package, framework, SDK, API, or CLI names to canonical library IDs.",
-      promptSnippet: "Resolve a library name to a canonical library ID before querying docs.",
-      promptGuidelines: ["Use library_search when a library/framework/package is ambiguous or you need a canonical library ID."],
+      description: "Resolve library, package, framework, SDK, API, or CLI names to canonical library IDs with version, trust, and snippet metadata. Use when you need to inspect candidate matches (official sources, versions, forks); library_docs resolves names automatically.",
+      promptSnippet: "List candidate library IDs; library_docs resolves names on its own.",
+      promptGuidelines: ["Use library_search only to inspect matching libraries (official source, versions, forks) before a precise library_docs call.", "Not needed for ordinary doc lookups — library_docs resolves a libraryName for you."],
       parameters: buildLibrarySearchSchema(),
       async execute(_toolCallId, rawParams, signal, _onUpdate, ctx) {
         const params = rawParams as Record<string, any>;
@@ -126,9 +126,9 @@ function registerTools(pi: ExtensionAPI, startupConfig: ReturnType<typeof resolv
     pi.registerTool({
       name: "library_docs",
       label: "Library Docs",
-      description: "Fetch current, version-aware documentation and code examples for a library.",
-      promptSnippet: "Get current library documentation and code examples.",
-      promptGuidelines: ["Use library_docs for current APIs, framework behavior, SDK examples, package docs, and version-specific library questions."],
+      description: "Fetch current, version-aware documentation and code examples for a library. Pass libraryName to resolve it automatically, or a known libraryId.",
+      promptSnippet: "Get current, version-aware library/framework/SDK docs and code examples.",
+      promptGuidelines: ["Use library_docs for any library, framework, SDK, API, or CLI — even familiar ones like React, Next.js, Prisma, or Express. Training data may be outdated; this returns version-specific docs.", "Prefer library_docs over web_search or your own knowledge for library/API questions. Pass libraryName and query; you rarely need library_search first."],
       parameters: buildLibraryDocsSchema(),
       async execute(_toolCallId, rawParams, signal, _onUpdate, ctx) {
         const params = rawParams as Record<string, any>;
@@ -154,7 +154,7 @@ function registerTools(pi: ExtensionAPI, startupConfig: ReturnType<typeof resolv
       label: "Code Search",
       description: "Find practical code examples, usage patterns, setup snippets, migrations, and error context.",
       promptSnippet: "Find real-world code examples, usage patterns, migrations, and error context.",
-      promptGuidelines: ["Use code_search for real-world code examples, GitHub/open-source usage patterns, API syntax examples, setup snippets, migrations, and error messages."],
+      promptGuidelines: ["Use code_search for real-world code examples, usage patterns, setup snippets, migrations, and error context from open source.", "Prefer library_docs for official API/reference documentation."],
       parameters: buildCodeSearchSchema(),
       async execute(_toolCallId, rawParams, signal, _onUpdate, ctx) {
         const params = rawParams as Record<string, any>;

--- a/packages/pi-web-kit/extensions/index.ts
+++ b/packages/pi-web-kit/extensions/index.ts
@@ -38,8 +38,17 @@ function registerTools(pi: ExtensionAPI, startupConfig: ReturnType<typeof resolv
     name: "web_search",
     label: "Web Search",
     description: buildSearchDescription(startupConfig.provider_search),
-    promptSnippet: "Search the live web for current events, news, and non-library topics.",
-    promptGuidelines: ["Use web_search for current events, news, and non-library topics.", "Prefer library_docs over web_search for versioned library/framework/SDK documentation."],
+    promptSnippet: startupConfig.apiKeys.context7
+      ? "Search the live web for current events, news, and non-library topics."
+      : "Find current or external web information.",
+    promptGuidelines: [
+      startupConfig.apiKeys.context7
+        ? "Use web_search for current events, news, and non-library topics."
+        : "Use web_search to find current or external web information.",
+      ...(startupConfig.apiKeys.context7
+        ? ["Prefer library_docs over web_search for versioned library/framework/SDK documentation."]
+        : []),
+    ],
     parameters: buildSearchSchema(startupConfig.provider_search),
     async execute(_toolCallId, rawParams, signal, onUpdate, ctx) {
       const params = rawParams as Record<string, any>;
@@ -154,7 +163,10 @@ function registerTools(pi: ExtensionAPI, startupConfig: ReturnType<typeof resolv
       label: "Code Search",
       description: "Find practical code examples, usage patterns, setup snippets, migrations, and error context.",
       promptSnippet: "Find real-world code examples, usage patterns, migrations, and error context.",
-      promptGuidelines: ["Use code_search for real-world code examples, usage patterns, setup snippets, migrations, and error context from open source.", "Prefer library_docs for official API/reference documentation."],
+      promptGuidelines: [
+        "Use code_search for real-world code examples, usage patterns, setup snippets, migrations, and error context from open source.",
+        ...(startupConfig.apiKeys.context7 ? ["Prefer library_docs for official API/reference documentation."] : []),
+      ],
       parameters: buildCodeSearchSchema(),
       async execute(_toolCallId, rawParams, signal, _onUpdate, ctx) {
         const params = rawParams as Record<string, any>;

--- a/packages/pi-web-kit/tests/extension.test.mjs
+++ b/packages/pi-web-kit/tests/extension.test.mjs
@@ -143,6 +143,37 @@ test("developer-search tools are hidden unless backing API keys are available", 
   }
 });
 
+// Regression: web_search and code_search may only defer to library_docs when
+// library_docs is actually registered (CONTEXT7_API_KEY set). Otherwise they
+// would steer documentation requests toward a missing tool and, for web_search,
+// exclude library topics from its own lane.
+test("library_docs deferral guidance only appears when Context7 is configured", () => {
+  const oldExa = process.env.EXA_API_KEY;
+  const oldContext7 = process.env.CONTEXT7_API_KEY;
+  const defers = (tool) => (tool?.promptGuidelines ?? []).some((g) => g.includes("library_docs"));
+  try {
+    delete process.env.EXA_API_KEY;
+    delete process.env.CONTEXT7_API_KEY;
+    let web = registerWithFlags({}).find((t) => t.name === "web_search");
+    assert(!defers(web), "web_search must not defer to library_docs when Context7 is absent");
+    assert((web.promptGuidelines ?? []).every((g) => !g.includes("non-library")), "web_search must stay usable for library docs when Context7 is absent");
+
+    process.env.EXA_API_KEY = "exa-test";
+    const code = registerWithFlags({}).find((t) => t.name === "code_search");
+    assert(!defers(code), "code_search must not defer to library_docs when Context7 is absent");
+
+    process.env.CONTEXT7_API_KEY = "ctx7sk_test";
+    const tools = registerWithFlags({});
+    assert(defers(tools.find((t) => t.name === "web_search")), "web_search defers to library_docs when Context7 is present");
+    assert(defers(tools.find((t) => t.name === "code_search")), "code_search defers to library_docs when Context7 is present");
+  } finally {
+    if (oldExa === undefined) delete process.env.EXA_API_KEY;
+    else process.env.EXA_API_KEY = oldExa;
+    if (oldContext7 === undefined) delete process.env.CONTEXT7_API_KEY;
+    else process.env.CONTEXT7_API_KEY = oldContext7;
+  }
+});
+
 test("web_search returns grouped multi-query output with bounded details", async () => {
   const tools = registerWithFlags({});
   const searchTool = tools.find((t) => t.name === "web_search");


### PR DESCRIPTION
## Why

`library_search`/`library_docs` (Context7-backed) fired very rarely. Root cause was in the prompt surface, not the backend: the wording actively suppressed calls.

- `library_search`'s guideline said "use … **when a library/framework/package is ambiguous**". Most libraries the model meets are *not* ambiguous (it "knows" React, Next.js, …), so it read the rule literally and skipped the tool.
- No routing guidance, so `web_search`'s broader guideline ("find current or external web information") won versioned-docs questions.
- No claim over the model's own training data. Context7's effectiveness comes largely from its injected rule ("use … even when you think you know the answer … prefer this over web search").

## What changed

Pure prompt-surface edits in `packages/pi-web-kit/extensions/index.ts` — provider calls, output bounding, and tool schemas are untouched. A routing mesh is now explicit across four tools:

| Tool | Lane | Defers to |
|---|---|---|
| `library_docs` | **any** library/framework/SDK/CLI docs, even familiar ones (React, Next.js, Prisma, Express) | preferred over `web_search` **and** over the model's own knowledge |
| `web_search` | current events, news, non-library topics | `library_docs` for versioned lib docs |
| `code_search` | real-world usage/migrations/error context from open source | `library_docs` for official API reference |
| `library_search` | inspect candidate matches (sources/versions/forks) only | "not needed for ordinary lookups — `library_docs` resolves names for you" |

Targeted fixes:
- Killed "ambiguous".
- `library_docs` claims the lane explicitly ("Prefer library_docs over web_search or your own knowledge").
- Surfaced the one-call win: description/snippet now state `library_docs` auto-resolves `libraryName`, removing the perceived two-step cost.
- Added anchor library examples to teach the pattern.

## Validation

- `npm run -w packages/pi-web-kit typecheck` — clean
- `npm run -w packages/pi-web-kit test` — 41/41 pass
- `git diff --check` — clean

No tests pinned these prompt strings, so no test updates were needed.

## Notes

This addresses only the self-inflicted trigger suppression. If `library_docs` still fires rarely after this, that points to genuine low demand in a given workflow rather than a wording bug. A follow-up could add a short global rule via the `before_agent_start` system-prompt injection (analogous to Context7's `rules/context7-mcp.md`), left out here so this change can be evaluated in isolation.

CHANGELOG entry added under `[Unreleased]`.