### PR TITLE
Release pi-web-kit 0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4522,7 +4522,7 @@
       }
     },
     "packages/pi-web-kit": {
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.80.10",

--- a/packages/pi-web-kit/CHANGELOG.md
+++ b/packages/pi-web-kit/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-07-28
+
 ### Changed
 
 - Rewrite `library_search`, `library_docs`, `web_search`, and `code_search` prompts so `library_docs` is the default for versioned library/framework/SDK docs (even familiar libraries), `library_search` is reserved for inspecting candidate matches, and `web_search`/`code_search` defer to it. Removes the "ambiguous library" wording that suppressed calls to well-known libraries. The `web_search`/`code_search` deferrals are emitted only when Context7 is configured, so installations without `CONTEXT7_API_KEY` are unaffected. Provider behavior and tool schemas are unchanged.

--- a/packages/pi-web-kit/package.json
+++ b/packages/pi-web-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-web-kit",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Context-efficient web search and fetch tools for Pi.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Lands the `pi-web-kit@0.2.4` release commit on `main`.

## Context

The `0.2.4` release was interrupted after tagging: the version-bump commit `cf1f676` and tag `pi-web-kit@0.2.4` were created, but the commit never reached `main` (branch protection requires a PR + passing checks; `enforce_admins` blocks direct pushes). The GitHub Release and npm publish were completed separately — `pi-web-kit@0.2.4` is already live on npm (`latest`).

This PR is the missing step: bring `main` to `0.2.4` so it matches the released tag, consistent with prior releases (e.g. `0.2.3`'s tagged commit is on `main`).

## Contents

Exactly the release commit (`cf1f676`), parent is the current `main` tip — a clean fast-forward equivalent:

- `packages/pi-web-kit/package.json` — `0.2.3` → `0.2.4`
- `packages/pi-web-kit/CHANGELOG.md` — `[Unreleased]` → `[0.2.4] - 2026-07-28`
- `package-lock.json` — version sync

Functional change shipped in `0.2.4` (already merged via #97): reworded `library_*`/`web_search`/`code_search` prompts with Context7-conditional deferrals + regression test.

## Merge note

Please **merge with a merge commit (not squash)** so the tagged commit `cf1f676` lands on `main` and the tag stays reachable — matching the `0.2.3` pattern.