### PR TITLE
Add pi-fast package

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Each package installs independently. Pick the capability you need, then follow i
 | Control how skills are invoked and discovered | [pi-skillful](./packages/pi-skillful) | Inline invocation, prompt visibility controls, and session skill toggles. |
 | Learn from reference implementations | [pi-scout](./packages/pi-scout) | Reusable local reference repositories for agent exploration. |
 
+### Performance and providers
+
+| Need | Package | What it adds |
+| --- | --- | --- |
+| Use supported provider fast modes on demand | [pi-fast](./packages/pi-fast) | Session-local Fast toggles for provider/model pairs that advertise faster processing. |
+
 ### Research and create
 
 | Need | Package | What it adds |

--- a/package-lock.json
+++ b/package-lock.json
@@ -4124,6 +4124,10 @@
       "resolved": "packages/pi-dcg",
       "link": true
     },
+    "node_modules/pi-fast": {
+      "resolved": "packages/pi-fast",
+      "link": true
+    },
     "node_modules/pi-insomnia": {
       "resolved": "packages/pi-insomnia",
       "link": true
@@ -4431,6 +4435,24 @@
       },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": "*"
+      }
+    },
+    "packages/pi-fast": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@earendil-works/pi-coding-agent": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
+        "@types/node": "^26.1.1",
+        "tsx": "^4.23.1",
+        "typescript": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*"
       }
     },
     "packages/pi-goal": {

--- a/packages/pi-agentsmd/src/install-telemetry.ts
+++ b/packages/pi-agentsmd/src/install-telemetry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -83,18 +83,30 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const version = getPackageVersion();
     const extensionsDir = join(getAgentDir(), "extensions");
     const statePath = join(extensionsDir, "pi-agentsmd-install.json");
-    const state = readJsonFile(statePath) as InstallTelemetryState;
-    if (state.lastReportedVersion === version) return;
-
-    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
-      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
-      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
-
+    const lockPath = `${statePath}.lock`;
     await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    try {
+      await writeFile(lockPath, "", { flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+      throw error;
+    }
+
+    try {
+      const state = readJsonFile(statePath) as InstallTelemetryState;
+      if (state.lastReportedVersion === version) return;
+
+      const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+        headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+        signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+      await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    } finally {
+      await rm(lockPath, { force: true });
+    }
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-agentsmd/src/install-telemetry.ts
+++ b/packages/pi-agentsmd/src/install-telemetry.ts
@@ -86,14 +86,15 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const state = readJsonFile(statePath) as InstallTelemetryState;
     if (state.lastReportedVersion === version) return;
 
-    await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
-
     const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
       headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
       signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
     });
+    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-agentsmd/src/install-telemetry.ts
+++ b/packages/pi-agentsmd/src/install-telemetry.ts
@@ -97,6 +97,7 @@ async function reportInstallTelemetryAsync(): Promise<void> {
       if (state.lastReportedVersion === version) return;
 
       const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
       const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
         headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
         signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),

--- a/packages/pi-codex-image-gen/src/install-telemetry.ts
+++ b/packages/pi-codex-image-gen/src/install-telemetry.ts
@@ -86,14 +86,15 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const state = readJsonFile(statePath) as InstallTelemetryState;
     if (state.lastReportedVersion === version) return;
 
-    await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
-
     const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
       headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
       signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
     });
+    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-codex-image-gen/src/install-telemetry.ts
+++ b/packages/pi-codex-image-gen/src/install-telemetry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -83,18 +83,30 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const version = getPackageVersion();
     const extensionsDir = join(getAgentDir(), "extensions");
     const statePath = join(extensionsDir, "pi-codex-image-gen-install.json");
-    const state = readJsonFile(statePath) as InstallTelemetryState;
-    if (state.lastReportedVersion === version) return;
-
-    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
-      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
-      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
-
+    const lockPath = `${statePath}.lock`;
     await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    try {
+      await writeFile(lockPath, "", { flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+      throw error;
+    }
+
+    try {
+      const state = readJsonFile(statePath) as InstallTelemetryState;
+      if (state.lastReportedVersion === version) return;
+
+      const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+        headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+        signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+      await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    } finally {
+      await rm(lockPath, { force: true });
+    }
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-codex-image-gen/src/install-telemetry.ts
+++ b/packages/pi-codex-image-gen/src/install-telemetry.ts
@@ -97,6 +97,7 @@ async function reportInstallTelemetryAsync(): Promise<void> {
       if (state.lastReportedVersion === version) return;
 
       const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
       const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
         headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
         signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),

--- a/packages/pi-compound-engineering/src/install-telemetry.ts
+++ b/packages/pi-compound-engineering/src/install-telemetry.ts
@@ -86,15 +86,16 @@ async function reportInstallTelemetryAsync(): Promise<void> {
 		const state = readJsonFile(statePath) as InstallTelemetryState;
 		if (state.lastReportedVersion === version) return;
 
-		await mkdir(extensionsDir, { recursive: true });
-		await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
-
 		const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
 		// codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
-		await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+		const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
 			headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
 			signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
 		});
+		if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+		await mkdir(extensionsDir, { recursive: true });
+		await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
 	} catch {
 		// Best-effort telemetry: ignore settings, filesystem, and network failures.
 	}

--- a/packages/pi-compound-engineering/src/install-telemetry.ts
+++ b/packages/pi-compound-engineering/src/install-telemetry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -83,19 +83,31 @@ async function reportInstallTelemetryAsync(): Promise<void> {
 		const version = getPackageVersion();
 		const extensionsDir = join(getAgentDir(), "extensions");
 		const statePath = join(extensionsDir, "compound-engineering-install.json");
-		const state = readJsonFile(statePath) as InstallTelemetryState;
-		if (state.lastReportedVersion === version) return;
-
-		const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-		// codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
-		const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
-			headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
-			signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
-		});
-		if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
-
+		const lockPath = `${statePath}.lock`;
 		await mkdir(extensionsDir, { recursive: true });
-		await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+		try {
+			await writeFile(lockPath, "", { flag: "wx" });
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+			throw error;
+		}
+
+		try {
+			const state = readJsonFile(statePath) as InstallTelemetryState;
+			if (state.lastReportedVersion === version) return;
+
+			const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+			// codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
+			const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+				headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+				signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+			});
+			if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+			await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+		} finally {
+			await rm(lockPath, { force: true });
+		}
 	} catch {
 		// Best-effort telemetry: ignore settings, filesystem, and network failures.
 	}

--- a/packages/pi-dcg/src/install-telemetry.ts
+++ b/packages/pi-dcg/src/install-telemetry.ts
@@ -86,14 +86,15 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const state = readJsonFile(statePath) as InstallTelemetryState;
     if (state.lastReportedVersion === version) return;
 
-    await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
-
     const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
       headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
       signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
     });
+    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-dcg/src/install-telemetry.ts
+++ b/packages/pi-dcg/src/install-telemetry.ts
@@ -97,6 +97,7 @@ async function reportInstallTelemetryAsync(): Promise<void> {
       if (state.lastReportedVersion === version) return;
 
       const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
       const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
         headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
         signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),

--- a/packages/pi-dcg/src/install-telemetry.ts
+++ b/packages/pi-dcg/src/install-telemetry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -83,18 +83,30 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const version = getPackageVersion();
     const extensionsDir = join(getAgentDir(), "extensions");
     const statePath = join(extensionsDir, "pi-dcg-install.json");
-    const state = readJsonFile(statePath) as InstallTelemetryState;
-    if (state.lastReportedVersion === version) return;
-
-    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
-      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
-      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
-
+    const lockPath = `${statePath}.lock`;
     await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    try {
+      await writeFile(lockPath, "", { flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+      throw error;
+    }
+
+    try {
+      const state = readJsonFile(statePath) as InstallTelemetryState;
+      if (state.lastReportedVersion === version) return;
+
+      const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+        headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+        signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+      await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    } finally {
+      await rm(lockPath, { force: true });
+    }
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-fast/.editorconfig
+++ b/packages/pi-fast/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/pi-fast/.gitignore
+++ b/packages/pi-fast/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+*.tgz
+*.tsbuildinfo
+.DS_Store
+.env
+.env.*
+!.env.example
+npm-debug.log*

--- a/packages/pi-fast/AGENTS.md
+++ b/packages/pi-fast/AGENTS.md
@@ -1,0 +1,19 @@
+# pi-fast Guidelines
+
+Root `AGENTS.md` applies.
+
+## Invariants
+
+- Fast mode is disabled on every new extension instance and is never persisted.
+- Only provider/model pairs known to advertise Fast support may receive a fast-mode request.
+- OpenAI Codex Fast mode uses the `priority` service tier, which can increase usage.
+- The status indicator must reflect the current model: on, off, or unavailable.
+- The extension must not read, log, or persist prompts, credentials, or provider response data.
+
+## Validation
+
+```bash
+npm run -w packages/pi-fast check
+npm test -w packages/pi-fast
+npm run -w packages/pi-fast pack:dry-run
+```

--- a/packages/pi-fast/CHANGELOG.md
+++ b/packages/pi-fast/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-08-02
+
+### Added
+
+- Initial `pi-fast` extension.
+- Session-local `/fast` command and `Ctrl+Shift+F` toggle.
+- OpenAI Codex Fast mode for models that advertise the `priority` service tier.
+- Footer status for Fast mode state.

--- a/packages/pi-fast/CODE_OF_CONDUCT.md
+++ b/packages/pi-fast/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best for the community, rather than us as individuals
+
+Examples of unacceptable behavior by participants include:
+
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at jose@mocito.dev. All complaints will be reviewed and investigated promptly and fairly.
+
+Community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/packages/pi-fast/CONTRIBUTING.md
+++ b/packages/pi-fast/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Thanks for your interest in contributing to `pi-fast`.
+
+## Development setup
+
+```bash
+npm install
+npm run -w packages/pi-fast check
+```
+
+This package is source-distributed: Pi loads the TypeScript extension files directly. There is no build step for runtime use.
+
+## Pull request checklist
+
+Before opening a pull request:
+
+- Run `npm run -w packages/pi-fast check`.
+- Run `npm test -w packages/pi-fast`.
+- Run `npm audit --omit=dev`.
+- Run `npm run -w packages/pi-fast pack:dry-run` and confirm the package contents are intentional.
+- Update `README.md` if user-visible behavior changes.
+- Update `CHANGELOG.md` for notable changes.
+- Keep examples and paths generic; do not commit API keys, tokens, auth headers, local settings, or provider configuration containing secrets.
+
+## Coding guidelines
+
+- Keep provider/model capability checks explicit and conservative.
+- Preserve the off-by-default, session-local behavior.
+- Add a regression test when changing request rewriting or toggle state.
+
+## Code of conduct
+
+This project follows the Contributor Covenant Code of Conduct.

--- a/packages/pi-fast/LICENSE
+++ b/packages/pi-fast/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jose Mocito
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-fast/README.md
+++ b/packages/pi-fast/README.md
@@ -1,0 +1,79 @@
+# pi-fast
+
+Use provider fast modes in Pi when you need lower latency, while keeping the paid path off by default.
+
+`pi-fast` currently supports OpenAI Codex models that advertise Fast processing. It adds Codex's `priority` service tier only after you explicitly enable it for the session.
+
+## Features
+
+- **On-demand toggle** — use `/fast`, `/fast on`, `/fast off`, or `Ctrl+Shift+F`.
+- **Safe model guard** — only supported `openai-codex` models receive the Fast request field.
+- **Visible state** — the Pi footer shows `Fast on`, `Fast off`, or `Fast n/a`.
+- **Session-local behavior** — Fast mode starts off and is never persisted.
+
+## Supported models
+
+The current OpenAI Codex catalog advertises Fast support for:
+
+- `gpt-5.4`
+- `gpt-5.5`
+- `gpt-5.6-luna`
+- `gpt-5.6-sol`
+- `gpt-5.6-terra`
+
+The support list follows the upstream Codex model catalog and may need an update when that catalog changes. Models without an advertised Fast tier are left untouched.
+
+## Installation
+
+Install from npm:
+
+```bash
+pi install npm:pi-fast
+```
+
+Install project-locally with Pi's `-l` flag:
+
+```bash
+pi install -l npm:pi-fast
+```
+
+During local development from this monorepo:
+
+```bash
+pi install /path/to/pi-mono/packages/pi-fast
+```
+
+For a one-off run without installing:
+
+```bash
+pi -e /path/to/pi-mono/packages/pi-fast
+```
+
+This is an npm-compatible TypeScript Pi package. There is no runtime build step.
+
+## Usage
+
+Start a supported Codex model, then use either:
+
+```text
+/fast
+```
+
+or press `Ctrl+Shift+F`.
+
+`/fast` toggles the current state. `/fast on`, `/fast off`, and `/fast toggle` select it explicitly. When active, supported Codex requests include `service_tier: "priority"`, which upstream describes as faster processing with increased usage.
+
+## Configuration
+
+There is no Fast-mode configuration. The mode is intentionally disabled when Pi starts and resets when the extension reloads or the session ends.
+
+Install/update telemetry can be disabled with `PI_OFFLINE=1` or `PI_TELEMETRY=0`.
+
+## Development
+
+```bash
+npm install
+npm run -w packages/pi-fast check
+npm test -w packages/pi-fast
+npm run -w packages/pi-fast pack:dry-run
+```

--- a/packages/pi-fast/SECURITY.md
+++ b/packages/pi-fast/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the latest released version of `pi-fast`.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for suspected security vulnerabilities.
+
+Report privately by contacting the repository maintainer through GitHub. Include:
+
+- a description of the issue;
+- steps to reproduce;
+- affected versions or commits, if known;
+- any suggested mitigation.
+
+## Security model
+
+`pi-fast` is a Pi package. Pi extensions execute with the same permissions as the local user running Pi. Users should review installed Pi packages and only install packages from sources they trust.
+
+The extension does not read or log prompts, credentials, auth headers, or provider responses. It only inspects the current provider/model identifier and creates an in-memory request payload copy with `service_tier: "priority"` for supported OpenAI Codex models when Fast mode is enabled.
+
+Fast mode is off by default and is never persisted. Models without an advertised Fast tier are not modified. The `priority` tier can increase provider usage, so the footer and toggle notifications make the active state visible.
+
+On startup, the package sends a best-effort install/update telemetry ping to `mocito.dev` once per package version unless Pi telemetry is disabled, offline mode is enabled, or Pi runs in CI. The ping contains only the package name, version, and parsed platform/runtime/architecture from its User-Agent; it does not include prompts, file paths, config values, environment variables, or API keys.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development and validation instructions.

--- a/packages/pi-fast/SECURITY.md
+++ b/packages/pi-fast/SECURITY.md
@@ -8,7 +8,7 @@ Security fixes are provided for the latest released version of `pi-fast`.
 
 Please do not open a public issue for suspected security vulnerabilities.
 
-Report privately by contacting the repository maintainer through GitHub. Include:
+Report privately through [GitHub Security Advisories](https://github.com/jvm/pi-mono/security/advisories/new) or by contacting the repository maintainer through GitHub. Include:
 
 - a description of the issue;
 - steps to reproduce;

--- a/packages/pi-fast/extensions/index.ts
+++ b/packages/pi-fast/extensions/index.ts
@@ -1,0 +1,79 @@
+import { Key } from "@earendil-works/pi-tui";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { reportInstallTelemetry } from "../src/install-telemetry.js";
+import { applyFastMode, supportsFastMode } from "../src/fast-mode.js";
+
+const STATUS_KEY = "pi-fast";
+
+type Toggle = "on" | "off" | "toggle";
+
+export default function piFast(pi: ExtensionAPI): void {
+  reportInstallTelemetry();
+
+  let enabled = false;
+
+  function updateStatus(ctx: ExtensionContext): void {
+    if (!ctx.hasUI) return;
+
+    const supported = supportsFastMode(ctx.model);
+    const text = !supported ? "Fast n/a" : enabled ? "Fast on" : "Fast off";
+    const color = enabled && supported ? "warning" : "muted";
+    ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg(color, text));
+  }
+
+  function notify(ctx: ExtensionContext, message: string, type: "info" | "warning"): void {
+    if (ctx.hasUI) ctx.ui.notify(message, type);
+  }
+
+  function setEnabled(next: boolean, ctx: ExtensionContext): void {
+    if (next && !supportsFastMode(ctx.model)) {
+      notify(ctx, "Fast mode is unavailable for the current provider/model.", "warning");
+      updateStatus(ctx);
+      return;
+    }
+
+    enabled = next;
+    updateStatus(ctx);
+    notify(
+      ctx,
+      next
+        ? "Fast mode enabled; supported requests use priority processing and increased usage."
+        : "Fast mode disabled.",
+      next ? "warning" : "info",
+    );
+  }
+
+  function toggle(ctx: ExtensionContext): void {
+    setEnabled(!enabled, ctx);
+  }
+
+  pi.registerCommand("fast", {
+    description: "Toggle Fast mode for supported provider/models",
+    handler: async (args, ctx) => {
+      const mode = args.trim().toLowerCase() as Toggle | "";
+      if (mode === "on") return setEnabled(true, ctx);
+      if (mode === "off") return setEnabled(false, ctx);
+      if (mode === "" || mode === "toggle") return toggle(ctx);
+      notify(ctx, "Usage: /fast [on|off|toggle]", "warning");
+    },
+  });
+
+  pi.registerShortcut(Key.ctrlShift("f"), {
+    description: "Toggle Fast mode",
+    handler: toggle,
+  });
+
+  pi.on("before_provider_request", (event, ctx) => {
+    if (!enabled || !supportsFastMode(ctx.model)) return;
+    return applyFastMode(event.payload, ctx.model);
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    updateStatus(ctx);
+  });
+
+  pi.on("model_select", async (_event, ctx) => {
+    updateStatus(ctx);
+  });
+
+}

--- a/packages/pi-fast/extensions/index.ts
+++ b/packages/pi-fast/extensions/index.ts
@@ -13,7 +13,7 @@ export default function piFast(pi: ExtensionAPI): void {
   let enabled = false;
 
   function updateStatus(ctx: ExtensionContext): void {
-    if (!ctx.hasUI) return;
+    if (ctx.mode !== "tui") return;
 
     const supported = supportsFastMode(ctx.model);
     const text = !supported ? "Fast n/a" : enabled ? "Fast on" : "Fast off";
@@ -69,11 +69,11 @@ export default function piFast(pi: ExtensionAPI): void {
   });
 
   pi.on("session_start", async (_event, ctx) => {
+    enabled = false;
     updateStatus(ctx);
   });
 
   pi.on("model_select", async (_event, ctx) => {
     updateStatus(ctx);
   });
-
 }

--- a/packages/pi-fast/index.ts
+++ b/packages/pi-fast/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./extensions/index.js";

--- a/packages/pi-fast/package.json
+++ b/packages/pi-fast/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "pi-fast",
+  "version": "0.1.0",
+  "description": "Toggle provider fast modes in Pi on demand.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Jose Mocito",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jvm/pi-mono.git",
+    "directory": "packages/pi-fast"
+  },
+  "bugs": {
+    "url": "https://github.com/jvm/pi-mono/issues"
+  },
+  "homepage": "https://github.com/jvm/pi-mono/tree/main/packages/pi-fast#readme",
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi",
+    "fast-mode",
+    "provider",
+    "service-tier",
+    "openai-codex"
+  ],
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "files": [
+    "index.ts",
+    "extensions",
+    "src",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md",
+    "SECURITY.md",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md"
+  ],
+  "scripts": {
+    "check": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test tests/*.test.mjs",
+    "pack:dry-run": "npm pack --dry-run"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.80.10",
+    "@earendil-works/pi-tui": "^0.80.10",
+    "@types/node": "^26.1.1",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20.6.0"
+  }
+}

--- a/packages/pi-fast/src/fast-mode.ts
+++ b/packages/pi-fast/src/fast-mode.ts
@@ -1,0 +1,27 @@
+export const FAST_SERVICE_TIER = "priority" as const;
+
+export interface FastModel {
+  readonly provider: string;
+  readonly id: string;
+}
+
+const OPENAI_CODEX_FAST_MODELS: ReadonlySet<string> = new Set([
+  "gpt-5.4",
+  "gpt-5.5",
+  "gpt-5.6-luna",
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+]);
+
+export function supportsFastMode(model: FastModel | undefined): boolean {
+  return model?.provider === "openai-codex" && OPENAI_CODEX_FAST_MODELS.has(model.id);
+}
+
+export function applyFastMode(payload: unknown, model: FastModel | undefined): unknown {
+  if (!supportsFastMode(model) || !isRecord(payload)) return payload;
+  return { ...payload, service_tier: FAST_SERVICE_TIER };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/pi-fast/src/index.ts
+++ b/packages/pi-fast/src/index.ts
@@ -1,0 +1,3 @@
+export const PACKAGE_NAME = "pi-fast";
+
+export * from "./fast-mode.js";

--- a/packages/pi-fast/src/install-telemetry.ts
+++ b/packages/pi-fast/src/install-telemetry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -83,19 +83,31 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const version = getPackageVersion();
     const extensionsDir = join(getAgentDir(), "extensions");
     const statePath = join(extensionsDir, "pi-fast-install.json");
-    const state = readJsonFile(statePath) as InstallTelemetryState;
-    if (state.lastReportedVersion === version) return;
-
-    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
-    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
-      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
-      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
-
+    const lockPath = `${statePath}.lock`;
     await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    try {
+      await writeFile(lockPath, "", { flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+      throw error;
+    }
+
+    try {
+      const state = readJsonFile(statePath) as InstallTelemetryState;
+      if (state.lastReportedVersion === version) return;
+
+      const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
+      const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+        headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+        signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+      await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    } finally {
+      await rm(lockPath, { force: true });
+    }
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-fast/src/install-telemetry.ts
+++ b/packages/pi-fast/src/install-telemetry.ts
@@ -3,8 +3,8 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { PACKAGE_NAME } from "./index.js";
 
-const PACKAGE_NAME = "pi-fast";
 const INSTALL_TELEMETRY_URL = "https://mocito.dev/api/report-install";
 const INSTALL_TELEMETRY_TIMEOUT_MS = 5000;
 const CI_ENVIRONMENT_VARIABLES = [

--- a/packages/pi-fast/src/install-telemetry.ts
+++ b/packages/pi-fast/src/install-telemetry.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+const PACKAGE_NAME = "pi-fast";
+const INSTALL_TELEMETRY_URL = "https://mocito.dev/api/report-install";
+const INSTALL_TELEMETRY_TIMEOUT_MS = 5000;
+const CI_ENVIRONMENT_VARIABLES = [
+  "APPVEYOR",
+  "BITBUCKET_BUILD_NUMBER",
+  "BUILDKITE",
+  "CIRCLECI",
+  "CODESPACES",
+  "DRONE",
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "JENKINS_URL",
+  "NETLIFY",
+  "TEAMCITY_VERSION",
+  "TF_BUILD",
+  "TRAVIS",
+  "VERCEL",
+];
+
+interface InstallTelemetryState {
+  lastReportedVersion?: string;
+}
+
+interface PiSettingsDocument {
+  enableInstallTelemetry?: unknown;
+}
+
+function readJsonFile(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as unknown;
+  } catch {
+    return {};
+  }
+}
+
+function isTruthyEnvFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
+}
+
+function isPresentEnvFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized !== "0" && normalized !== "false" && normalized !== "no";
+}
+
+function isCiEnvironment(): boolean {
+  if (isTruthyEnvFlag(process.env.CI)) return true;
+  return CI_ENVIRONMENT_VARIABLES.some((name) => isPresentEnvFlag(process.env[name]));
+}
+
+function isInstallTelemetryEnabled(): boolean {
+  if (isCiEnvironment()) return false;
+  if (isTruthyEnvFlag(process.env.PI_OFFLINE)) return false;
+  if (process.env.PI_TELEMETRY !== undefined) return isTruthyEnvFlag(process.env.PI_TELEMETRY);
+
+  const settings = readJsonFile(join(getAgentDir(), "settings.json")) as PiSettingsDocument;
+  return settings.enableInstallTelemetry !== false;
+}
+
+function getPackageVersion(): string {
+  const packageJson = readJsonFile(fileURLToPath(new URL("../package.json", import.meta.url))) as { version?: unknown };
+  return typeof packageJson.version === "string" && packageJson.version.length > 0 ? packageJson.version : "0.0.0";
+}
+
+function getInstallTelemetryUserAgent(version: string): string {
+  const runtimeVersions = process.versions as NodeJS.ProcessVersions & { bun?: string };
+  const runtime = runtimeVersions.bun ? `bun/${runtimeVersions.bun}` : `node/${process.version}`;
+  return `${PACKAGE_NAME}/${version} (${process.platform}; ${runtime}; ${process.arch})`;
+}
+
+async function reportInstallTelemetryAsync(): Promise<void> {
+  try {
+    if (!isInstallTelemetryEnabled()) return;
+
+    const version = getPackageVersion();
+    const extensionsDir = join(getAgentDir(), "extensions");
+    const statePath = join(extensionsDir, "pi-fast-install.json");
+    const state = readJsonFile(statePath) as InstallTelemetryState;
+    if (state.lastReportedVersion === version) return;
+
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+
+    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+    });
+  } catch {
+    // Best-effort telemetry: ignore settings, filesystem, and network failures.
+  }
+}
+
+export function reportInstallTelemetry(): void {
+  void reportInstallTelemetryAsync();
+}

--- a/packages/pi-fast/src/install-telemetry.ts
+++ b/packages/pi-fast/src/install-telemetry.ts
@@ -86,14 +86,16 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const state = readJsonFile(statePath) as InstallTelemetryState;
     if (state.lastReportedVersion === version) return;
 
-    await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
-
     const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+    // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
+    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
       headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
       signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
     });
+    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-fast/tests/extension.test.mjs
+++ b/packages/pi-fast/tests/extension.test.mjs
@@ -33,6 +33,7 @@ function makeContext(model, hasUI = true) {
   const notifications = [];
   return {
     model,
+    mode: hasUI ? "tui" : "print",
     hasUI,
     statuses,
     notifications,
@@ -82,6 +83,21 @@ test("keeps Fast off by default and rewrites supported provider requests after t
 
   await pi.shortcuts.get("ctrl+shift+f").handler(context);
   assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast off" });
+
+  await pi.commands.get("fast").handler("on", context);
+  await pi.handlers.get("session_start")[0]({}, context);
+  assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast off" });
+  assert.deepEqual(await beforeRequest({ payload: { model: "gpt-5.4" } }, context), undefined);
+});
+
+test("does not render footer status outside TUI", async () => {
+  const pi = makePi();
+  piFast(pi);
+  const context = makeContext({ provider: "openai-codex", id: "gpt-5.4" }, false);
+
+  await pi.handlers.get("session_start")[0]({}, context);
+
+  assert.deepEqual(context.statuses, []);
 });
 
 test("does not enable Fast for unsupported models", async () => {

--- a/packages/pi-fast/tests/extension.test.mjs
+++ b/packages/pi-fast/tests/extension.test.mjs
@@ -28,12 +28,12 @@ function makePi() {
   };
 }
 
-function makeContext(model, hasUI = true) {
+function makeContext(model, hasUI = true, mode = hasUI ? "tui" : "print") {
   const statuses = [];
   const notifications = [];
   return {
     model,
-    mode: hasUI ? "tui" : "print",
+    mode,
     hasUI,
     statuses,
     notifications,
@@ -93,7 +93,7 @@ test("keeps Fast off by default and rewrites supported provider requests after t
 test("does not render footer status outside TUI", async () => {
   const pi = makePi();
   piFast(pi);
-  const context = makeContext({ provider: "openai-codex", id: "gpt-5.4" }, false);
+  const context = makeContext({ provider: "openai-codex", id: "gpt-5.4" }, true, "print");
 
   await pi.handlers.get("session_start")[0]({}, context);
 

--- a/packages/pi-fast/tests/extension.test.mjs
+++ b/packages/pi-fast/tests/extension.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.CI = "1";
+
+const { default: piFast } = await import("../extensions/index.ts");
+const { FAST_SERVICE_TIER, applyFastMode, supportsFastMode } = await import("../src/fast-mode.ts");
+
+function makePi() {
+  const handlers = new Map();
+  const commands = new Map();
+  const shortcuts = new Map();
+  return {
+    handlers,
+    commands,
+    shortcuts,
+    on(event, handler) {
+      const eventHandlers = handlers.get(event) ?? [];
+      eventHandlers.push(handler);
+      handlers.set(event, eventHandlers);
+    },
+    registerCommand(name, command) {
+      commands.set(name, command);
+    },
+    registerShortcut(key, shortcut) {
+      shortcuts.set(key, shortcut);
+    },
+  };
+}
+
+function makeContext(model, hasUI = true) {
+  const statuses = [];
+  const notifications = [];
+  return {
+    model,
+    hasUI,
+    statuses,
+    notifications,
+    ui: {
+      theme: { fg: (_color, text) => text },
+      setStatus: (key, value) => statuses.push({ key, value }),
+      notify: (message, type) => notifications.push({ message, type }),
+    },
+  };
+}
+
+test("recognizes only the Codex models with an advertised Fast tier", () => {
+  assert.equal(supportsFastMode({ provider: "openai-codex", id: "gpt-5.4" }), true);
+  assert.equal(supportsFastMode({ provider: "openai-codex", id: "gpt-5.6-sol" }), true);
+  assert.equal(supportsFastMode({ provider: "openai-codex", id: "gpt-5.4-mini" }), false);
+  assert.equal(supportsFastMode({ provider: "openai", id: "gpt-5.4" }), false);
+});
+
+test("adds Codex priority processing without mutating the original payload", () => {
+  const payload = { model: "gpt-5.4", input: [] };
+  const updated = applyFastMode(payload, { provider: "openai-codex", id: "gpt-5.4" });
+
+  assert.deepEqual(updated, { ...payload, service_tier: FAST_SERVICE_TIER });
+  assert.deepEqual(payload, { model: "gpt-5.4", input: [] });
+  assert.deepEqual(
+    applyFastMode(payload, { provider: "openai-codex", id: "gpt-5.4-mini" }),
+    payload,
+  );
+});
+
+test("keeps Fast off by default and rewrites supported provider requests after toggling", async () => {
+  const pi = makePi();
+  piFast(pi);
+  const context = makeContext({ provider: "openai-codex", id: "gpt-5.4" });
+  const beforeRequest = pi.handlers.get("before_provider_request")[0];
+
+  assert.deepEqual(await beforeRequest({ payload: { model: "gpt-5.4" } }, context), undefined);
+  await pi.handlers.get("session_start")[0]({}, context);
+  assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast off" });
+
+  await pi.commands.get("fast").handler("on", context);
+  assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast on" });
+  assert.deepEqual(
+    await beforeRequest({ payload: { model: "gpt-5.4" } }, context),
+    { model: "gpt-5.4", service_tier: "priority" },
+  );
+
+  await pi.shortcuts.get("ctrl+shift+f").handler(context);
+  assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast off" });
+});
+
+test("does not enable Fast for unsupported models", async () => {
+  const pi = makePi();
+  piFast(pi);
+  const context = makeContext({ provider: "openai-codex", id: "gpt-5.4-mini" });
+
+  await pi.handlers.get("session_start")[0]({}, context);
+  await pi.commands.get("fast").handler("on", context);
+
+  assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast n/a" });
+  assert.equal(context.notifications.at(-1).type, "warning");
+  assert.equal(await pi.handlers.get("before_provider_request")[0]({ payload: {} }, context), undefined);
+});

--- a/packages/pi-fast/tests/install-telemetry.test.mjs
+++ b/packages/pi-fast/tests/install-telemetry.test.mjs
@@ -44,40 +44,21 @@ async function waitFor(predicate) {
   }
 }
 
-test("retries telemetry after failed and non-OK reports", async () => {
+async function withTelemetryEnvironment(callback) {
   const agentDir = await mkdtemp(join(tmpdir(), "pi-fast-telemetry-"));
   const statePath = join(agentDir, "extensions", "pi-fast-install.json");
+  const lockPath = `${statePath}.lock`;
   const previousEnv = Object.fromEntries(
     CI_ENVIRONMENT_VARIABLES.map((name) => [name, process.env[name]]),
   );
   const previousFetch = globalThis.fetch;
-  let calls = 0;
 
   for (const name of CI_ENVIRONMENT_VARIABLES) delete process.env[name];
   process.env.PI_TELEMETRY = "1";
   process.env.PI_CODING_AGENT_DIR = agentDir;
-  globalThis.fetch = async () => {
-    calls += 1;
-    if (calls === 1) throw new Error("temporary network failure");
-    return { ok: calls !== 2, status: calls === 2 ? 503 : 204 };
-  };
 
   try {
-    reportInstallTelemetry();
-    await waitFor(() => calls === 1);
-    assert.equal(await exists(statePath), false);
-
-    reportInstallTelemetry();
-    await waitFor(() => calls === 2);
-    assert.equal(await exists(statePath), false);
-
-    reportInstallTelemetry();
-    await waitFor(() => calls === 3 && exists(statePath));
-    assert.deepEqual(JSON.parse(await readFile(statePath, "utf8")), { lastReportedVersion: "0.1.0" });
-
-    reportInstallTelemetry();
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    assert.equal(calls, 3);
+    await callback({ statePath, lockPath });
   } finally {
     globalThis.fetch = previousFetch;
     for (const [name, value] of Object.entries(previousEnv)) {
@@ -86,4 +67,58 @@ test("retries telemetry after failed and non-OK reports", async () => {
     }
     await rm(agentDir, { recursive: true, force: true });
   }
+}
+
+test("retries telemetry after failed and non-OK reports", async () => {
+  await withTelemetryEnvironment(async ({ statePath, lockPath }) => {
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("temporary network failure");
+      return { ok: calls !== 2, status: calls === 2 ? 503 : 204 };
+    };
+
+    reportInstallTelemetry();
+    await waitFor(() => calls === 1);
+    await waitFor(async () => !(await exists(lockPath)));
+    assert.equal(await exists(statePath), false);
+
+    reportInstallTelemetry();
+    await waitFor(() => calls === 2);
+    await waitFor(async () => !(await exists(lockPath)));
+    assert.equal(await exists(statePath), false);
+
+    reportInstallTelemetry();
+    await waitFor(async () => calls === 3 && (await exists(statePath)));
+    assert.deepEqual(JSON.parse(await readFile(statePath, "utf8")), { lastReportedVersion: "0.1.0" });
+
+    reportInstallTelemetry();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(calls, 3);
+  });
+});
+
+test("serializes concurrent telemetry reports", async () => {
+  await withTelemetryEnvironment(async ({ statePath, lockPath }) => {
+    let calls = 0;
+    let release;
+    globalThis.fetch = async () => {
+      calls += 1;
+      await new Promise((resolve) => {
+        release = resolve;
+      });
+      return { ok: true, status: 204 };
+    };
+
+    reportInstallTelemetry();
+    await waitFor(() => calls === 1);
+    reportInstallTelemetry();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(calls, 1);
+
+    release();
+    await waitFor(async () => await exists(statePath));
+    await waitFor(async () => !(await exists(lockPath)));
+    assert.equal(calls, 1);
+  });
 });

--- a/packages/pi-fast/tests/install-telemetry.test.mjs
+++ b/packages/pi-fast/tests/install-telemetry.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import test from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { reportInstallTelemetry } = await import("../src/install-telemetry.ts");
+
+const CI_ENVIRONMENT_VARIABLES = [
+  "CI",
+  "APPVEYOR",
+  "BITBUCKET_BUILD_NUMBER",
+  "BUILDKITE",
+  "CIRCLECI",
+  "CODESPACES",
+  "DRONE",
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "JENKINS_URL",
+  "NETLIFY",
+  "TEAMCITY_VERSION",
+  "TF_BUILD",
+  "TRAVIS",
+  "VERCEL",
+  "PI_OFFLINE",
+  "PI_TELEMETRY",
+  "PI_CODING_AGENT_DIR",
+];
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(predicate) {
+  const deadline = Date.now() + 1000;
+  while (!(await predicate())) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for telemetry work.");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+test("retries telemetry after failed and non-OK reports", async () => {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-fast-telemetry-"));
+  const statePath = join(agentDir, "extensions", "pi-fast-install.json");
+  const previousEnv = Object.fromEntries(
+    CI_ENVIRONMENT_VARIABLES.map((name) => [name, process.env[name]]),
+  );
+  const previousFetch = globalThis.fetch;
+  let calls = 0;
+
+  for (const name of CI_ENVIRONMENT_VARIABLES) delete process.env[name];
+  process.env.PI_TELEMETRY = "1";
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) throw new Error("temporary network failure");
+    return { ok: calls !== 2, status: calls === 2 ? 503 : 204 };
+  };
+
+  try {
+    reportInstallTelemetry();
+    await waitFor(() => calls === 1);
+    assert.equal(await exists(statePath), false);
+
+    reportInstallTelemetry();
+    await waitFor(() => calls === 2);
+    assert.equal(await exists(statePath), false);
+
+    reportInstallTelemetry();
+    await waitFor(() => calls === 3 && exists(statePath));
+    assert.deepEqual(JSON.parse(await readFile(statePath, "utf8")), { lastReportedVersion: "0.1.0" });
+
+    reportInstallTelemetry();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(calls, 3);
+  } finally {
+    globalThis.fetch = previousFetch;
+    for (const [name, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});

--- a/packages/pi-fast/tsconfig.json
+++ b/packages/pi-fast/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["index.ts", "src/**/*.ts", "extensions/**/*.ts"]
+}

--- a/packages/pi-goal/src/install-telemetry.ts
+++ b/packages/pi-goal/src/install-telemetry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -83,18 +83,30 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const version = getPackageVersion();
     const extensionsDir = join(getAgentDir(), "extensions");
     const statePath = join(extensionsDir, "pi-goal-install.json");
-    const state = readJsonFile(statePath) as InstallTelemetryState;
-    if (state.lastReportedVersion === version) return;
-
-    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
-      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
-      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
-
+    const lockPath = `${statePath}.lock`;
     await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    try {
+      await writeFile(lockPath, "", { flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+      throw error;
+    }
+
+    try {
+      const state = readJsonFile(statePath) as InstallTelemetryState;
+      if (state.lastReportedVersion === version) return;
+
+      const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+        headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+        signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+      await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    } finally {
+      await rm(lockPath, { force: true });
+    }
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-goal/src/install-telemetry.ts
+++ b/packages/pi-goal/src/install-telemetry.ts
@@ -86,14 +86,15 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const state = readJsonFile(statePath) as InstallTelemetryState;
     if (state.lastReportedVersion === version) return;
 
-    await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
-
     const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
       headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
       signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
     });
+    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-goal/src/install-telemetry.ts
+++ b/packages/pi-goal/src/install-telemetry.ts
@@ -97,6 +97,7 @@ async function reportInstallTelemetryAsync(): Promise<void> {
       if (state.lastReportedVersion === version) return;
 
       const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
       const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
         headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
         signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),

--- a/packages/pi-insomnia/src/install-telemetry.ts
+++ b/packages/pi-insomnia/src/install-telemetry.ts
@@ -86,14 +86,15 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const state = readJsonFile(statePath) as InstallTelemetryState;
     if (state.lastReportedVersion === version) return;
 
-    await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
-
     const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
       headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
       signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
     });
+    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-insomnia/src/install-telemetry.ts
+++ b/packages/pi-insomnia/src/install-telemetry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -83,18 +83,30 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const version = getPackageVersion();
     const extensionsDir = join(getAgentDir(), "extensions");
     const statePath = join(extensionsDir, "pi-insomnia-install.json");
-    const state = readJsonFile(statePath) as InstallTelemetryState;
-    if (state.lastReportedVersion === version) return;
-
-    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
-      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
-      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
-
+    const lockPath = `${statePath}.lock`;
     await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    try {
+      await writeFile(lockPath, "", { flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+      throw error;
+    }
+
+    try {
+      const state = readJsonFile(statePath) as InstallTelemetryState;
+      if (state.lastReportedVersion === version) return;
+
+      const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+        headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+        signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+      await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    } finally {
+      await rm(lockPath, { force: true });
+    }
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-insomnia/src/install-telemetry.ts
+++ b/packages/pi-insomnia/src/install-telemetry.ts
@@ -97,6 +97,7 @@ async function reportInstallTelemetryAsync(): Promise<void> {
       if (state.lastReportedVersion === version) return;
 
       const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
       const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
         headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
         signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),

--- a/packages/pi-scout/src/install-telemetry.ts
+++ b/packages/pi-scout/src/install-telemetry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -83,18 +83,30 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const version = getPackageVersion();
     const extensionsDir = join(getAgentDir(), "extensions");
     const statePath = join(extensionsDir, "pi-scout-install.json");
-    const state = readJsonFile(statePath) as InstallTelemetryState;
-    if (state.lastReportedVersion === version) return;
-
-    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
-      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
-      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
-
+    const lockPath = `${statePath}.lock`;
     await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    try {
+      await writeFile(lockPath, "", { flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+      throw error;
+    }
+
+    try {
+      const state = readJsonFile(statePath) as InstallTelemetryState;
+      if (state.lastReportedVersion === version) return;
+
+      const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+        headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+        signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+      await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    } finally {
+      await rm(lockPath, { force: true });
+    }
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-scout/src/install-telemetry.ts
+++ b/packages/pi-scout/src/install-telemetry.ts
@@ -86,14 +86,15 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const state = readJsonFile(statePath) as InstallTelemetryState;
     if (state.lastReportedVersion === version) return;
 
-    await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
-
     const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
       headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
       signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
     });
+    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-scout/src/install-telemetry.ts
+++ b/packages/pi-scout/src/install-telemetry.ts
@@ -97,6 +97,7 @@ async function reportInstallTelemetryAsync(): Promise<void> {
       if (state.lastReportedVersion === version) return;
 
       const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
       const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
         headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
         signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),

--- a/packages/pi-skillful/src/install-telemetry.ts
+++ b/packages/pi-skillful/src/install-telemetry.ts
@@ -86,14 +86,15 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const state = readJsonFile(statePath) as InstallTelemetryState;
     if (state.lastReportedVersion === version) return;
 
-    await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
-
     const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
       headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
       signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
     });
+    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-skillful/src/install-telemetry.ts
+++ b/packages/pi-skillful/src/install-telemetry.ts
@@ -97,6 +97,7 @@ async function reportInstallTelemetryAsync(): Promise<void> {
       if (state.lastReportedVersion === version) return;
 
       const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
       const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
         headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
         signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),

--- a/packages/pi-skillful/src/install-telemetry.ts
+++ b/packages/pi-skillful/src/install-telemetry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
@@ -83,18 +83,30 @@ async function reportInstallTelemetryAsync(): Promise<void> {
     const version = getPackageVersion();
     const extensionsDir = join(getAgentDir(), "extensions");
     const statePath = join(extensionsDir, "skillful-install.json");
-    const state = readJsonFile(statePath) as InstallTelemetryState;
-    if (state.lastReportedVersion === version) return;
-
-    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
-      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
-      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
-
+    const lockPath = `${statePath}.lock`;
     await mkdir(extensionsDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    try {
+      await writeFile(lockPath, "", { flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+      throw error;
+    }
+
+    try {
+      const state = readJsonFile(statePath) as InstallTelemetryState;
+      if (state.lastReportedVersion === version) return;
+
+      const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+        headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+        signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+      await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`, "utf8");
+    } finally {
+      await rm(lockPath, { force: true });
+    }
   } catch {
     // Best-effort telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-web-kit/src/install-telemetry.ts
+++ b/packages/pi-web-kit/src/install-telemetry.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 
@@ -52,18 +52,30 @@ export async function reportInstallTelemetry(): Promise<void> {
     const version = getPackageVersion();
     const telemetryDir = join(getAgentDir(), "extensions");
     const statePath = join(telemetryDir, "pi-web-kit-install.json");
-    const state = readJsonFile(statePath) as InstallTelemetryState;
-    if (state.lastReportedVersion === version) return;
-
-    const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
-      headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
-      signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
-
+    const lockPath = `${statePath}.lock`;
     await mkdir(telemetryDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`);
+    try {
+      await writeFile(lockPath, "", { flag: "wx" });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+      throw error;
+    }
+
+    try {
+      const state = readJsonFile(statePath) as InstallTelemetryState;
+      if (state.lastReportedVersion === version) return;
+
+      const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+        headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
+        signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+      await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`);
+    } finally {
+      await rm(lockPath, { force: true });
+    }
   } catch {
     // Best-effort install telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-web-kit/src/install-telemetry.ts
+++ b/packages/pi-web-kit/src/install-telemetry.ts
@@ -55,14 +55,15 @@ export async function reportInstallTelemetry(): Promise<void> {
     const state = readJsonFile(statePath) as InstallTelemetryState;
     if (state.lastReportedVersion === version) return;
 
-    await mkdir(telemetryDir, { recursive: true });
-    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`);
-
     const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
-    await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
+    const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
       headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
       signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),
     });
+    if (!response.ok) throw new Error(`Install telemetry request failed: ${response.status}`);
+
+    await mkdir(telemetryDir, { recursive: true });
+    await writeFile(statePath, `${JSON.stringify({ lastReportedVersion: version }, null, 2)}\n`);
   } catch {
     // Best-effort install telemetry: ignore settings, filesystem, and network failures.
   }

--- a/packages/pi-web-kit/src/install-telemetry.ts
+++ b/packages/pi-web-kit/src/install-telemetry.ts
@@ -66,6 +66,7 @@ export async function reportInstallTelemetry(): Promise<void> {
       if (state.lastReportedVersion === version) return;
 
       const params = new URLSearchParams({ tool: PACKAGE_NAME, version });
+      // codeql[js/file-access-to-http] `version` is the install telemetry package version read from package.json; it is not user-controlled input and the telemetry endpoint already trusts the package name.
       const response = await fetch(`${INSTALL_TELEMETRY_URL}?${params.toString()}`, {
         headers: { "User-Agent": getInstallTelemetryUserAgent(version) },
         signal: AbortSignal.timeout(INSTALL_TELEMETRY_TIMEOUT_MS),


### PR DESCRIPTION
## Summary

- Add `pi-fast`, a session-local Fast-mode toggle for supported OpenAI Codex models.
- Support `/fast [on|off|toggle]` and `Ctrl+Shift+F`.
- Inject `service_tier: "priority"` only when explicitly enabled for advertised models.
- Show `Fast on`, `Fast off`, or `Fast n/a` in the Pi footer.
- Add package documentation, security policy, telemetry, tests, root README entry, and workspace lockfile metadata.

## Validation

- [x] `npm run check`
- [x] `npm test`
- [x] `npm run pack:dry-run`
- [x] `npm run security:audit`
- [x] `npm run validate`
- [x] `npm ci --dry-run --no-audit --no-fund`
- [x] `npm run validate:packages`
- [x] `semgrep scan --config p/default --error` (full repository: 0 findings)

## Security and privacy checklist

- [x] No API keys, tokens, auth headers, local Pi settings, provider configs with secrets, or machine-specific paths are committed.
- [x] The telemetry data flow is documented in `packages/pi-fast/SECURITY.md`; it sends only package/version and runtime metadata to the fixed HTTPS endpoint.
- [x] No new config values store secrets.
- [x] No prompts, credentials, auth headers, or provider responses are logged or persisted.
- [x] Package `files` entries include only intended runtime/docs assets.
- [x] Security implications are documented in README/SECURITY/CHANGELOG.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pi-fast`, enabling session-local Fast mode through the `/fast` command or keyboard shortcut.
  * Supports eligible OpenAI Codex models and displays the current mode in the interface.
  * Fast mode remains disabled by default and warns when the selected model is unsupported.
  * Added privacy-conscious, optional installation telemetry.

* **Bug Fixes**
  * Prevented failed telemetry requests from being recorded as successful installations.

* **Documentation**
  * Added usage, security, contribution, licensing, and community guidance.

* **Tests**
  * Added coverage for toggling, model support, request handling, telemetry, and status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->