### PR TITLE
Add pi-codex-tools package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each package installs independently. Pick the capability you need, then follow i
 | Need | Package | What it adds |
 | --- | --- | --- |
 | Use supported provider fast modes on demand | [pi-fast](./packages/pi-fast) | Session-local Fast toggles for provider/model pairs that advertise faster processing. |
+| Give grammar-capable Codex models their native patch tool | [pi-codex-tools](./packages/pi-codex-tools) | Raw `apply_patch` grammar tooling with safe local mutation and model-aware activation. |
 | Use Codex provider-side compaction | [pi-codex-compaction](./packages/pi-codex-compaction) | RemoteCompactionV2 checkpoints for supported OpenAI Codex sessions. |
 
 ### Research and create

--- a/package-lock.json
+++ b/package-lock.json
@@ -4129,6 +4129,10 @@
       "resolved": "packages/pi-codex-image-gen",
       "link": true
     },
+    "node_modules/pi-codex-tools": {
+      "resolved": "packages/pi-codex-tools",
+      "link": true
+    },
     "node_modules/pi-compound-engineering": {
       "resolved": "packages/pi-compound-engineering",
       "link": true
@@ -4441,6 +4445,36 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.6.tgz",
       "integrity": "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/pi-codex-tools": {
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mocito/install-telemetry": "0.1.1"
+      },
+      "devDependencies": {
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-coding-agent": "^0.80.10",
+        "@types/node": "^26.1.1",
+        "tsx": "^4.23.1",
+        "typebox": "^1.3.6",
+        "typescript": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*",
+        "typebox": "*"
+      }
+    },
+    "packages/pi-codex-tools/node_modules/typebox": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.10.tgz",
+      "integrity": "sha512-L0MT00X96q0P30f1NrGULgaSbmu8hfTjWbLULeVoM+j5u0jR5wyefoDquX2NmRa39f0KiNIBo1wWSaVvHJTZlA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4449,7 +4449,7 @@
       "license": "MIT"
     },
     "packages/pi-codex-tools": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@mocito/install-telemetry": "0.1.1"

--- a/packages/pi-codex-tools/.editorconfig
+++ b/packages/pi-codex-tools/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/pi-codex-tools/.gitignore
+++ b/packages/pi-codex-tools/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+*.tgz
+*.tsbuildinfo
+.DS_Store
+.env
+.env.*
+!.env.example
+npm-debug.log*

--- a/packages/pi-codex-tools/AGENTS.md
+++ b/packages/pi-codex-tools/AGENTS.md
@@ -1,0 +1,20 @@
+# pi-codex-tools Guidelines
+
+Root `AGENTS.md` applies.
+
+## Invariants
+
+- Keep `apply_patch` a raw OpenAI custom tool: use the Codex Lark grammar and never ask the model to JSON-wrap the patch.
+- Activate `apply_patch` only when the current model uses `openai-codex-responses` or `openai-responses` and explicitly advertises `compat.supportsOpenAIGrammarTools`.
+- Preserve unrelated active tools when switching models; only manage the Pi `edit` and `write` tools and this package's `apply_patch` tool.
+- Resolve patch paths under the current working directory, reject symlink escapes, use root-anchored descriptor-based no-follow operations on Linux/macOS, fail closed elsewhere, serialize mutations through `withFileMutationQueue`, and preflight every hunk before writing.
+- Do not add Codex's shell/session or code-mode tools without a separate sandbox/approval design; Pi already provides shell, read, and write tools.
+- Preserve OpenAI Codex attribution in `NOTICE` and the Apache-2.0 license for adapted grammar/parser behavior.
+
+## Validation
+
+```bash
+npm run -w packages/pi-codex-tools check
+npm test -w packages/pi-codex-tools
+npm run -w packages/pi-codex-tools pack:dry-run
+```

--- a/packages/pi-codex-tools/AGENTS.md
+++ b/packages/pi-codex-tools/AGENTS.md
@@ -7,7 +7,7 @@ Root `AGENTS.md` applies.
 - Keep `apply_patch` a raw OpenAI custom tool: use the Codex Lark grammar and never ask the model to JSON-wrap the patch.
 - Activate `apply_patch` only when the current model uses `openai-codex-responses` or `openai-responses` and explicitly advertises `compat.supportsOpenAIGrammarTools`.
 - Preserve unrelated active tools when switching models; only manage the Pi `edit` and `write` tools and this package's `apply_patch` tool.
-- Resolve patch paths under the current working directory, reject symlink escapes, use root-anchored descriptor-based no-follow operations on Linux/macOS, fail closed elsewhere, serialize mutations through `withFileMutationQueue`, and preflight every hunk before writing.
+- Resolve patch paths under the current working directory, reject symlink escapes, use root-anchored descriptor-based no-follow operations on Linux, fail closed elsewhere, serialize mutations through `withFileMutationQueue`, and preflight every hunk before writing.
 - Do not add Codex's shell/session or code-mode tools without a separate sandbox/approval design; Pi already provides shell, read, and write tools.
 - Preserve OpenAI Codex attribution in `NOTICE` and the Apache-2.0 license for adapted grammar/parser behavior.
 

--- a/packages/pi-codex-tools/CHANGELOG.md
+++ b/packages/pi-codex-tools/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project follows the spirit of [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and uses semantic versioning.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-08-03
+
+### Added
+
+- Initial `pi-codex-tools` extension.
+- Codex-compatible raw `apply_patch` grammar tooling and capability-based model activation.
+- Supported models replace Pi's `edit` and `write` tools with `apply_patch` and restore their previous active states when switching models.
+
+### Fixed
+
+- Preserve indented patch marker lines as update context instead of interpreting them as control markers.
+- Anchor filesystem mutations to no-follow directory descriptors on Linux/macOS and fail closed on unsupported platforms.
+- Bound target-file reads and use linear hunk matching to prevent unbounded memory and quadratic matching work.

--- a/packages/pi-codex-tools/CHANGELOG.md
+++ b/packages/pi-codex-tools/CHANGELOG.md
@@ -6,6 +6,16 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-08-04
+
+### Fixed
+
+- Guard `apply_patch` execution when the active model does not advertise grammar-tool support.
+- Require the Pi runtime grammar-tool contract and fail closed on unsupported filesystem platforms.
+- Preflight repeated file hunks sequentially without rejecting valid Codex patches.
+- Respect `enableInstallTelemetry: false` even when `PI_TELEMETRY` is enabled.
+- Document credential-containing target reads, telemetry controls, runtime requirements, and line-oriented compatibility.
+
 ## [0.1.0] - 2026-08-03
 
 ### Added

--- a/packages/pi-codex-tools/CODE_OF_CONDUCT.md
+++ b/packages/pi-codex-tools/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best for the community, rather than us as individuals
+
+Examples of unacceptable behavior by participants include:
+
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at jose@mocito.dev. All complaints will be reviewed and investigated promptly and fairly.
+
+Community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/packages/pi-codex-tools/CONTRIBUTING.md
+++ b/packages/pi-codex-tools/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Thanks for your interest in contributing to `pi-codex-tools`.
+
+## Development setup
+
+```bash
+npm install
+npm run -w packages/pi-codex-tools check
+```
+
+This package is source-distributed: Pi loads the TypeScript extension files directly. There is no build step for runtime use.
+
+## Pull request checklist
+
+Before opening a pull request:
+
+- Run `npm run -w packages/pi-codex-tools check`.
+- Run `npm test -w packages/pi-codex-tools`.
+- Run `npm audit --omit=dev`.
+- Run `npm run -w packages/pi-codex-tools pack:dry-run` and confirm the package contents are intentional.
+- Update `README.md` if user-visible behavior changes.
+- Update `CHANGELOG.md` for notable changes.
+- Keep examples and paths generic; do not commit API keys, tokens, auth headers, local settings, or provider configuration containing secrets.
+
+## Coding guidelines
+
+- Keep model capability checks explicit and conservative; never switch on model names alone.
+- Keep raw grammar input separate from JSON tool arguments.
+- Add regression coverage for parser, path-safety, mutation, or model-switching changes.
+- Preserve OpenAI Codex attribution when changing adapted parser or grammar behavior.
+
+## Code of conduct
+
+This project follows the Contributor Covenant Code of Conduct.

--- a/packages/pi-codex-tools/LICENSE
+++ b/packages/pi-codex-tools/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright 2025 OpenAI
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/pi-codex-tools/NOTICE
+++ b/packages/pi-codex-tools/NOTICE
@@ -1,0 +1,6 @@
+pi-codex-tools includes code and grammar behavior derived from OpenAI Codex.
+
+OpenAI Codex
+Copyright 2025 OpenAI
+
+This project includes code derived from OpenAI Codex and is distributed under the Apache License, Version 2.0. See LICENSE for the license text.

--- a/packages/pi-codex-tools/README.md
+++ b/packages/pi-codex-tools/README.md
@@ -6,7 +6,7 @@ Give grammar-capable OpenAI/Codex models the Codex `apply_patch` tool in Pi with
 
 - **Raw `apply_patch`** — sends Codex's Lark grammar as an OpenAI custom tool, so patches are not JSON-wrapped.
 - **Capability-based activation** — requires `openai-codex-responses` or `openai-responses` plus `model.compat.supportsOpenAIGrammarTools === true`; model names alone are never enough.
-- **Safe local mutation** — patches are limited to 1 MiB, target files to 64 MiB, stay under Pi's current working directory, reject symlink escapes, use descriptor-anchored no-follow operations on Linux/macOS, fail closed elsewhere, preflight all hunks, and serialize writes with Pi's mutation queue.
+- **Safe local mutation** — patches are limited to 1 MiB, target files to 64 MiB, stay under Pi's current working directory, reject symlink escapes, use descriptor-anchored no-follow operations on Linux, fail closed elsewhere, preflight all hunks, and serialize writes with Pi's mutation queue.
 - **Model switching** — supported models replace Pi's `edit` and `write` tools with `apply_patch`; other active tools are preserved. Switching back restores only the file tools that were active before the switch.
 - **Sequential patch calls** — the extension marks patch execution sequential and disables provider-side parallel tool calls when the patch tool is active.
 
@@ -24,7 +24,7 @@ pi -e /path/to/pi-mono/packages/pi-codex-tools
 
 ## Scope decisions
 
-The current Codex source does not define separate `read_file` or `write_file` tools: file inspection is normally done through shell commands and file mutation through `apply_patch`. This package keeps Pi's bounded `read` and `bash` tools, and uses `apply_patch` in place of Pi's `edit` and `write` tools for supported models. Because Pi does not provide Codex's OS-level filesystem sandbox, `apply_patch` runs only on Linux/macOS and fails closed on unsupported platforms.
+The current Codex source does not define separate `read_file` or `write_file` tools: file inspection is normally done through shell commands and file mutation through `apply_patch`. This package keeps Pi's bounded `read` and `bash` tools, and uses `apply_patch` in place of Pi's `edit` and `write` tools for supported models. Because Pi does not provide Codex's OS-level filesystem sandbox, `apply_patch` runs only on Linux and fails closed on unsupported platforms. It also requires a Pi model runtime that advertises `compat.supportsOpenAIGrammarTools`; older runtimes leave the tool inactive.
 
 | Codex surface | Decision |
 | --- | --- |
@@ -48,6 +48,8 @@ These choices are based on the Codex tool specifications in `codex-rs/core/src/t
 
 These behaviors intentionally match Codex `apply_patch`.
 
+The provider contract is runtime-specific: use Pi 0.83.0 or newer for OpenAI grammar-tool support. For a manual smoke test, start Pi with this extension and a model that advertises `supportsOpenAIGrammarTools`, then verify that a file change appears as an `apply_patch` call and not as `edit`, `write`, or `bash`.
+
 ## Development
 
 ```bash
@@ -56,7 +58,7 @@ npm test -w packages/pi-codex-tools
 npm run -w packages/pi-codex-tools pack:dry-run
 ```
 
-Install/update telemetry can be disabled with `PI_OFFLINE=1` or `PI_TELEMETRY=0`.
+Install/update telemetry is disabled in CI and can be disabled with `PI_OFFLINE=1`, `PI_TELEMETRY=0` or `PI_TELEMETRY=false`, or Pi's `enableInstallTelemetry: false` setting. See [SECURITY.md](./SECURITY.md).
 
 ## License
 

--- a/packages/pi-codex-tools/README.md
+++ b/packages/pi-codex-tools/README.md
@@ -1,0 +1,63 @@
+# pi-codex-tools
+
+Give grammar-capable OpenAI/Codex models the Codex `apply_patch` tool in Pi without changing Pi's normal tools for other models.
+
+## What it adds
+
+- **Raw `apply_patch`** — sends Codex's Lark grammar as an OpenAI custom tool, so patches are not JSON-wrapped.
+- **Capability-based activation** — requires `openai-codex-responses` or `openai-responses` plus `model.compat.supportsOpenAIGrammarTools === true`; model names alone are never enough.
+- **Safe local mutation** — patches are limited to 1 MiB, target files to 64 MiB, stay under Pi's current working directory, reject symlink escapes, use descriptor-anchored no-follow operations on Linux/macOS, fail closed elsewhere, preflight all hunks, and serialize writes with Pi's mutation queue.
+- **Model switching** — supported models replace Pi's `edit` and `write` tools with `apply_patch`; other active tools are preserved. Switching back restores only the file tools that were active before the switch.
+- **Sequential patch calls** — the extension marks patch execution sequential and disables provider-side parallel tool calls when the patch tool is active.
+
+## Installation
+
+```bash
+pi install npm:pi-codex-tools
+```
+
+For a one-off run:
+
+```bash
+pi -e /path/to/pi-mono/packages/pi-codex-tools
+```
+
+## Scope decisions
+
+The current Codex source does not define separate `read_file` or `write_file` tools: file inspection is normally done through shell commands and file mutation through `apply_patch`. This package keeps Pi's bounded `read` and `bash` tools, and uses `apply_patch` in place of Pi's `edit` and `write` tools for supported models. Because Pi does not provide Codex's OS-level filesystem sandbox, `apply_patch` runs only on Linux/macOS and fails closed on unsupported platforms.
+
+| Codex surface | Decision |
+| --- | --- |
+| `apply_patch` | Included; it is a materially different freeform grammar tool. |
+| `shell_command` | Deferred; Pi already has the bounded shell backend, while a faithful adapter needs Codex's approval and working-directory contract. |
+| `exec_command` + `write_stdin` | Deferred; persistent PTY sessions need a separate process/session design. |
+| `view_image` | Deferred; Pi's `read` already sends supported images as attachments. |
+| `update_plan` | Deferred; it is workflow metadata rather than a capability-specific file tool. |
+| Code Mode `exec` + `wait` | Deferred; it requires a real sandbox for model-authored JavaScript, not Node's ordinary `vm` wrapper. |
+
+These choices are based on the Codex tool specifications in `codex-rs/core/src/tools`, the model profiles in `codex-rs/models-manager/models.json`, and the Code Mode protocol. They intentionally keep this package focused on the one tool with a distinct transport and model-facing contract.
+
+## Compatibility notes
+
+`apply_patch` is line-oriented rather than byte-oriented:
+
+- `*** Add File` requires at least one `+` line and writes a trailing newline. A `+`-only hunk creates a one-newline file, not a zero-byte file.
+- Updates produce a trailing newline for non-empty output, so updating a file that lacks one may add it.
+- Existing CRLF line endings are preserved when detected.
+- Use `bash` when exact byte-level output or a truly empty file is required.
+
+These behaviors intentionally match Codex `apply_patch`.
+
+## Development
+
+```bash
+npm run -w packages/pi-codex-tools check
+npm test -w packages/pi-codex-tools
+npm run -w packages/pi-codex-tools pack:dry-run
+```
+
+Install/update telemetry can be disabled with `PI_OFFLINE=1` or `PI_TELEMETRY=0`.
+
+## License
+
+This package is Apache-2.0 licensed because its grammar/parser behavior is adapted from OpenAI Codex. See [NOTICE](./NOTICE).

--- a/packages/pi-codex-tools/SECURITY.md
+++ b/packages/pi-codex-tools/SECURITY.md
@@ -19,7 +19,7 @@ Report privately through [GitHub Security Advisories](https://github.com/jvm/pi-
 
 Pi extensions execute with the same permissions as the local user running Pi. Review installed extensions and only install packages from sources you trust.
 
-`apply_patch` does not access the network or credentials. It validates paths beneath the current working directory, rejects symlink paths and symlinked parents, limits patch input to 1 MiB and target-file reads to 64 MiB, preflights file changes before writing, and uses root-anchored descriptor-based no-follow operations on Linux/macOS. It fails closed on unsupported platforms because Pi does not provide Codex's OS-level filesystem sandbox. A failure during a multi-file write can still leave earlier files changed; callers should use version control and review the resulting diff.
+`apply_patch` does not access the network or credential APIs. It can read credential-containing files when a patch targets them. It validates paths beneath the current working directory, rejects symlink paths and symlinked parents, limits patch input to 1 MiB and target-file reads to 64 MiB, preflights file changes before writing, and uses root-anchored descriptor-based no-follow operations on Linux. It fails closed on unsupported platforms because Pi does not provide Codex's OS-level filesystem sandbox. A failure during a multi-file write can still leave earlier files changed; callers should use version control and review the resulting diff.
 
 The package reads the current provider/model capability flags only to select tools. It does not log prompts, patches, file contents, credentials, auth headers, or provider responses.
 

--- a/packages/pi-codex-tools/SECURITY.md
+++ b/packages/pi-codex-tools/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the latest released version of `pi-codex-tools`.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for suspected security vulnerabilities.
+
+Report privately through [GitHub Security Advisories](https://github.com/jvm/pi-mono/security/advisories/new) or by contacting the repository maintainer through GitHub. Include:
+
+- a description of the issue;
+- steps to reproduce;
+- affected versions or commits, if known;
+- any suggested mitigation.
+
+## Security model
+
+Pi extensions execute with the same permissions as the local user running Pi. Review installed extensions and only install packages from sources you trust.
+
+`apply_patch` does not access the network or credentials. It validates paths beneath the current working directory, rejects symlink paths and symlinked parents, limits patch input to 1 MiB and target-file reads to 64 MiB, preflights file changes before writing, and uses root-anchored descriptor-based no-follow operations on Linux/macOS. It fails closed on unsupported platforms because Pi does not provide Codex's OS-level filesystem sandbox. A failure during a multi-file write can still leave earlier files changed; callers should use version control and review the resulting diff.
+
+The package reads the current provider/model capability flags only to select tools. It does not log prompts, patches, file contents, credentials, auth headers, or provider responses.
+
+Install/update telemetry is best effort and can be disabled with `PI_OFFLINE=1`, `PI_TELEMETRY=0`, CI detection, or Pi's `enableInstallTelemetry: false` setting. It sends only package/version and runtime metadata through `@mocito/install-telemetry`.

--- a/packages/pi-codex-tools/SECURITY.md
+++ b/packages/pi-codex-tools/SECURITY.md
@@ -23,4 +23,4 @@ Pi extensions execute with the same permissions as the local user running Pi. Re
 
 The package reads the current provider/model capability flags only to select tools. It does not log prompts, patches, file contents, credentials, auth headers, or provider responses.
 
-Install/update telemetry is best effort and can be disabled with `PI_OFFLINE=1`, `PI_TELEMETRY=0`, CI detection, or Pi's `enableInstallTelemetry: false` setting. It sends only package/version and runtime metadata through `@mocito/install-telemetry`.
+Install/update telemetry is best effort and can be disabled with `PI_OFFLINE=1`, `PI_TELEMETRY=0`, `PI_TELEMETRY=false`, CI detection, or Pi's `enableInstallTelemetry: false` setting. Through `@mocito/install-telemetry`, it sends the package name and version as HTTPS URL query parameters and adds `process.platform`, the runtime name/version, and `process.arch` to the `User-Agent`. These fields are not intended to identify a host, user, repository, or path; no prompts, patches, file contents, credentials, auth headers, or provider responses are sent.

--- a/packages/pi-codex-tools/extensions/index.ts
+++ b/packages/pi-codex-tools/extensions/index.ts
@@ -1,0 +1,94 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { reportInstallTelemetry } from "../src/install-telemetry.js";
+import { applyPatch, APPLY_PATCH_GRAMMAR, MAX_PATCH_BYTES } from "../src/apply-patch.js";
+import { createFreeformInputSchema, createOpenAILarkSampling, type OpenAIGrammarSampling } from "../src/grammar.js";
+import { supportsOpenAIGrammarTools } from "../src/model-support.js";
+
+const APPLY_PATCH = "apply_patch";
+const EDIT = "edit";
+const WRITE = "write";
+const REPLACED_TOOLS = [EDIT, WRITE] as const;
+type ReplacedTool = (typeof REPLACED_TOOLS)[number];
+
+const APPLY_PATCH_PARAMETERS = createFreeformInputSchema(
+  "patch",
+  "Raw Codex apply_patch text. Do not wrap it in JSON.",
+);
+
+export default function piCodexTools(pi: ExtensionAPI): void {
+  reportInstallTelemetry();
+
+  const registerGrammarTool = pi.registerTool as (tool: Parameters<ExtensionAPI["registerTool"]>[0] & {
+    constrainedSampling?: OpenAIGrammarSampling;
+  }) => void;
+
+  registerGrammarTool({
+    name: APPLY_PATCH,
+    label: APPLY_PATCH,
+    description: "Apply a Codex patch to files. This is a FREEFORM tool: send the patch text directly, never as JSON.",
+    promptSnippet: "Apply Codex-format file patches without JSON wrapping",
+    promptGuidelines: [
+      "Use apply_patch for file changes when it is available.",
+      "Send the patch body directly; do not wrap it in JSON or add a shell heredoc.",
+      `Patch paths must stay inside the current working directory and patches are limited to ${MAX_PATCH_BYTES} bytes.`,
+    ],
+    parameters: APPLY_PATCH_PARAMETERS,
+    constrainedSampling: createOpenAILarkSampling(APPLY_PATCH_GRAMMAR),
+    executionMode: "sequential",
+    async execute(_toolCallId, rawParams, signal, _onUpdate, ctx) {
+      const patch = (rawParams as { patch?: unknown }).patch;
+      if (typeof patch !== "string") throw new Error("apply_patch requires raw patch text.");
+      const result = await applyPatch(patch, { cwd: ctx.cwd, signal });
+      const summary = result.changes
+        .map((change) => `${change.kind[0].toUpperCase()}${change.kind.slice(1)} ${change.path}${change.moveTo ? ` -> ${change.moveTo}` : ""}`)
+        .join("\n");
+      return { content: [{ type: "text", text: `Applied patch:\n${summary}` }], details: result };
+    },
+  });
+
+  let replacedToolsWasActive: Record<ReplacedTool, boolean> | undefined;
+
+  function synchronizeTools(ctx: ExtensionContext): void {
+    if (typeof pi.getActiveTools !== "function" || typeof pi.setActiveTools !== "function") return;
+
+    const active = new Set(pi.getActiveTools());
+    if (supportsOpenAIGrammarTools(ctx.model)) {
+      if (replacedToolsWasActive === undefined) {
+        replacedToolsWasActive = {
+          edit: active.has(EDIT),
+          write: active.has(WRITE),
+        };
+      }
+      for (const tool of REPLACED_TOOLS) active.delete(tool);
+      active.add(APPLY_PATCH);
+    } else {
+      active.delete(APPLY_PATCH);
+      if (replacedToolsWasActive) {
+        for (const tool of REPLACED_TOOLS) {
+          if (replacedToolsWasActive[tool]) active.add(tool);
+        }
+      }
+      replacedToolsWasActive = undefined;
+    }
+    pi.setActiveTools([...active]);
+  }
+
+  pi.on("session_start", (_event, ctx) => {
+    synchronizeTools(ctx);
+  });
+
+  pi.on("model_select", (_event, ctx) => {
+    synchronizeTools(ctx);
+  });
+
+  pi.on("before_provider_request", (event, ctx) => {
+    if (!supportsOpenAIGrammarTools(ctx.model)) return;
+    if (typeof pi.getActiveTools !== "function" || !pi.getActiveTools().includes(APPLY_PATCH)) return;
+    if (!isRecord(event.payload) || event.payload.parallel_tool_calls !== true) return;
+    return { ...event.payload, parallel_tool_calls: false };
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/pi-codex-tools/extensions/index.ts
+++ b/packages/pi-codex-tools/extensions/index.ts
@@ -36,6 +36,9 @@ export default function piCodexTools(pi: ExtensionAPI): void {
     constrainedSampling: createOpenAILarkSampling(APPLY_PATCH_GRAMMAR),
     executionMode: "sequential",
     async execute(_toolCallId, rawParams, signal, _onUpdate, ctx) {
+      if (!supportsOpenAIGrammarTools(ctx.model)) {
+        throw new Error("apply_patch is only available for OpenAI models that advertise grammar-tool support.");
+      }
       const patch = (rawParams as { patch?: unknown }).patch;
       if (typeof patch !== "string") throw new Error("apply_patch requires raw patch text.");
       const result = await applyPatch(patch, { cwd: ctx.cwd, signal });

--- a/packages/pi-codex-tools/index.ts
+++ b/packages/pi-codex-tools/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./extensions/index.js";

--- a/packages/pi-codex-tools/package.json
+++ b/packages/pi-codex-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-tools",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Codex-compatible apply_patch tooling for Pi's grammar-capable OpenAI models.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/pi-codex-tools/package.json
+++ b/packages/pi-codex-tools/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "pi-codex-tools",
+  "version": "0.1.0",
+  "description": "Codex-compatible apply_patch tooling for Pi's grammar-capable OpenAI models.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "author": "Jose Mocito",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jvm/pi-mono.git",
+    "directory": "packages/pi-codex-tools"
+  },
+  "bugs": {
+    "url": "https://github.com/jvm/pi-mono/issues"
+  },
+  "homepage": "https://github.com/jvm/pi-mono/tree/main/packages/pi-codex-tools#readme",
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi",
+    "codex",
+    "openai",
+    "gpt-5",
+    "apply-patch"
+  ],
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "files": [
+    "index.ts",
+    "extensions",
+    "src",
+    "README.md",
+    "NOTICE",
+    "LICENSE",
+    "CHANGELOG.md",
+    "SECURITY.md",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md"
+  ],
+  "scripts": {
+    "check": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test tests/*.test.mjs",
+    "pack:dry-run": "npm pack --dry-run"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-ai": "^0.80.10",
+    "@earendil-works/pi-coding-agent": "^0.80.10",
+    "@types/node": "^26.1.1",
+    "tsx": "^4.23.1",
+    "typebox": "^1.3.6",
+    "typescript": "^7.0.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20.6.0"
+  },
+  "dependencies": {
+    "@mocito/install-telemetry": "0.1.1"
+  }
+}

--- a/packages/pi-codex-tools/src/apply-patch.ts
+++ b/packages/pi-codex-tools/src/apply-patch.ts
@@ -10,7 +10,7 @@ export const MAX_PATCH_HUNKS = 1_000;
 export const MAX_TARGET_FILE_BYTES = 64 * 1024 * 1024;
 
 const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
-const SECURE_FD_DIRECTORY = process.platform === "linux" ? "/proc/self/fd" : process.platform === "darwin" ? "/dev/fd" : undefined;
+const SECURE_FD_DIRECTORY = process.platform === "linux" ? "/proc/self/fd" : undefined;
 const SECURE_FILESYSTEM_SUPPORTED = SECURE_FD_DIRECTORY !== undefined && O_NOFOLLOW !== 0;
 const SECURE_DIRECTORY_FLAGS = constants.O_RDONLY | O_NOFOLLOW | (constants.O_DIRECTORY ?? 0) | (constants.O_NONBLOCK ?? 0);
 const SECURE_READ_FLAGS = constants.O_RDONLY | O_NOFOLLOW | (constants.O_NONBLOCK ?? 0);
@@ -225,6 +225,7 @@ type PlannedOperation =
   | { kind: "update"; path: string; displayPath: string; moveTo?: string; moveDisplayPath?: string; chunkGroups: UpdateChunk[][]; content: string };
 
 type SafePath = { absolute: string; exists: boolean; isDirectory: boolean; isFile: boolean };
+type VirtualFile = Omit<SafePath, "absolute"> & { content?: string };
 
 export async function applyPatch(input: string, options: ApplyPatchOptions): Promise<ApplyPatchResult> {
   requireSecureFilesystem();
@@ -271,77 +272,108 @@ export async function applyPatch(input: string, options: ApplyPatchOptions): Pro
 
 async function planOperations(hunks: ApplyPatchHunk[], root: string, rootHandle: FileHandle, signal?: AbortSignal): Promise<PlannedOperation[]> {
   const operations: PlannedOperation[] = [];
-  const byPath = new Map<string, PlannedOperation>();
-  const occupied = new Set<string>();
+  const virtualFiles = new Map<string, VirtualFile>();
+
+  const getVirtualFile = async (rawPath: string): Promise<{ absolute: string; file: VirtualFile }> => {
+    const absolute = resolvePatchPath(rawPath, root);
+    const existing = virtualFiles.get(absolute);
+    if (existing) return { absolute, file: existing };
+    const safe = await safePath(rawPath, root, signal);
+    const file: VirtualFile = {
+      exists: safe.exists,
+      isDirectory: safe.isDirectory,
+      isFile: safe.isFile,
+    };
+    virtualFiles.set(absolute, file);
+    return { absolute, file };
+  };
+
+  const getVirtualContent = async (absolute: string, file: VirtualFile): Promise<string> => {
+    if (!file.exists || !file.isFile) throw new Error(`Cannot read non-file '${absolute}'.`);
+    if (file.content === undefined) file.content = await readSecureFile(rootHandle, root, absolute, signal);
+    return file.content;
+  };
 
   for (const hunk of hunks) {
     throwIfAborted(signal);
-    const source = await safePath(hunk.path, root, signal);
-    if (occupied.has(source.absolute) && !(hunk.kind === "update" && byPath.get(source.absolute)?.kind === "update")) {
-      throw new Error(`Patch addresses '${hunk.path}' more than once.`);
-    }
+    const source = await getVirtualFile(hunk.path);
 
     if (hunk.kind === "add") {
-      if (source.isDirectory || (source.exists && !source.isFile)) throw new Error(`Cannot add file over non-file '${hunk.path}'.`);
-      const operation: PlannedOperation = { kind: "add", path: source.absolute, displayPath: displayPath(root, source.absolute, hunk.path), content: hunk.content };
-      operations.push(operation);
-      byPath.set(source.absolute, operation);
-      occupied.add(source.absolute);
+      if (source.file.isDirectory || (source.file.exists && !source.file.isFile)) {
+        throw new Error(`Cannot add file over non-file '${hunk.path}'.`);
+      }
+      source.file.exists = true;
+      source.file.isDirectory = false;
+      source.file.isFile = true;
+      source.file.content = hunk.content;
+      operations.push({
+        kind: "add",
+        path: source.absolute,
+        displayPath: displayPath(root, source.absolute, hunk.path),
+        content: hunk.content,
+      });
       continue;
     }
 
     if (hunk.kind === "delete") {
-      if (!source.exists) throw new Error(`Cannot delete missing file '${hunk.path}'.`);
-      if (source.isDirectory || !source.isFile) throw new Error(`Cannot delete non-file '${hunk.path}'.`);
-      const operation: PlannedOperation = { kind: "delete", path: source.absolute, displayPath: displayPath(root, source.absolute, hunk.path) };
-      operations.push(operation);
-      byPath.set(source.absolute, operation);
-      occupied.add(source.absolute);
+      if (!source.file.exists) throw new Error(`Cannot delete missing file '${hunk.path}'.`);
+      if (source.file.isDirectory || !source.file.isFile) throw new Error(`Cannot delete non-file '${hunk.path}'.`);
+      operations.push({ kind: "delete", path: source.absolute, displayPath: displayPath(root, source.absolute, hunk.path) });
+      source.file.exists = false;
+      source.file.content = undefined;
       continue;
     }
 
-    if (!source.exists) throw new Error(`Cannot update missing file '${hunk.path}'.`);
-    if (source.isDirectory || !source.isFile) throw new Error(`Cannot update non-file '${hunk.path}'.`);
-    const original = await readSecureFile(rootHandle, root, source.absolute, signal);
-    const moveTo = hunk.moveTo ? (await safePath(hunk.moveTo, root, signal)).absolute : undefined;
+    if (!source.file.exists) throw new Error(`Cannot update missing file '${hunk.path}'.`);
+    if (source.file.isDirectory || !source.file.isFile) throw new Error(`Cannot update non-file '${hunk.path}'.`);
+    const original = await getVirtualContent(source.absolute, source.file);
+    const moveTo = hunk.moveTo ? resolvePatchPath(hunk.moveTo, root) : undefined;
     if (moveTo === source.absolute) throw new Error(`Cannot move '${hunk.path}' onto itself.`);
+
+    let destination: { absolute: string; file: VirtualFile } | undefined;
     if (moveTo) {
-      const destination = await safePath(hunk.moveTo!, root, signal);
-      if (destination.isDirectory || (destination.exists && !destination.isFile)) throw new Error(`Cannot move file over non-file '${hunk.moveTo}'.`);
-      if (occupied.has(moveTo)) throw new Error(`Patch addresses move destination '${hunk.moveTo}' more than once.`);
-      occupied.add(moveTo);
+      destination = await getVirtualFile(hunk.moveTo!);
+      if (destination.file.isDirectory || (destination.file.exists && !destination.file.isFile)) {
+        throw new Error(`Cannot move file over non-file '${hunk.moveTo}'.`);
+      }
     }
 
-    const existing = byPath.get(source.absolute);
-    if (existing?.kind === "update") {
-      if (existing.moveTo || moveTo) throw new Error(`A file can only be moved once in a patch: '${hunk.path}'.`);
-      existing.chunkGroups.push(hunk.chunks);
-      existing.content = existing.chunkGroups.reduce(
-        (content, chunks) => applyUpdateContent(content, chunks, hunk.path),
-        original,
-      );
+    const content = applyUpdateContent(original, hunk.chunks, hunk.path);
+    if (destination) {
+      operations.push({
+        kind: "update",
+        path: source.absolute,
+        displayPath: displayPath(root, source.absolute, hunk.path),
+        moveTo: moveTo!,
+        moveDisplayPath: displayPath(root, moveTo!, hunk.moveTo!),
+        chunkGroups: [[...hunk.chunks]],
+        content,
+      });
+      source.file.exists = false;
+      source.file.content = undefined;
+      destination.file.exists = true;
+      destination.file.isDirectory = false;
+      destination.file.isFile = true;
+      destination.file.content = content;
       continue;
     }
 
-    const operation: PlannedOperation = {
-      kind: "update",
-      path: source.absolute,
-      displayPath: displayPath(root, source.absolute, hunk.path),
-      moveTo,
-      moveDisplayPath: moveTo ? displayPath(root, moveTo, hunk.moveTo!) : undefined,
-      chunkGroups: [[...hunk.chunks]],
-      content: applyUpdateContent(original, hunk.chunks, hunk.path),
-    };
-    operations.push(operation);
-    byPath.set(source.absolute, operation);
-    occupied.add(source.absolute);
+    const previous = operations.at(-1);
+    if (previous?.kind === "update" && previous.path === source.absolute && !previous.moveTo) {
+      previous.content = content;
+      previous.chunkGroups.push([...hunk.chunks]);
+    } else {
+      operations.push({
+        kind: "update",
+        path: source.absolute,
+        displayPath: displayPath(root, source.absolute, hunk.path),
+        chunkGroups: [[...hunk.chunks]],
+        content,
+      });
+    }
+    source.file.content = content;
   }
 
-  for (const operation of operations) {
-    if (operation.kind === "update" && operation.moveTo && byPath.has(operation.moveTo)) {
-      throw new Error(`Move destination '${operation.moveDisplayPath}' is also changed by this patch.`);
-    }
-  }
   return operations;
 }
 

--- a/packages/pi-codex-tools/src/apply-patch.ts
+++ b/packages/pi-codex-tools/src/apply-patch.ts
@@ -1,0 +1,652 @@
+// Adapted from OpenAI Codex apply-patch grammar/parser behavior; see NOTICE.
+import { constants } from "node:fs";
+import { lstat, mkdir, open, realpath, unlink } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+
+export const MAX_PATCH_BYTES = 1_048_576;
+export const MAX_PATCH_HUNKS = 1_000;
+export const MAX_TARGET_FILE_BYTES = 64 * 1024 * 1024;
+
+const O_NOFOLLOW = constants.O_NOFOLLOW ?? 0;
+const SECURE_FD_DIRECTORY = process.platform === "linux" ? "/proc/self/fd" : process.platform === "darwin" ? "/dev/fd" : undefined;
+const SECURE_FILESYSTEM_SUPPORTED = SECURE_FD_DIRECTORY !== undefined && O_NOFOLLOW !== 0;
+const SECURE_DIRECTORY_FLAGS = constants.O_RDONLY | O_NOFOLLOW | (constants.O_DIRECTORY ?? 0) | (constants.O_NONBLOCK ?? 0);
+const SECURE_READ_FLAGS = constants.O_RDONLY | O_NOFOLLOW | (constants.O_NONBLOCK ?? 0);
+const SECURE_UPDATE_FLAGS = constants.O_WRONLY | O_NOFOLLOW | constants.O_TRUNC | (constants.O_NONBLOCK ?? 0);
+const SECURE_CREATE_FLAGS = SECURE_UPDATE_FLAGS | constants.O_CREAT;
+const FILE_READ_CHUNK_BYTES = 64 * 1024;
+
+export const APPLY_PATCH_GRAMMAR = `start: begin_patch hunk+ end_patch
+begin_patch: "*** Begin Patch" LF
+end_patch: "*** End Patch" LF?
+
+hunk: add_hunk | delete_hunk | update_hunk
+add_hunk: "*** Add File: " filename LF add_line+
+delete_hunk: "*** Delete File: " filename LF
+update_hunk: "*** Update File: " filename LF change_move? change?
+filename: /(.+)/
+add_line: "+" /(.*)/ LF -> line
+
+change_move: "*** Move to: " filename LF
+change: (change_context | change_line)+ eof_line?
+change_context: ("@@" | "@@ " /(.+)/) LF
+change_line: ("+" | "-" | " ") /(.*)/ LF
+eof_line: "*** End of File" LF
+
+%import common.LF`;
+
+export interface UpdateChunk {
+  context?: string;
+  oldLines: string[];
+  newLines: string[];
+  endOfFile: boolean;
+}
+
+export type ApplyPatchHunk =
+  | { kind: "add"; path: string; content: string }
+  | { kind: "delete"; path: string }
+  | { kind: "update"; path: string; moveTo?: string; chunks: UpdateChunk[] };
+
+export interface ApplyPatchResult {
+  changes: Array<{ kind: "added" | "updated" | "deleted"; path: string; moveTo?: string }>;
+}
+
+export interface ApplyPatchOptions {
+  cwd: string;
+  signal?: AbortSignal;
+}
+
+export function parseApplyPatch(input: string): ApplyPatchHunk[] {
+  if (typeof input !== "string") throw new Error("apply_patch input must be a string.");
+  if (Buffer.byteLength(input, "utf8") > MAX_PATCH_BYTES) {
+    throw new Error(`apply_patch input exceeds the ${MAX_PATCH_BYTES}-byte limit.`);
+  }
+
+  const lines = input.replace(/\r\n?/g, "\n").trim().split("\n");
+  if (lines[0]?.trim() !== "*** Begin Patch") {
+    throw new Error("The first line of the patch must be '*** Begin Patch'.");
+  }
+  if (lines.at(-1)?.trim() !== "*** End Patch") {
+    throw new Error("The last line of the patch must be '*** End Patch'.");
+  }
+
+  const hunks: ApplyPatchHunk[] = [];
+  let index = 1;
+  while (index < lines.length - 1) {
+    const line = lines[index];
+    const trimmed = line.trim();
+    if (trimmed === "*** End Patch") break;
+    if (trimmed === "") {
+      throw new Error(`Unexpected blank line at patch line ${index + 1}.`);
+    }
+
+    if (trimmed.startsWith("*** Add File: ")) {
+      const path = headerPath(trimmed, "*** Add File: ", index + 1);
+      index++;
+      const content: string[] = [];
+      while (index < lines.length - 1 && !isHunkHeader(lines[index])) {
+        if (!lines[index].startsWith("+")) {
+          throw new Error(`Invalid add hunk at patch line ${index + 1}: every line must start with '+'.`);
+        }
+        content.push(lines[index].slice(1));
+        index++;
+      }
+      if (content.length === 0) {
+        throw new Error(`Add hunk for '${path}' must contain at least one line.`);
+      }
+      hunks.push({ kind: "add", path, content: `${content.join("\n")}\n` });
+      continue;
+    }
+
+    if (trimmed.startsWith("*** Delete File: ")) {
+      const path = headerPath(trimmed, "*** Delete File: ", index + 1);
+      hunks.push({ kind: "delete", path });
+      index++;
+      continue;
+    }
+
+    if (trimmed.startsWith("*** Update File: ")) {
+      const path = headerPath(trimmed, "*** Update File: ", index + 1);
+      index++;
+      let moveTo: string | undefined;
+      if (index < lines.length - 1 && lines[index].startsWith("*** Move to: ")) {
+        moveTo = headerPath(lines[index], "*** Move to: ", index + 1);
+        index++;
+      }
+
+      const chunks: UpdateChunk[] = [];
+      let current: UpdateChunk | undefined;
+      while (index < lines.length - 1 && !isUpdateBoundary(lines[index])) {
+        const raw = lines[index];
+        const currentLine = raw.trimEnd();
+
+        if (currentLine === "*** End of File") {
+          if (!current || (current.oldLines.length === 0 && current.newLines.length === 0)) {
+            throw new Error(`Update hunk for '${path}' has no change lines at patch line ${index + 1}.`);
+          }
+          current.endOfFile = true;
+          index++;
+          continue;
+        }
+
+        if (currentLine === "@@" || currentLine.startsWith("@@ ")) {
+          if (current && current.oldLines.length === 0 && current.newLines.length === 0) {
+            throw new Error(`Update hunk for '${path}' has an empty chunk at patch line ${index + 1}.`);
+          }
+          const context = currentLine === "@@" ? undefined : currentLine.slice(3);
+          current = {
+            ...(context === undefined ? {} : { context }),
+            oldLines: [],
+            newLines: [],
+            endOfFile: false,
+          };
+          chunks.push(current);
+          index++;
+          continue;
+        }
+
+        if (current?.endOfFile && currentLine === "") {
+          index++;
+          continue;
+        }
+
+        current ??= { oldLines: [], newLines: [], endOfFile: false };
+        if (raw === "") {
+          current.oldLines.push("");
+          current.newLines.push("");
+        } else if (raw.startsWith(" ")) {
+          const text = raw.slice(1);
+          current.oldLines.push(text);
+          current.newLines.push(text);
+        } else if (raw.startsWith("+")) {
+          current.newLines.push(raw.slice(1));
+        } else if (raw.startsWith("-")) {
+          current.oldLines.push(raw.slice(1));
+        } else {
+          throw new Error(
+            `Unexpected line at patch line ${index + 1}. Every update line must start with ' ', '+' or '-'.`,
+          );
+        }
+        index++;
+      }
+
+      if (chunks.length === 0 || chunks.every((chunk) => chunk.oldLines.length === 0 && chunk.newLines.length === 0)) {
+        throw new Error(`Update hunk for '${path}' must contain change lines.`);
+      }
+      hunks.push({ kind: "update", path, moveTo, chunks });
+      continue;
+    }
+
+    throw new Error(`Invalid hunk header at patch line ${index + 1}: '${line}'.`);
+  }
+
+  if (hunks.length === 0) {
+    throw new Error("Patch must contain at least one file hunk.");
+  }
+  if (hunks.length > MAX_PATCH_HUNKS) {
+    throw new Error(`Patch contains more than the ${MAX_PATCH_HUNKS}-hunk limit.`);
+  }
+  return hunks;
+}
+
+function isHunkHeader(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed.startsWith("*** Add File: ") ||
+    trimmed.startsWith("*** Delete File: ") ||
+    trimmed.startsWith("*** Update File: ") ||
+    trimmed === "*** End Patch"
+  );
+}
+
+function isUpdateBoundary(line: string): boolean {
+  // Keep leading whitespace: one leading space is the update context marker.
+  const currentLine = line.trimEnd();
+  return (
+    currentLine.startsWith("*** Add File: ") ||
+    currentLine.startsWith("*** Delete File: ") ||
+    currentLine.startsWith("*** Update File: ") ||
+    currentLine === "*** End Patch"
+  );
+}
+
+function headerPath(line: string, marker: string, lineNumber: number): string {
+  const path = line.slice(marker.length).trim();
+  if (!path) throw new Error(`Missing path at patch line ${lineNumber}.`);
+  if (path.includes("\0")) throw new Error(`NUL byte in path at patch line ${lineNumber}.`);
+  return path;
+}
+
+type PlannedOperation =
+  | { kind: "add"; path: string; displayPath: string; content: string }
+  | { kind: "delete"; path: string; displayPath: string }
+  | { kind: "update"; path: string; displayPath: string; moveTo?: string; moveDisplayPath?: string; chunkGroups: UpdateChunk[][]; content: string };
+
+type SafePath = { absolute: string; exists: boolean; isDirectory: boolean; isFile: boolean };
+
+export async function applyPatch(input: string, options: ApplyPatchOptions): Promise<ApplyPatchResult> {
+  requireSecureFilesystem();
+  const hunks = parseApplyPatch(input);
+  const root = await realpath(resolve(options.cwd));
+  const lockPaths = hunks.flatMap((hunk) => {
+    const paths = [resolvePatchPath(hunk.path, root)];
+    if (hunk.kind === "update" && hunk.moveTo) paths.push(resolvePatchPath(hunk.moveTo, root));
+    return paths;
+  });
+
+  return withMutationLocks(lockPaths, async () => {
+    const rootHandle = await openSecureRoot(root, options.signal);
+    try {
+      const operations = await planOperations(hunks, root, rootHandle, options.signal);
+      throwIfAborted(options.signal);
+      // ponytail: preflight catches parse/match errors before writes; cross-process failures can still leave a partial multi-file patch.
+      for (const operation of operations) {
+        throwIfAborted(options.signal);
+        if (operation.kind === "add") {
+          await writeSecureFile(rootHandle, root, operation.path, operation.content, true, options.signal);
+        } else if (operation.kind === "delete") {
+          await removeSecureFile(rootHandle, root, operation.path, options.signal);
+        } else if (operation.moveTo) {
+          await writeSecureFile(rootHandle, root, operation.moveTo, operation.content, true, options.signal);
+          await removeSecureFile(rootHandle, root, operation.path, options.signal);
+        } else {
+          await writeSecureFile(rootHandle, root, operation.path, operation.content, false, options.signal);
+        }
+      }
+
+      return {
+        changes: operations.map((operation) => ({
+          kind: operation.kind === "add" ? "added" : operation.kind === "delete" ? "deleted" : "updated",
+          path: operation.displayPath,
+          ...(operation.kind === "update" && operation.moveDisplayPath ? { moveTo: operation.moveDisplayPath } : {}),
+        })),
+      };
+    } finally {
+      await rootHandle.close();
+    }
+  });
+}
+
+async function planOperations(hunks: ApplyPatchHunk[], root: string, rootHandle: FileHandle, signal?: AbortSignal): Promise<PlannedOperation[]> {
+  const operations: PlannedOperation[] = [];
+  const byPath = new Map<string, PlannedOperation>();
+  const occupied = new Set<string>();
+
+  for (const hunk of hunks) {
+    throwIfAborted(signal);
+    const source = await safePath(hunk.path, root, signal);
+    if (occupied.has(source.absolute) && !(hunk.kind === "update" && byPath.get(source.absolute)?.kind === "update")) {
+      throw new Error(`Patch addresses '${hunk.path}' more than once.`);
+    }
+
+    if (hunk.kind === "add") {
+      if (source.isDirectory || (source.exists && !source.isFile)) throw new Error(`Cannot add file over non-file '${hunk.path}'.`);
+      const operation: PlannedOperation = { kind: "add", path: source.absolute, displayPath: displayPath(root, source.absolute, hunk.path), content: hunk.content };
+      operations.push(operation);
+      byPath.set(source.absolute, operation);
+      occupied.add(source.absolute);
+      continue;
+    }
+
+    if (hunk.kind === "delete") {
+      if (!source.exists) throw new Error(`Cannot delete missing file '${hunk.path}'.`);
+      if (source.isDirectory || !source.isFile) throw new Error(`Cannot delete non-file '${hunk.path}'.`);
+      const operation: PlannedOperation = { kind: "delete", path: source.absolute, displayPath: displayPath(root, source.absolute, hunk.path) };
+      operations.push(operation);
+      byPath.set(source.absolute, operation);
+      occupied.add(source.absolute);
+      continue;
+    }
+
+    if (!source.exists) throw new Error(`Cannot update missing file '${hunk.path}'.`);
+    if (source.isDirectory || !source.isFile) throw new Error(`Cannot update non-file '${hunk.path}'.`);
+    const original = await readSecureFile(rootHandle, root, source.absolute, signal);
+    const moveTo = hunk.moveTo ? (await safePath(hunk.moveTo, root, signal)).absolute : undefined;
+    if (moveTo === source.absolute) throw new Error(`Cannot move '${hunk.path}' onto itself.`);
+    if (moveTo) {
+      const destination = await safePath(hunk.moveTo!, root, signal);
+      if (destination.isDirectory || (destination.exists && !destination.isFile)) throw new Error(`Cannot move file over non-file '${hunk.moveTo}'.`);
+      if (occupied.has(moveTo)) throw new Error(`Patch addresses move destination '${hunk.moveTo}' more than once.`);
+      occupied.add(moveTo);
+    }
+
+    const existing = byPath.get(source.absolute);
+    if (existing?.kind === "update") {
+      if (existing.moveTo || moveTo) throw new Error(`A file can only be moved once in a patch: '${hunk.path}'.`);
+      existing.chunkGroups.push(hunk.chunks);
+      existing.content = existing.chunkGroups.reduce(
+        (content, chunks) => applyUpdateContent(content, chunks, hunk.path),
+        original,
+      );
+      continue;
+    }
+
+    const operation: PlannedOperation = {
+      kind: "update",
+      path: source.absolute,
+      displayPath: displayPath(root, source.absolute, hunk.path),
+      moveTo,
+      moveDisplayPath: moveTo ? displayPath(root, moveTo, hunk.moveTo!) : undefined,
+      chunkGroups: [[...hunk.chunks]],
+      content: applyUpdateContent(original, hunk.chunks, hunk.path),
+    };
+    operations.push(operation);
+    byPath.set(source.absolute, operation);
+    occupied.add(source.absolute);
+  }
+
+  for (const operation of operations) {
+    if (operation.kind === "update" && operation.moveTo && byPath.has(operation.moveTo)) {
+      throw new Error(`Move destination '${operation.moveDisplayPath}' is also changed by this patch.`);
+    }
+  }
+  return operations;
+}
+
+function resolvePatchPath(rawPath: string, root: string): string {
+  const absolute = isAbsolute(rawPath) ? resolve(rawPath) : resolve(root, rawPath);
+  if (!isWithin(root, absolute) || absolute === root) {
+    throw new Error(`Patch path must stay inside the current working directory: ${rawPath}`);
+  }
+  return absolute;
+}
+
+async function safePath(rawPath: string, root: string, signal?: AbortSignal): Promise<SafePath> {
+  throwIfAborted(signal);
+  const absolute = resolvePatchPath(rawPath, root);
+
+  let current = absolute;
+  while (true) {
+    throwIfAborted(signal);
+    try {
+      const stats = await lstat(current);
+      if (stats.isSymbolicLink()) {
+        throw new Error(`Symlink paths are not allowed in apply_patch: ${rawPath}`);
+      }
+      const resolved = await realpath(current);
+      if (!isWithin(root, resolved)) {
+        throw new Error(`Patch path escapes the current working directory: ${rawPath}`);
+      }
+      if (current !== absolute && !stats.isDirectory()) {
+        throw new Error(`Parent path is not a directory: ${rawPath}`);
+      }
+      return {
+        absolute,
+        exists: current === absolute,
+        isDirectory: current === absolute && stats.isDirectory(),
+        isFile: current === absolute && stats.isFile(),
+      };
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
+      const parent = dirname(current);
+      if (parent === current) throw new Error(`Cannot resolve patch path: ${rawPath}`);
+      current = parent;
+    }
+  }
+}
+
+function requireSecureFilesystem(): void {
+  if (!SECURE_FILESYSTEM_SUPPORTED) {
+    throw new Error("apply_patch requires a POSIX filesystem with descriptor-based no-follow support.");
+  }
+}
+
+function secureChildPath(parent: FileHandle, child: string): string {
+  if (!SECURE_FD_DIRECTORY) throw new Error("Secure filesystem operations are unavailable on this platform.");
+  return join(SECURE_FD_DIRECTORY, String(parent.fd), child);
+}
+
+async function openSecureRoot(root: string, signal?: AbortSignal): Promise<FileHandle> {
+  requireSecureFilesystem();
+  let current = await open(sep, SECURE_DIRECTORY_FLAGS);
+  try {
+    for (const component of root.split(sep).filter(Boolean)) {
+      throwIfAborted(signal);
+      const next = await openSecureDirectoryChild(current, component);
+      await current.close();
+      current = next;
+    }
+    return current;
+  } catch (error) {
+    await current.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function openSecureDirectoryChild(parent: FileHandle, component: string): Promise<FileHandle> {
+  const handle = await open(secureChildPath(parent, component), SECURE_DIRECTORY_FLAGS);
+  try {
+    if (!(await handle.stat()).isDirectory()) throw new Error(`Secure path component is not a directory: ${component}`);
+    return handle;
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+type SecureParent = { handle: FileHandle; owned: boolean };
+
+async function openSecureParentDirectory(rootHandle: FileHandle, root: string, absolute: string, createParents: boolean, signal?: AbortSignal): Promise<SecureParent> {
+  const parentPath = dirname(absolute);
+  const relativeParent = relative(root, parentPath);
+  const components = relativeParent ? relativeParent.split(sep) : [];
+  if (components.some((component) => !component || component === "." || component === "..")) {
+    throw new Error(`Patch path must stay inside the current working directory: ${absolute}`);
+  }
+
+  let current = rootHandle;
+  let owned = false;
+  try {
+    for (const component of components) {
+      throwIfAborted(signal);
+      let next: FileHandle;
+      try {
+        next = await openSecureDirectoryChild(current, component);
+      } catch (error) {
+        if (!createParents || !isNoEntryError(error)) throw error;
+        try {
+          await mkdir(secureChildPath(current, component));
+        } catch (mkdirError) {
+          if (!isAlreadyExistsError(mkdirError)) throw mkdirError;
+        }
+        next = await openSecureDirectoryChild(current, component);
+      }
+      if (owned) await current.close();
+      current = next;
+      owned = true;
+    }
+    return { handle: current, owned };
+  } catch (error) {
+    if (owned) await current.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function withSecureFile<T>(
+  rootHandle: FileHandle,
+  root: string,
+  absolute: string,
+  flags: number,
+  createParents: boolean,
+  callback: (file: FileHandle, size: number) => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const parent = await openSecureParentDirectory(rootHandle, root, absolute, createParents, signal);
+  let file: FileHandle | undefined;
+  try {
+    file = await open(secureChildPath(parent.handle, basename(absolute)), flags, 0o666);
+    const stats = await file.stat();
+    if (!stats.isFile()) throw new Error(`Patch target is not a regular file: ${absolute}`);
+    return await callback(file, stats.size);
+  } finally {
+    await file?.close().catch(() => undefined);
+    if (parent.owned) await parent.handle.close().catch(() => undefined);
+  }
+}
+
+async function readSecureFile(rootHandle: FileHandle, root: string, absolute: string, signal?: AbortSignal): Promise<string> {
+  return withSecureFile(rootHandle, root, absolute, SECURE_READ_FLAGS, false, async (file, size) => {
+    if (size > MAX_TARGET_FILE_BYTES) {
+      throw new Error(`Patch target exceeds the ${MAX_TARGET_FILE_BYTES}-byte limit: ${absolute}`);
+    }
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      throwIfAborted(signal);
+      const buffer = Buffer.alloc(Math.min(FILE_READ_CHUNK_BYTES, MAX_TARGET_FILE_BYTES + 1 - total));
+      const { bytesRead } = await file.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      chunks.push(buffer.subarray(0, bytesRead));
+      if (total > MAX_TARGET_FILE_BYTES) {
+        throw new Error(`Patch target exceeds the ${MAX_TARGET_FILE_BYTES}-byte limit: ${absolute}`);
+      }
+    }
+    return Buffer.concat(chunks, total).toString("utf8");
+  }, signal);
+}
+
+async function writeSecureFile(rootHandle: FileHandle, root: string, absolute: string, content: string, createParents: boolean, signal?: AbortSignal): Promise<void> {
+  const flags = createParents ? SECURE_CREATE_FLAGS : SECURE_UPDATE_FLAGS;
+  await withSecureFile(rootHandle, root, absolute, flags, createParents, async (file) => {
+    await file.writeFile(content, "utf8");
+  }, signal);
+}
+
+async function removeSecureFile(rootHandle: FileHandle, root: string, absolute: string, signal?: AbortSignal): Promise<void> {
+  const parent = await openSecureParentDirectory(rootHandle, root, absolute, false, signal);
+  try {
+    const target = secureChildPath(parent.handle, basename(absolute));
+    const stats = await lstat(target);
+    if (stats.isSymbolicLink()) throw new Error(`Symlink paths are not allowed in apply_patch: ${absolute}`);
+    if (stats.isDirectory()) throw new Error(`Cannot delete directory '${absolute}'.`);
+    await unlink(target);
+  } finally {
+    if (parent.owned) await parent.handle.close().catch(() => undefined);
+  }
+}
+
+function applyUpdateContent(original: string, chunks: UpdateChunk[], displayPath: string): string {
+  const bom = original.startsWith("\uFEFF") ? "\uFEFF" : "";
+  const body = bom ? original.slice(1) : original;
+  const lineEnding = body.includes("\r\n") ? "\r\n" : "\n";
+  const lines = body.replace(/\r\n/g, "\n").split("\n");
+  if (lines.at(-1) === "") lines.pop();
+
+  const replacements: Array<{ start: number; length: number; lines: string[] }> = [];
+  let lineIndex = 0;
+  for (const chunk of chunks) {
+    if (chunk.context !== undefined) {
+      const contextIndex = seekSequence(lines, [chunk.context], lineIndex, false);
+      if (contextIndex === undefined) throw new Error(`Failed to find context '${chunk.context}' in ${displayPath}.`);
+      lineIndex = contextIndex + 1;
+    }
+
+    if (chunk.oldLines.length === 0) {
+      replacements.push({ start: lines.length, length: 0, lines: [...chunk.newLines] });
+      continue;
+    }
+
+    let pattern = chunk.oldLines;
+    let replacementLines = chunk.newLines;
+    let found = seekSequence(lines, pattern, lineIndex, chunk.endOfFile);
+    if (found === undefined && pattern.at(-1) === "") {
+      pattern = pattern.slice(0, -1);
+      if (replacementLines.at(-1) === "") replacementLines = replacementLines.slice(0, -1);
+      found = seekSequence(lines, pattern, lineIndex, chunk.endOfFile);
+    }
+    if (found === undefined) {
+      throw new Error(`Failed to find expected lines in ${displayPath}:\n${chunk.oldLines.join("\n")}`);
+    }
+    replacements.push({ start: found, length: pattern.length, lines: [...replacementLines] });
+    lineIndex = found + pattern.length;
+  }
+
+  replacements.sort((left, right) => left.start - right.start);
+  for (let index = 1; index < replacements.length; index++) {
+    const previous = replacements[index - 1];
+    const current = replacements[index];
+    if (current.start < previous.start + previous.length) {
+      throw new Error(`Overlapping update chunks are not allowed in ${displayPath}.`);
+    }
+  }
+
+  const updated = [...lines];
+  for (const replacement of [...replacements].reverse()) {
+    updated.splice(replacement.start, replacement.length, ...replacement.lines);
+  }
+  if (updated.at(-1) !== "") updated.push("");
+  return bom + updated.join(lineEnding);
+}
+
+function seekSequence(lines: string[], pattern: string[], start: number, endOfFile: boolean): number | undefined {
+  if (pattern.length === 0) return Math.min(start, lines.length);
+  if (pattern.length > lines.length) return undefined;
+  const first = endOfFile ? Math.max(start, lines.length - pattern.length) : start;
+  const last = lines.length - pattern.length;
+  if (first > last) return undefined;
+
+  // KMP keeps each normalization pass linear instead of rescanning the pattern at every line.
+  for (const normalize of [(value: string) => value, (value: string) => value.trimEnd(), (value: string) => value.trim(), normalizePunctuation]) {
+    const expected = pattern.map(normalize);
+    const prefix = buildPrefixTable(expected);
+    let matched = 0;
+    for (let index = first; index < lines.length; index++) {
+      const actual = normalize(lines[index]);
+      while (matched > 0 && actual !== expected[matched]) matched = prefix[matched - 1];
+      if (actual === expected[matched]) matched++;
+      if (matched === expected.length) return index - expected.length + 1;
+    }
+  }
+  return undefined;
+}
+
+function buildPrefixTable(pattern: string[]): number[] {
+  const prefix = Array<number>(pattern.length).fill(0);
+  for (let index = 1, matched = 0; index < pattern.length; index++) {
+    while (matched > 0 && pattern[index] !== pattern[matched]) matched = prefix[matched - 1];
+    if (pattern[index] === pattern[matched]) matched++;
+    prefix[index] = matched;
+  }
+  return prefix;
+}
+
+function normalizePunctuation(value: string): string {
+  return value.trim().replace(/[\u2010-\u2015\u2212]/g, "-").replace(/[\u2018-\u201b]/g, "'").replace(/[\u201c-\u201f]/g, '"').replace(/[\u00a0\u2002-\u200a\u202f\u205f\u3000]/g, " ");
+}
+
+async function withMutationLocks<T>(paths: string[], callback: () => Promise<T>): Promise<T> {
+  const uniquePaths = [...new Set(paths)].sort();
+  const acquire = (index: number): Promise<T> =>
+    index === uniquePaths.length ? callback() : withFileMutationQueue(uniquePaths[index], () => acquire(index + 1));
+  return acquire(0);
+}
+
+function displayPath(root: string, absolute: string, fallback: string): string {
+  const relativePath = relative(root, absolute);
+  return relativePath && !relativePath.startsWith("..") ? relativePath : fallback;
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error.code === "ENOENT" || error.code === "ENOTDIR");
+}
+
+function isNoEntryError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw new Error("Operation aborted");
+}

--- a/packages/pi-codex-tools/src/grammar.ts
+++ b/packages/pi-codex-tools/src/grammar.ts
@@ -1,0 +1,25 @@
+import { Type, type TSchema } from "typebox";
+
+export interface OpenAIGrammarSampling {
+  type: "grammar";
+  variants: { openai_lark: string };
+}
+
+/** Create the OpenAI grammar transport used by Responses custom tools. */
+export function createOpenAILarkSampling(definition: string): OpenAIGrammarSampling {
+  if (definition.trim().length === 0) {
+    throw new Error("OpenAI Lark grammar cannot be empty.");
+  }
+  return { type: "grammar", variants: { openai_lark: definition } };
+}
+
+/** Build the one-required-string schema Pi uses to identify raw custom-tool input. */
+export function createFreeformInputSchema(inputProperty: string, description: string): TSchema {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(inputProperty) || inputProperty === "__proto__") {
+    throw new Error(`Invalid freeform input property: ${inputProperty}`);
+  }
+
+  const properties: Record<string, TSchema> = Object.create(null) as Record<string, TSchema>;
+  properties[inputProperty] = Type.String({ description });
+  return Type.Object(properties, { additionalProperties: false });
+}

--- a/packages/pi-codex-tools/src/index.ts
+++ b/packages/pi-codex-tools/src/index.ts
@@ -1,0 +1,5 @@
+export { APPLY_PATCH_GRAMMAR, MAX_PATCH_BYTES, MAX_PATCH_HUNKS, MAX_TARGET_FILE_BYTES, applyPatch, parseApplyPatch } from "./apply-patch.js";
+export type { ApplyPatchHunk, ApplyPatchOptions, ApplyPatchResult, UpdateChunk } from "./apply-patch.js";
+export { createFreeformInputSchema, createOpenAILarkSampling } from "./grammar.js";
+export type { OpenAIGrammarSampling } from "./grammar.js";
+export { isOpenAIResponsesApi, supportsOpenAIGrammarTools } from "./model-support.js";

--- a/packages/pi-codex-tools/src/install-telemetry.ts
+++ b/packages/pi-codex-tools/src/install-telemetry.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { reportInstallTelemetry as report } from "@mocito/install-telemetry";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+const PACKAGE_NAME = "pi-codex-tools";
+const INSTALL_TELEMETRY_ENDPOINT = "https://mocito.dev/api/report-install";
+const CI_ENVIRONMENT_VARIABLES = [
+  "APPVEYOR",
+  "BITBUCKET_BUILD_NUMBER",
+  "BUILDKITE",
+  "CIRCLECI",
+  "CODESPACES",
+  "DRONE",
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "JENKINS_URL",
+  "NETLIFY",
+  "TEAMCITY_VERSION",
+  "TF_BUILD",
+  "TRAVIS",
+  "VERCEL",
+];
+
+type SettingsDocument = { enableInstallTelemetry?: unknown };
+
+function readJsonFile(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as unknown;
+  } catch {
+    return {};
+  }
+}
+
+function isTruthyEnvFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  return value === "1" || value.toLowerCase() === "true" || value.toLowerCase() === "yes";
+}
+
+function isPresentEnvFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized !== "0" && normalized !== "false" && normalized !== "no";
+}
+
+function isInstallTelemetryEnabled(): boolean {
+  if (isTruthyEnvFlag(process.env.CI)) return false;
+  if (CI_ENVIRONMENT_VARIABLES.some((name) => isPresentEnvFlag(process.env[name]))) return false;
+  if (isTruthyEnvFlag(process.env.PI_OFFLINE)) return false;
+  if (process.env.PI_TELEMETRY !== undefined) return isTruthyEnvFlag(process.env.PI_TELEMETRY);
+
+  const settings = readJsonFile(join(getAgentDir(), "settings.json")) as SettingsDocument;
+  return settings.enableInstallTelemetry !== false;
+}
+
+function getPackageVersion(): string {
+  const packageJson = readJsonFile(fileURLToPath(new URL("../package.json", import.meta.url))) as { version?: unknown };
+  return typeof packageJson.version === "string" && packageJson.version.length > 0 ? packageJson.version : "0.0.0";
+}
+
+export function reportInstallTelemetry(): void {
+  try {
+    void report({
+      endpoint: INSTALL_TELEMETRY_ENDPOINT,
+      tool: PACKAGE_NAME,
+      version: getPackageVersion(),
+      statePath: join(getAgentDir(), "extensions", "pi-codex-tools-install.json"),
+      enabled: isInstallTelemetryEnabled(),
+    }).catch(() => undefined);
+  } catch {
+    // Best-effort telemetry: ignore local policy and filesystem failures.
+  }
+}

--- a/packages/pi-codex-tools/src/install-telemetry.ts
+++ b/packages/pi-codex-tools/src/install-telemetry.ts
@@ -44,14 +44,15 @@ function isPresentEnvFlag(value: string | undefined): boolean {
   return normalized !== "0" && normalized !== "false" && normalized !== "no";
 }
 
-function isInstallTelemetryEnabled(): boolean {
-  if (isTruthyEnvFlag(process.env.CI)) return false;
-  if (CI_ENVIRONMENT_VARIABLES.some((name) => isPresentEnvFlag(process.env[name]))) return false;
-  if (isTruthyEnvFlag(process.env.PI_OFFLINE)) return false;
-  if (process.env.PI_TELEMETRY !== undefined) return isTruthyEnvFlag(process.env.PI_TELEMETRY);
+export function isInstallTelemetryEnabled(env: NodeJS.ProcessEnv = process.env, settingsPath = join(getAgentDir(), "settings.json")): boolean {
+  if (isTruthyEnvFlag(env.CI)) return false;
+  if (CI_ENVIRONMENT_VARIABLES.some((name) => isPresentEnvFlag(env[name]))) return false;
+  if (isTruthyEnvFlag(env.PI_OFFLINE)) return false;
 
-  const settings = readJsonFile(join(getAgentDir(), "settings.json")) as SettingsDocument;
-  return settings.enableInstallTelemetry !== false;
+  const settings = readJsonFile(settingsPath) as SettingsDocument;
+  if (settings.enableInstallTelemetry === false) return false;
+  if (env.PI_TELEMETRY !== undefined) return isTruthyEnvFlag(env.PI_TELEMETRY);
+  return true;
 }
 
 function getPackageVersion(): string {

--- a/packages/pi-codex-tools/src/model-support.ts
+++ b/packages/pi-codex-tools/src/model-support.ts
@@ -1,0 +1,12 @@
+import type { Model } from "@earendil-works/pi-ai";
+
+const OPENAI_RESPONSES_APIS = new Set(["openai-codex-responses", "openai-responses"]);
+
+export function supportsOpenAIGrammarTools(model: Model<any> | undefined): boolean {
+  const compat = model?.compat as { supportsOpenAIGrammarTools?: boolean } | undefined;
+  return model !== undefined && OPENAI_RESPONSES_APIS.has(model.api) && compat?.supportsOpenAIGrammarTools === true;
+}
+
+export function isOpenAIResponsesApi(api: string | undefined): boolean {
+  return api !== undefined && OPENAI_RESPONSES_APIS.has(api);
+}

--- a/packages/pi-codex-tools/tests/apply-patch.test.mjs
+++ b/packages/pi-codex-tools/tests/apply-patch.test.mjs
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, symlink, truncate, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+process.env.CI = "1";
+
+const { applyPatch, MAX_TARGET_FILE_BYTES, parseApplyPatch } = await import("../src/apply-patch.ts");
+
+const patch = (body) => `*** Begin Patch\n${body}\n*** End Patch`;
+const supportsSecureFilesystem = process.platform === "linux" || process.platform === "darwin";
+const applyTest = (name, fn) => test(name, { skip: !supportsSecureFilesystem }, fn);
+
+test("parses Codex add, delete, update, and move hunks", () => {
+  assert.deepEqual(
+    parseApplyPatch(
+      patch(`*** Add File: add.txt
++one
++two
+*** Delete File: delete.txt
+*** Update File: old.txt
+*** Move to: new.txt
+@@
+-old
++new`),
+    ),
+    [
+      { kind: "add", path: "add.txt", content: "one\ntwo\n" },
+      { kind: "delete", path: "delete.txt" },
+      {
+        kind: "update",
+        path: "old.txt",
+        moveTo: "new.txt",
+        chunks: [{ oldLines: ["old"], newLines: ["new"], endOfFile: false }],
+      },
+    ],
+  );
+});
+
+test("fails closed on unsupported filesystems", { skip: supportsSecureFilesystem }, async () => {
+  await assert.rejects(applyPatch(patch(`*** Add File: blocked.txt
++blocked`), { cwd: process.cwd() }), /POSIX filesystem/);
+});
+
+applyTest("applies a multi-file patch after preflighting all hunks", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await mkdir(join(cwd, "src"));
+    await writeFile(join(cwd, "src", "old.txt"), "first\nsecond\nthird\n");
+    await writeFile(join(cwd, "delete.txt"), "gone\n");
+
+    const result = await applyPatch(
+      patch(`*** Add File: nested/new.txt
++created
+*** Delete File: delete.txt
+*** Update File: src/old.txt
+@@
+ first
+-second
++changed
+ third
+*** Update File: src/old.txt
+@@
+ third
++last
+*** End of File`),
+      { cwd },
+    );
+
+    assert.deepEqual(result.changes.map(({ kind, path }) => ({ kind, path })), [
+      { kind: "added", path: "nested/new.txt" },
+      { kind: "deleted", path: "delete.txt" },
+      { kind: "updated", path: "src/old.txt" },
+    ]);
+    assert.equal(await readFile(join(cwd, "nested", "new.txt"), "utf8"), "created\n");
+    assert.equal(await readFile(join(cwd, "src", "old.txt"), "utf8"), "first\nchanged\nthird\nlast\n");
+    await assert.rejects(readFile(join(cwd, "delete.txt")));
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("creates a one-newline file for an empty add hunk", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await applyPatch(
+      patch(`*** Add File: empty.txt
++`),
+      { cwd },
+    );
+    assert.equal(await readFile(join(cwd, "empty.txt"), "utf8"), "\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("adds a trailing newline when updating a file without one", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await writeFile(join(cwd, "file.txt"), "before");
+    await applyPatch(
+      patch(`*** Update File: file.txt
+@@
+-before
++after`),
+      { cwd },
+    );
+    assert.equal(await readFile(join(cwd, "file.txt"), "utf8"), "after\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("keeps indented patch markers as update context lines", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await writeFile(join(cwd, "file.txt"), "before\n*** Update File: b.txt\n");
+    await applyPatch(
+      patch(`*** Update File: file.txt
+@@
+-before
++after
+ *** Update File: b.txt`),
+      { cwd },
+    );
+    assert.equal(await readFile(join(cwd, "file.txt"), "utf8"), "after\n*** Update File: b.txt\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("does not treat an indented End of File line as a control marker", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await writeFile(join(cwd, "file.txt"), "wrong\nold\n");
+    await assert.rejects(
+      applyPatch(
+        patch(`*** Update File: file.txt
+@@
+-old
++new
+ *** End of File`),
+        { cwd },
+      ),
+      /Failed to find expected lines/,
+    );
+    assert.equal(await readFile(join(cwd, "file.txt"), "utf8"), "wrong\nold\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("rejects update targets above the file-size limit", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    const path = join(cwd, "large.txt");
+    await writeFile(path, "");
+    await truncate(path, MAX_TARGET_FILE_BYTES + 1);
+    await assert.rejects(
+      applyPatch(
+        patch(`*** Update File: large.txt
+@@
+-old
++new`),
+        { cwd },
+      ),
+      /exceeds the 67108864-byte limit/,
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("uses Codex's lenient line matching and preserves CRLF endings", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await writeFile(join(cwd, "file.txt"), "  first  \r\nsecond\r\n");
+    await applyPatch(
+      patch(`*** Update File: file.txt
+@@ first
+-second
++changed`),
+      { cwd },
+    );
+    assert.equal(await readFile(join(cwd, "file.txt"), "utf8"), "  first  \r\nchanged\r\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("rejects symlink path escapes", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  const outside = await mkdtemp(join(tmpdir(), "pi-codex-tools-outside-"));
+  try {
+    await writeFile(join(outside, "victim.txt"), "safe\n");
+    await symlink(outside, join(cwd, "link"));
+    await assert.rejects(
+      applyPatch(patch(`*** Add File: link/victim.txt
++overwritten`), { cwd }),
+      /Symlink paths are not allowed|Patch path escapes/,
+    );
+    assert.equal(await readFile(join(outside, "victim.txt"), "utf8"), "safe\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+    await rm(outside, { recursive: true, force: true });
+  }
+});
+
+applyTest("rejects path escapes and does not partially apply a patch", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await assert.rejects(
+      applyPatch(
+        patch(`*** Add File: created.txt
++must not exist
+*** Update File: missing.txt
+@@
+-old
++new`),
+        { cwd },
+      ),
+      /missing file/,
+    );
+    await assert.rejects(readFile(join(cwd, "created.txt")));
+
+    await assert.rejects(
+      applyPatch(patch(`*** Add File: ../outside.txt
++blocked`), { cwd }),
+      /inside the current working directory/,
+    );
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/packages/pi-codex-tools/tests/apply-patch.test.mjs
+++ b/packages/pi-codex-tools/tests/apply-patch.test.mjs
@@ -9,7 +9,7 @@ process.env.CI = "1";
 const { applyPatch, MAX_TARGET_FILE_BYTES, parseApplyPatch } = await import("../src/apply-patch.ts");
 
 const patch = (body) => `*** Begin Patch\n${body}\n*** End Patch`;
-const supportsSecureFilesystem = process.platform === "linux" || process.platform === "darwin";
+const supportsSecureFilesystem = process.platform === "linux";
 const applyTest = (name, fn) => test(name, { skip: !supportsSecureFilesystem }, fn);
 
 test("parses Codex add, delete, update, and move hunks", () => {
@@ -76,6 +76,74 @@ applyTest("applies a multi-file patch after preflighting all hunks", async () =>
     assert.equal(await readFile(join(cwd, "nested", "new.txt"), "utf8"), "created\n");
     assert.equal(await readFile(join(cwd, "src", "old.txt"), "utf8"), "first\nchanged\nthird\nlast\n");
     await assert.rejects(readFile(join(cwd, "delete.txt")));
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("applies move hunks by writing the destination and removing the source", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await writeFile(join(cwd, "source.txt"), "old\n");
+    await applyPatch(
+      patch(`*** Update File: source.txt
+*** Move to: destination.txt
+@@
+-old
++new`),
+      { cwd },
+    );
+    assert.equal(await readFile(join(cwd, "destination.txt"), "utf8"), "new\n");
+    await assert.rejects(readFile(join(cwd, "source.txt")));
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("allows Add File to overwrite an existing regular file", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await writeFile(join(cwd, "existing.txt"), "old\n");
+    await applyPatch(
+      patch(`*** Add File: existing.txt
++new`),
+      { cwd },
+    );
+    assert.equal(await readFile(join(cwd, "existing.txt"), "utf8"), "new\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("keeps Codex pure additions at the end of the file", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await writeFile(join(cwd, "file.txt"), "first\nsecond\n");
+    await applyPatch(
+      patch(`*** Update File: file.txt
+@@ first
++inserted`),
+      { cwd },
+    );
+    assert.equal(await readFile(join(cwd, "file.txt"), "utf8"), "first\nsecond\ninserted\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+applyTest("preflights repeated Add File and Update File hunks sequentially", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  try {
+    await applyPatch(
+      patch(`*** Add File: repeated.txt
++one
+*** Update File: repeated.txt
+@@
+-one
++two`),
+      { cwd },
+    );
+    assert.equal(await readFile(join(cwd, "repeated.txt"), "utf8"), "two\n");
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/packages/pi-codex-tools/tests/extension.test.mjs
+++ b/packages/pi-codex-tools/tests/extension.test.mjs
@@ -70,6 +70,16 @@ test("replaces edit and write while preserving unrelated active tools", async ()
   assert.equal(await pi.handlers.get("before_provider_request")[0]({ payload: { parallel_tool_calls: true } }, { model: ordinaryModel }), undefined);
 });
 
+test("rejects apply_patch execution for unsupported models", async () => {
+  const pi = makePi();
+  piCodexTools(pi);
+  const tool = pi.tools.get("apply_patch");
+  await assert.rejects(
+    tool.execute("call", { patch: "*** Begin Patch\n*** End Patch" }, undefined, undefined, { model: ordinaryModel, cwd: process.cwd() }),
+    /only available for OpenAI models that advertise grammar-tool support/,
+  );
+});
+
 test("restores only file tools that were active before replacement", async () => {
   const pi = makePi(["read", "edit", "bash"]);
   piCodexTools(pi);

--- a/packages/pi-codex-tools/tests/extension.test.mjs
+++ b/packages/pi-codex-tools/tests/extension.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.CI = "1";
+
+const { default: piCodexTools } = await import("../extensions/index.ts");
+const { supportsOpenAIGrammarTools } = await import("../src/model-support.ts");
+
+function makePi(initialActive = ["read", "write", "edit", "bash"]) {
+  const handlers = new Map();
+  const tools = new Map();
+  let active = [...initialActive];
+  return {
+    handlers,
+    tools,
+    on(event, handler) {
+      const eventHandlers = handlers.get(event) ?? [];
+      eventHandlers.push(handler);
+      handlers.set(event, eventHandlers);
+    },
+    registerTool(tool) {
+      tools.set(tool.name, tool);
+    },
+    getActiveTools() {
+      return [...active];
+    },
+    setActiveTools(names) {
+      active = [...names];
+    },
+  };
+}
+
+const codexModel = {
+  provider: "openai-codex",
+  api: "openai-codex-responses",
+  id: "gpt-5.5",
+  compat: { supportsOpenAIGrammarTools: true },
+};
+
+const ordinaryModel = {
+  provider: "anthropic",
+  api: "anthropic-messages",
+  id: "claude-sonnet",
+  compat: {},
+};
+
+test("requires both a Responses API and the advertised grammar capability", () => {
+  assert.equal(supportsOpenAIGrammarTools(codexModel), true);
+  assert.equal(supportsOpenAIGrammarTools({ ...codexModel, api: "openai-completions" }), false);
+  assert.equal(supportsOpenAIGrammarTools({ ...codexModel, compat: {} }), false);
+  assert.equal(supportsOpenAIGrammarTools(ordinaryModel), false);
+});
+
+test("replaces edit and write while preserving unrelated active tools", async () => {
+  const pi = makePi();
+  piCodexTools(pi);
+  const context = { model: codexModel };
+
+  await pi.handlers.get("session_start")[0]({}, context);
+  assert.deepEqual(pi.getActiveTools(), ["read", "bash", "apply_patch"]);
+
+  const rewritten = await pi.handlers.get("before_provider_request")[0](
+    { payload: { model: codexModel.id, parallel_tool_calls: true } },
+    context,
+  );
+  assert.deepEqual(rewritten, { model: codexModel.id, parallel_tool_calls: false });
+
+  await pi.handlers.get("model_select")[0]({}, { model: ordinaryModel });
+  assert.deepEqual(pi.getActiveTools(), ["read", "bash", "edit", "write"]);
+  assert.equal(await pi.handlers.get("before_provider_request")[0]({ payload: { parallel_tool_calls: true } }, { model: ordinaryModel }), undefined);
+});
+
+test("restores only file tools that were active before replacement", async () => {
+  const pi = makePi(["read", "edit", "bash"]);
+  piCodexTools(pi);
+  const context = { model: codexModel };
+
+  await pi.handlers.get("session_start")[0]({}, context);
+  assert.deepEqual(pi.getActiveTools(), ["read", "bash", "apply_patch"]);
+
+  await pi.handlers.get("model_select")[0]({}, { model: ordinaryModel });
+  assert.deepEqual(pi.getActiveTools(), ["read", "bash", "edit"]);
+});
+
+test("exposes apply_patch as a raw grammar tool", () => {
+  const pi = makePi();
+  piCodexTools(pi);
+  const tool = pi.tools.get("apply_patch");
+  assert.equal(tool.constrainedSampling.type, "grammar");
+  assert.match(tool.constrainedSampling.variants.openai_lark, /start: begin_patch hunk\+ end_patch/);
+  assert.match(tool.description, /FREEFORM/);
+});

--- a/packages/pi-codex-tools/tests/install-telemetry.test.mjs
+++ b/packages/pi-codex-tools/tests/install-telemetry.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const { isInstallTelemetryEnabled } = await import("../src/install-telemetry.ts");
+
+test("settings opt-out overrides an enabled PI_TELEMETRY environment flag", async () => {
+  const cwd = await mkdtemp(join(tmpdir(), "pi-codex-tools-"));
+  const settingsPath = join(cwd, "settings.json");
+  try {
+    const env = { PI_TELEMETRY: "1" };
+    await writeFile(settingsPath, JSON.stringify({ enableInstallTelemetry: false }));
+    assert.equal(isInstallTelemetryEnabled(env, settingsPath), false);
+
+    await writeFile(settingsPath, "{}");
+    assert.equal(isInstallTelemetryEnabled(env, settingsPath), true);
+    env.PI_TELEMETRY = "false";
+    assert.equal(isInstallTelemetryEnabled(env, settingsPath), false);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/packages/pi-codex-tools/tsconfig.json
+++ b/packages/pi-codex-tools/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["index.ts", "src/**/*.ts", "extensions/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Add `pi-codex-tools`, a capability-gated Codex `apply_patch` extension for Pi.
- Replace Pi `edit`/`write` for compatible models while preserving `read`, `bash`, and unrelated active tools.
- Add cwd-confined secure mutation, symlink/TOCTOU hardening, bounded reads, linear matching, documentation, and release metadata.
- Follow up on PR review in `4cbf79c`; the corrected release is `pi-codex-tools@0.1.1` because npm versions are immutable.

## Review follow-up

- Added execution-time capability checks and fail-closed grammar registration for runtimes that do not preserve constrained sampling.
- Restricted descriptor-anchored filesystem operations to verified Linux support.
- Fixed telemetry setting precedence and documented credential-containing target-file reads.
- Added move, overwrite, pure-addition, and repeated-hunk integration coverage.
- Retained Codex behavior for regular-file `Add File` overwrites and pure `+` additions; changing those would break the Codex grammar/parser contract.
- Kept workspace-compatible dependency ranges rather than introducing package-local exact-version drift.

## Security and privacy

- [x] `apply_patch` performs no network or credential-API access and does not log credentials.
- [x] Patch paths stay inside the working directory; symlink escapes and unsupported filesystems fail closed.
- [x] Patch input and target-file reads are bounded; all hunks are preflighted before writes.
- [x] Install telemetry is best effort, sends only package/version/runtime metadata, and respects CI, `PI_OFFLINE`, `PI_TELEMETRY`, and `enableInstallTelemetry: false`.

## Validation

- `npm run validate` — passed across all 12 workspaces; npm audit found 0 vulnerabilities.
- Semgrep security scan — 0 findings.
- `npm run -w packages/pi-codex-tools check` — passed.
- `npm test -w packages/pi-codex-tools` — 20 passed, 1 platform-specific skip.
- `npm run -w packages/pi-codex-tools pack:dry-run` — passed; package contents inspected.
- Pi `0.83.0` CLI help/model smoke — extension loads with `--help`; OpenAI Codex models are listed offline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex-compatible `apply_patch` tooling with grammar-constrained input.
  * Supports creating, updating, deleting, and moving files with sequential execution.
  * Automatically switches between patch tooling and standard editing tools based on model capabilities.
  * Added safeguards against unsafe paths, symlinks, oversized patches, and partial changes.
  * Added configurable installation telemetry with opt-out support.

* **Documentation**
  * Added installation, usage, security, contribution, licensing, and compatibility documentation.

* **Tests**
  * Added comprehensive coverage for patch handling, safety protections, telemetry, and model switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->