### PR TITLE
Sync pi-skillful lockfile version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4619,7 +4619,7 @@
       "license": "MIT"
     },
     "packages/pi-skillful": {
-      "version": "0.3.14",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@mocito/install-telemetry": "0.1.1"


### PR DESCRIPTION
## Summary

- Synchronize the root lockfile's `pi-skillful` workspace version with its published/package manifest version.
- Correct `0.3.14` to `0.4.0` in `package-lock.json`.

## Validation

- `npm run validate:packages`
- `npm ci --dry-run --no-audit --no-fund`
- Verified `packages/pi-skillful/package.json` and `package-lock.json` both report `0.4.0`.
