### PR TITLE
Show apply_patch progress in the pi TUI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4443,6 +4443,7 @@
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.82.1",
         "@earendil-works/pi-coding-agent": "^0.82.1",
+        "@earendil-works/pi-tui": "^0.82.1",
         "@types/node": "^26.1.2",
         "tsx": "^4.23.1",
         "typebox": "^1.3.8",
@@ -4454,6 +4455,7 @@
       "peerDependencies": {
         "@earendil-works/pi-ai": "*",
         "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
         "typebox": "*"
       }
     },

--- a/packages/pi-codex-tools/CHANGELOG.md
+++ b/packages/pi-codex-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Added
+
+- Stream `apply_patch` progress in the TUI: while a patch is generated the tool now shows a live diff glimpse of the content being written plus a running `+added -removed` tally (and a capped per-file roster for multi-file patches), reusing Pi's shared diff rendering. Moves render the source → destination transition, and the preview is byte/file bounded for responsiveness. Execution behavior is unchanged.
+
 ## [0.1.1] - 2026-08-04
 
 ### Fixed

--- a/packages/pi-codex-tools/README.md
+++ b/packages/pi-codex-tools/README.md
@@ -9,6 +9,7 @@ Give grammar-capable OpenAI/Codex models the Codex `apply_patch` tool in Pi with
 - **Safe local mutation** — patches are limited to 1 MiB, target files to 64 MiB, stay under Pi's current working directory, reject symlink escapes, use descriptor-anchored no-follow operations on Linux, fail closed elsewhere, preflight all hunks, and serialize writes with Pi's mutation queue.
 - **Model switching** — supported models replace Pi's `edit` and `write` tools with `apply_patch`; other active tools are preserved. Switching back restores only the file tools that were active before the switch.
 - **Sequential patch calls** — the extension marks patch execution sequential and disables provider-side parallel tool calls when the patch tool is active.
+- **Streaming progress** — while a patch is generated, the TUI shows a live, color-coded glimpse of the content being written (new-file content, or `+`/`-` lines for updates) plus a running `+added -removed` tally and a per-file roster for multi-file patches. It reuses Pi's shared diff rendering and mirrors the built-in `write`/`edit` previews; patch execution is unchanged.
 
 ## Installation
 

--- a/packages/pi-codex-tools/extensions/index.ts
+++ b/packages/pi-codex-tools/extensions/index.ts
@@ -1,8 +1,22 @@
+import { Container, Text } from "@earendil-works/pi-tui";
+import type { Component } from "@earendil-works/pi-tui";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { reportInstallTelemetry } from "../src/install-telemetry.js";
 import { applyPatch, APPLY_PATCH_GRAMMAR, MAX_PATCH_BYTES } from "../src/apply-patch.js";
 import { createFreeformInputSchema, createOpenAILarkSampling, type OpenAIGrammarSampling } from "../src/grammar.js";
 import { supportsOpenAIGrammarTools } from "../src/model-support.js";
+import { formatApplyPatchCallText, formatApplyPatchResultText } from "../src/patch-preview.js";
+
+class ApplyPatchCallComponent extends Text {
+  cache?: { key: string; text: string };
+  constructor() {
+    super("", 0, 0);
+  }
+}
+
+function readPatchArg(args: unknown): string {
+  return typeof (args as { patch?: unknown })?.patch === "string" ? (args as { patch: string }).patch : "";
+}
 
 const APPLY_PATCH = "apply_patch";
 const EDIT = "edit";
@@ -35,6 +49,31 @@ export default function piCodexTools(pi: ExtensionAPI): void {
     parameters: APPLY_PATCH_PARAMETERS,
     constrainedSampling: createOpenAILarkSampling(APPLY_PATCH_GRAMMAR),
     executionMode: "sequential",
+    renderCall(args, theme, context) {
+      const component =
+        context.lastComponent instanceof ApplyPatchCallComponent ? context.lastComponent : new ApplyPatchCallComponent();
+      const rawPatch = readPatchArg(args);
+      const key = `${context.expanded ? "1" : "0"}:${rawPatch}`;
+      if (!component.cache || component.cache.key !== key) {
+        component.cache = {
+          key,
+          text: formatApplyPatchCallText(rawPatch, theme, { expanded: context.expanded }),
+        };
+      }
+      component.setText(component.cache.text);
+      return component as Component;
+    },
+    renderResult(result, _options, theme, context) {
+      const text = formatApplyPatchResultText(result, theme, context.isError);
+      if (!text) {
+        const component = (context.lastComponent ?? new Container()) as Container;
+        component.clear();
+        return component as Component;
+      }
+      const component = context.lastComponent instanceof Text ? context.lastComponent : new Text("", 0, 0);
+      component.setText(text);
+      return component as Component;
+    },
     async execute(_toolCallId, rawParams, signal, _onUpdate, ctx) {
       if (!supportsOpenAIGrammarTools(ctx.model)) {
         throw new Error("apply_patch is only available for OpenAI models that advertise grammar-tool support.");

--- a/packages/pi-codex-tools/package.json
+++ b/packages/pi-codex-tools/package.json
@@ -52,11 +52,13 @@
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",
     "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
     "typebox": "*"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.82.1",
     "@earendil-works/pi-coding-agent": "^0.82.1",
+    "@earendil-works/pi-tui": "^0.82.1",
     "@types/node": "^26.1.2",
     "tsx": "^4.23.1",
     "typebox": "^1.3.8",

--- a/packages/pi-codex-tools/src/patch-preview.ts
+++ b/packages/pi-codex-tools/src/patch-preview.ts
@@ -1,0 +1,265 @@
+// Streaming preview rendering for the apply_patch tool.
+//
+// The strict parser in apply-patch.ts rejects incomplete input, but the patch arrives as a
+// growing prefix while the model generates it. This module scans that partial text tolerantly
+// (it never throws) to drive a live, write-style glimpse of the content plus a running
+// added/removed tally. It reuses Pi's shared `renderDiff` primitive for +/- coloring, so the
+// preview stays consistent with the built-in `edit` tool's diff preview.
+import { keyHint, type Theme } from "@earendil-works/pi-coding-agent";
+
+const FILE_ADD = "*** Add File: ";
+const FILE_DELETE = "*** Delete File: ";
+const FILE_UPDATE = "*** Update File: ";
+const MOVE_TO = "*** Move to: ";
+const END_OF_FILE = "*** End of File";
+const BEGIN_PATCH = "*** Begin Patch";
+const END_PATCH = "*** End Patch";
+
+/**
+ * Preview bounds. The patch itself is capped at apply time (1 MiB / 1000 hunks), but the TUI
+ * re-renders on every streaming token, so the preview scanner bails earlier to keep the UI
+ * responsive and its retained output bounded (see AGENTS.md: "bound tool output").
+ */
+const PREVIEW_LINES_COLLAPSED = 10;
+const PREVIEW_LINES_EXPANDED = 500;
+const MAX_PREVIEW_BYTES = 256 * 1024;
+const MAX_PREVIEW_FILES = 500;
+/** Cap a single rendered glimpse line so minified/generated content cannot flood the TUI. */
+const PREVIEW_LINE_CHARS = 200;
+
+export type PatchLineType = "add" | "del" | "ctx";
+
+export interface PatchPreviewLine {
+  type: PatchLineType;
+  text: string;
+}
+
+export interface PatchPreviewFile {
+  kind: "add" | "update" | "delete";
+  path: string;
+  /** Destination for an update that carries `*** Move to:`; execution writes this path and deletes `path`. */
+  moveTo?: string;
+  /** Diff lines for the file. Empty for deletes (the patch carries no content for them). */
+  lines: PatchPreviewLine[];
+}
+
+export interface PatchPreview {
+  files: PatchPreviewFile[];
+  totalAdded: number;
+  totalRemoved: number;
+  /** True when the preview stopped early because the patch exceeded a preview bound. */
+  truncated: boolean;
+}
+
+/**
+ * Tolerantly scan a (possibly incomplete) apply_patch body into a preview.
+ *
+ * The grammar is line-oriented, so a partial buffer is always a prefix of valid lines. We walk
+ * every line and accumulate per-file diff lines and running counts; malformed/unknown lines are
+ * ignored rather than thrown on. Each call re-scans the current buffer from scratch, so there is
+ * no accumulation drift across streaming deltas.
+ */
+export function scanPatchPreview(input: string): PatchPreview {
+  // Bound per-render work: cap the bytes we split and walk so a large patch (up to 1 MiB at apply
+  // time) cannot make streaming re-renders quadratic. Anything past the cap is reported truncated.
+  const capped = input.length > MAX_PREVIEW_BYTES + 1 ? input.slice(0, MAX_PREVIEW_BYTES + 1) : input;
+  const lines = capped.split("\n");
+
+  const filesByPath = new Map<string, PatchPreviewFile>();
+  const files: PatchPreviewFile[] = []; // first-seen order
+  let totalAdded = 0;
+  let totalRemoved = 0;
+  let current: PatchPreviewFile | undefined;
+  let truncated = input.length > capped.length;
+
+  for (const raw of lines) {
+    const line = raw.replace(/\r$/, "");
+    // The terminator ends the patch; trailing text must not change totals or the active file.
+    if (line === END_PATCH) break;
+    if (line === "" || line === BEGIN_PATCH || line === END_OF_FILE) continue;
+
+    if (line.startsWith(MOVE_TO)) {
+      // A move renames the current update's file; preserve the destination so the preview can
+      // show the source -> destination transition (execution deletes source, writes destination).
+      if (current) current.moveTo = line.slice(MOVE_TO.length).trim();
+      continue;
+    }
+
+    if (line.startsWith(FILE_ADD) || line.startsWith(FILE_DELETE) || line.startsWith(FILE_UPDATE)) {
+      const kind: PatchPreviewFile["kind"] = line.startsWith(FILE_ADD)
+        ? "add"
+        : line.startsWith(FILE_DELETE)
+          ? "delete"
+          : "update";
+      const prefix = kind === "add" ? FILE_ADD : kind === "delete" ? FILE_DELETE : FILE_UPDATE;
+      const path = line.slice(prefix.length);
+      const existing = filesByPath.get(path);
+      if (existing) {
+        // Execution coalesces multiple hunks for the same path; the preview must too, otherwise
+        // the roster shows duplicate rows and an inflated file count.
+        current = existing;
+        continue;
+      }
+      if (files.length >= MAX_PREVIEW_FILES) {
+        truncated = true;
+        break;
+      }
+      current = { kind, path, lines: [] };
+      filesByPath.set(path, current);
+      files.push(current);
+      continue;
+    }
+
+    // Lines before the first file header (or inside a delete) carry no preview content.
+    if (!current || current.kind === "delete") continue;
+
+    if (line === "@@" || line.startsWith("@@ ")) continue; // chunk context marker
+
+    if (line.startsWith("+")) {
+      current.lines.push({ type: "add", text: line.slice(1) });
+      totalAdded++;
+    } else if (line.startsWith("-")) {
+      current.lines.push({ type: "del", text: line.slice(1) });
+      totalRemoved++;
+    } else {
+      // Context line (" text") or a bare "" inside a chunk.
+      current.lines.push({ type: "ctx", text: line.startsWith(" ") ? line.slice(1) : line });
+    }
+  }
+
+  return { files, totalAdded, totalRemoved, truncated };
+}
+
+function fileStatusMark(file: PatchPreviewFile): string {
+  switch (file.kind) {
+    case "add":
+      return "A";
+    case "delete":
+      return "D";
+    default:
+      return "M";
+  }
+}
+
+function fileCountsLabel(file: PatchPreviewFile, theme: Theme): string {
+  if (file.kind === "delete") return "";
+  const added = theme.fg("toolDiffAdded", `+${countLines(file, "add")}`);
+  const removed = file.kind === "update" ? ` ${theme.fg("toolDiffRemoved", `-${countLines(file, "del")}`)}` : "";
+  return `${added}${removed}`;
+}
+
+function fileMarkLabel(file: PatchPreviewFile, theme: Theme): string {
+  const mark = file.kind === "add" ? "toolDiffAdded" : file.kind === "delete" ? "toolDiffRemoved" : "warning";
+  return theme.fg(mark, fileStatusMark(file));
+}
+
+function filePathLabel(file: PatchPreviewFile, theme: Theme): string {
+  const path = theme.fg("accent", truncatePath(file.path));
+  return file.moveTo ? `${path} ${theme.fg("muted", "->")} ${theme.fg("accent", truncatePath(file.moveTo))}` : path;
+}
+
+function formatFileRosterLine(file: PatchPreviewFile, theme: Theme): string {
+  const counts = fileCountsLabel(file, theme);
+  return `${fileMarkLabel(file, theme)} ${filePathLabel(file, theme)}${counts ? ` ${counts}` : ""}`;
+}
+
+function countLines(file: PatchPreviewFile, type: PatchLineType): number {
+  let n = 0;
+  for (const line of file.lines) if (line.type === type) n++;
+  return n;
+}
+
+/**
+ * Render one glimpse line directly. apply_patch has no real line numbers (only `@@` anchors), so
+ * we color +/- lines without fabricating numbers, and cap each line's width.
+ */
+function renderGlimpseLine(line: PatchPreviewLine, theme: Theme): string {
+  const sign = line.type === "add" ? "+" : line.type === "del" ? "-" : " ";
+  const body = line.text.length > PREVIEW_LINE_CHARS ? `${line.text.slice(0, PREVIEW_LINE_CHARS)}…` : line.text;
+  const styled = `${sign}${body}`;
+  if (line.type === "add") return theme.fg("toolDiffAdded", styled);
+  if (line.type === "del") return theme.fg("toolDiffRemoved", styled);
+  return theme.fg("toolDiffContext", styled);
+}
+
+function focusFile(files: PatchPreviewFile[]): PatchPreviewFile | undefined {
+  // Prefer the most recent file that has visible content to glimpse; fall back to the last file.
+  for (let index = files.length - 1; index >= 0; index--) {
+    const file = files[index];
+    if (file.kind !== "delete" && file.lines.length > 0) return file;
+  }
+  return files.at(-1);
+}
+
+/** Cap a rendered path: keep the tail (filename/extension) since that is the meaningful part. */
+function truncatePath(path: string): string {
+  return path.length > PREVIEW_LINE_CHARS ? `…${path.slice(path.length - PREVIEW_LINE_CHARS + 1)}` : path;
+}
+
+/** Format the live apply_patch tool-call text (streaming glimpse + tally). */
+export function formatApplyPatchCallText(rawPatch: string, theme: Theme, options: { expanded: boolean }): string {
+  const preview = scanPatchPreview(rawPatch);
+  const title = theme.fg("toolTitle", theme.bold("apply_patch"));
+  if (preview.files.length === 0) return title;
+
+  let text: string;
+  if (preview.files.length === 1) {
+    // Single file: lead with the status mark + path (like the built-in `write` tool, with the
+    // file's A/M/D status so a delete is distinguishable from an empty in-progress update).
+    const file = preview.files[0];
+    const counts = fileCountsLabel(file, theme);
+    text = `${title} ${fileMarkLabel(file, theme)} ${filePathLabel(file, theme)}${counts ? ` ${counts}` : ""}`;
+  } else {
+    const tally = `${theme.fg("toolDiffAdded", `+${preview.totalAdded}`)} ${theme.fg("toolDiffRemoved", `-${preview.totalRemoved}`)} ${theme.fg("muted", `· ${preview.files.length} files`)}`;
+    // Cap the collapsed roster so a multi-hundred-file patch cannot re-render hundreds of lines
+    // every token; expansion reveals the rest (up to the preview file cap).
+    const maxRoster = options.expanded ? preview.files.length : PREVIEW_LINES_COLLAPSED;
+    const visible = preview.files.slice(0, maxRoster);
+    let roster = visible.map((file) => formatFileRosterLine(file, theme)).join("\n");
+    const hidden = preview.files.length - visible.length;
+    if (hidden > 0) roster += `\n${theme.fg("muted", `… ${hidden} more files`)}`;
+    text = `${title}  ${tally}\n${roster}`;
+  }
+
+  const focus = focusFile(preview.files);
+  if (focus && focus.kind !== "delete" && focus.lines.length > 0) {
+    // Even expanded, cap rendered output so a huge file cannot stall the terminal.
+    const maxLines = options.expanded ? PREVIEW_LINES_EXPANDED : PREVIEW_LINES_COLLAPSED;
+    const visible = focus.lines.slice(0, maxLines);
+    const remaining = focus.lines.length - maxLines;
+    let body = visible.map((line) => renderGlimpseLine(line, theme)).join("\n");
+    if (remaining > 0) {
+      body += theme.fg(
+        "muted",
+        `\n... (${remaining} more lines, ${focus.lines.length} total, ${keyHint("app.tools.expand", "to expand")})`,
+      );
+    }
+    // In multi-file previews the focused file may be hidden behind the capped roster, so label the
+    // glimpse with its own row (the single-file header already carries the path).
+    const label = preview.files.length > 1 ? `${formatFileRosterLine(focus, theme)}\n` : "";
+    text += `\n\n${label}${body}`;
+  }
+
+  if (preview.truncated) {
+    text += `\n${theme.fg("muted", "(large patch; preview truncated)")}`;
+  }
+  return text;
+}
+
+/**
+ * Format the apply_patch tool-result text. On success the streaming glimpse already conveys the
+ * change, so nothing is added (mirrors the built-in `write` tool). On error the message is shown.
+ */
+export function formatApplyPatchResultText(
+  result: { content: Array<{ type: string; text?: string }> },
+  theme: Theme,
+  isError: boolean,
+): string | undefined {
+  if (!isError) return undefined;
+  const output = result.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text ?? "")
+    .join("\n")
+    .trim();
+  return output ? theme.fg("error", output) : undefined;
+}

--- a/packages/pi-codex-tools/tests/patch-preview.test.mjs
+++ b/packages/pi-codex-tools/tests/patch-preview.test.mjs
@@ -1,0 +1,304 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { scanPatchPreview } = await import("../src/patch-preview.ts");
+
+function findFile(preview, path) {
+  return preview.files.find((file) => file.path === path);
+}
+
+test("returns no files for an empty or header-only patch", () => {
+  assert.deepEqual(scanPatchPreview("").files, []);
+  assert.deepEqual(scanPatchPreview("*** Begin Patch").files, []);
+});
+
+test("does not throw on a truncated/partial patch body", () => {
+  // Missing "*** End Patch"; a file header is mid-stream. Must not throw.
+  const preview = scanPatchPreview("*** Begin Patch\n*** Update File: src/f");
+  assert.equal(preview.files.length, 1);
+  assert.equal(findFile(preview, "src/f").kind, "update");
+});
+
+test("counts added lines for a new (Add File) hunk", () => {
+  const preview = scanPatchPreview(
+    [
+      "*** Begin Patch",
+      "*** Add File: lib/new.ts",
+      "+export const x = 1;",
+      "+export const y = 2;",
+      "*** End Patch",
+    ].join("\n"),
+  );
+  const file = findFile(preview, "lib/new.ts");
+  assert.equal(file.kind, "add");
+  assert.equal(file.lines.length, 2);
+  assert.deepEqual(file.lines.map((line) => line.type), ["add", "add"]);
+  assert.equal(preview.totalAdded, 2);
+  assert.equal(preview.totalRemoved, 0);
+});
+
+test("counts added, removed, and context lines for an update hunk", () => {
+  const preview = scanPatchPreview(
+    [
+      "*** Begin Patch",
+      "*** Update File: src/app.ts",
+      "@@ context line here",
+      " unchanged",
+      "-old line",
+      "+new line",
+      "*** End Patch",
+    ].join("\n"),
+  );
+  const file = findFile(preview, "src/app.ts");
+  assert.equal(file.kind, "update");
+  assert.equal(file.lines.length, 3);
+  assert.deepEqual(
+    file.lines.map((line) => line.type),
+    ["ctx", "del", "add"],
+  );
+  assert.equal(file.lines[0].text, "unchanged");
+  assert.equal(file.lines[1].text, "old line");
+  assert.equal(file.lines[2].text, "new line");
+  assert.equal(preview.totalAdded, 1);
+  assert.equal(preview.totalRemoved, 1);
+});
+
+test("treats @@ and '@@ text' as chunk headers, not content", () => {
+  const preview = scanPatchPreview(
+    [
+      "*** Begin Patch",
+      "*** Update File: a.txt",
+      "@@",
+      "+first",
+      "@@ another anchor",
+      "+second",
+      "*** End Patch",
+    ].join("\n"),
+  );
+  const file = findFile(preview, "a.txt");
+  assert.equal(file.lines.length, 2);
+  assert.deepEqual(file.lines.map((line) => line.text), ["first", "second"]);
+});
+
+test("records a delete hunk with no diff lines", () => {
+  const preview = scanPatchPreview(
+    ["*** Begin Patch", "*** Delete File: stale.log", "*** End Patch"].join("\n"),
+  );
+  const file = findFile(preview, "stale.log");
+  assert.equal(file.kind, "delete");
+  assert.equal(file.lines.length, 0);
+  // Deletes contribute no +/- tallies (the patch carries no content for them).
+  assert.equal(preview.totalAdded, 0);
+  assert.equal(preview.totalRemoved, 0);
+});
+
+test("aggregates counts across multiple files", () => {
+  const preview = scanPatchPreview(
+    [
+      "*** Begin Patch",
+      "*** Add File: a.ts",
+      "+a1",
+      "+a2",
+      "*** Update File: b.ts",
+      "-b1",
+      "+b2",
+      "*** Delete File: c.ts",
+      "*** End Patch",
+    ].join("\n"),
+  );
+  assert.equal(preview.files.length, 3);
+  assert.equal(preview.totalAdded, 3);
+  assert.equal(preview.totalRemoved, 1);
+});
+
+test("ignores Move-to headers without creating a phantom file", () => {
+  const preview = scanPatchPreview(
+    [
+      "*** Begin Patch",
+      "*** Update File: old.ts",
+      "*** Move to: new.ts",
+      "@@ ctx",
+      "+x",
+      "*** End Patch",
+    ].join("\n"),
+  );
+  assert.equal(preview.files.length, 1);
+  assert.equal(findFile(preview, "new.ts"), undefined);
+  assert.equal(findFile(preview, "old.ts").lines.length, 1);
+});
+
+test("re-scans fresh each call: a growing prefix does not double-count", () => {
+  const head = "*** Begin Patch\n*** Add File: a.ts\n+one\n";
+  const partial = scanPatchPreview(head);
+  const grown = scanPatchPreview(head + "+two\n");
+  assert.equal(partial.totalAdded, 1);
+  assert.equal(grown.totalAdded, 2);
+  assert.equal(partial.files[0].lines.length, 1);
+  assert.equal(grown.files[0].lines.length, 2);
+});
+
+test("normalizes CRLF line endings before classifying lines", () => {
+  const preview = scanPatchPreview("*** Begin Patch\r\n*** Add File: a.ts\r\n+hello\r\n*** End Patch");
+  const file = findFile(preview, "a.ts");
+  assert.equal(file.lines.length, 1);
+  assert.equal(file.lines[0].type, "add");
+  assert.equal(file.lines[0].text, "hello");
+});
+
+test("stops scanning at *** End Patch: trailing content does not skew totals", () => {
+  const preview = scanPatchPreview(
+    [
+      "*** Begin Patch",
+      "*** Add File: a.ts",
+      "+real",
+      "*** End Patch",
+      "+phantom added after terminator",
+      "-phantom removed after terminator",
+      "*** Update File: phantom.ts",
+      "+more",
+    ].join("\n"),
+  );
+  assert.equal(preview.files.length, 1);
+  assert.equal(preview.totalAdded, 1);
+  assert.equal(preview.totalRemoved, 0);
+  assert.equal(findFile(preview, "phantom.ts"), undefined);
+});
+
+test("bounds a runaway patch: marks truncated and caps retained files", () => {
+  const manyFiles = Array.from({ length: 2000 }, (_, i) => `*** Add File: f${i}.ts\n+x`).join("\n");
+  const preview = scanPatchPreview(`*** Begin Patch\n${manyFiles}\n*** End Patch`);
+  assert.equal(preview.truncated, true);
+  assert.ok(preview.files.length <= 500, `expected <= 500 files, got ${preview.files.length}`);
+});
+
+test("marks truncated when the byte ceiling is exceeded", () => {
+  const big = "+" + "x".repeat(300 * 1024);
+  const preview = scanPatchPreview(`*** Begin Patch\n*** Add File: huge.txt\n${big}\n*** End Patch`);
+  assert.equal(preview.truncated, true);
+  assert.ok(preview.files.length >= 1);
+});
+
+test("single-file delete header shows the D status mark", async () => {
+  const { initTheme } = await import("@earendil-works/pi-coding-agent");
+  const { formatApplyPatchCallText } = await import("../src/patch-preview.ts");
+  initTheme("dark");
+  const theme = globalThis[Symbol.for("@earendil-works/pi-coding-agent:theme")];
+  const out = formatApplyPatchCallText(
+    ["*** Begin Patch", "*** Delete File: stale.log", "*** End Patch"].join("\n"),
+    theme,
+    { expanded: false },
+  ).replace(/\x1b\[[0-9;]*m/g, "");
+  assert.match(out, /D stale\.log/);
+});
+
+test("captures Move-to destination and renders the source -> destination transition", async () => {
+  const { initTheme } = await import("@earendil-works/pi-coding-agent");
+  const { scanPatchPreview, formatApplyPatchCallText } = await import("../src/patch-preview.ts");
+  initTheme("dark");
+  const theme = globalThis[Symbol.for("@earendil-works/pi-coding-agent:theme")];
+  const patch = [
+    "*** Begin Patch",
+    "*** Update File: src/old.ts",
+    "*** Move to: src/new.ts",
+    "@@ ctx",
+    "+x",
+    "*** End Patch",
+  ].join("\n");
+  const preview = scanPatchPreview(patch);
+  assert.equal(preview.files.length, 1);
+  assert.equal(findFile(preview, "src/old.ts").moveTo, "src/new.ts");
+  const out = formatApplyPatchCallText(patch, theme, { expanded: false }).replace(/\x1b\[[0-9;]*m/g, "");
+  assert.match(out, /src\/old\.ts -> src\/new\.ts/);
+});
+
+test("coalesces multiple update hunks for the same path into one file", () => {
+  const preview = scanPatchPreview(
+    [
+      "*** Begin Patch",
+      "*** Update File: src/app.ts",
+      "@@ a",
+      "+one",
+      "*** Update File: src/app.ts",
+      "@@ b",
+      "+two",
+      "*** End Patch",
+    ].join("\n"),
+  );
+  assert.equal(preview.files.length, 1, "same-path hunks must not duplicate roster rows");
+  assert.equal(findFile(preview, "src/app.ts").lines.length, 2);
+  assert.equal(preview.totalAdded, 2);
+});
+
+test("collapsed multi-file roster is capped; expansion reveals the rest", async () => {
+  const { initTheme } = await import("@earendil-works/pi-coding-agent");
+  const { formatApplyPatchCallText } = await import("../src/patch-preview.ts");
+  initTheme("dark");
+  const theme = globalThis[Symbol.for("@earendil-works/pi-coding-agent:theme")];
+  const hunks = Array.from({ length: 25 }, (_, i) => `*** Add File: f${i}.ts\n+x`).join("\n");
+  const patch = `*** Begin Patch\n${hunks}\n*** End Patch`;
+  const strip = (s) => s.replace(/\x1b\[[0-9;]*m/g, "");
+  const collapsed = strip(formatApplyPatchCallText(patch, theme, { expanded: false }));
+  const expanded = strip(formatApplyPatchCallText(patch, theme, { expanded: true }));
+  assert.match(collapsed, /… 15 more files/);
+  // The roster (before the blank-line-separated glimpse) is capped at 10.
+  const [rosterSection] = collapsed.split("\n\n");
+  const rosterRows = rosterSection.split("\n").filter((l) => /^A f\d+\.ts/.test(l)).length;
+  assert.ok(rosterRows <= 10, `roster should be capped, got ${rosterRows}`);
+  // Expanded still lists every file in the roster (hard-capped at MAX_PREVIEW_FILES);
+  // the focus label lives in the glimpse section, not the roster.
+  const expandedRoster = expanded.split("\n\n")[0];
+  const expandedRows = expandedRoster.split("\n").filter((l) => /^A f\d+\.ts/.test(l)).length;
+  assert.equal(expandedRows, 25);
+});
+
+test("the focused file labels the glimpse even when hidden behind the roster cap", async () => {
+  const { initTheme } = await import("@earendil-works/pi-coding-agent");
+  const { formatApplyPatchCallText } = await import("../src/patch-preview.ts");
+  initTheme("dark");
+  const theme = globalThis[Symbol.for("@earendil-works/pi-coding-agent:theme")];
+  const hunks = Array.from({ length: 25 }, (_, i) => `*** Add File: f${i}.ts\n+x`).join("\n");
+  const patch = `*** Begin Patch\n${hunks}\n*** End Patch`;
+  const out = formatApplyPatchCallText(patch, theme, { expanded: false }).replace(/\x1b\[[0-9;]*m/g, "");
+  const [, glimpse] = out.split("\n\n");
+  // focusFile picks f24 (latest with content), which is NOT in the capped roster (f0..f9).
+  assert.ok(glimpse.includes("f24.ts"), "the hidden focused file should label the glimpse");
+});
+
+test("truncates unusually long file paths", async () => {
+  const { initTheme } = await import("@earendil-works/pi-coding-agent");
+  const { formatApplyPatchCallText } = await import("../src/patch-preview.ts");
+  initTheme("dark");
+  const theme = globalThis[Symbol.for("@earendil-works/pi-coding-agent:theme")];
+  const longPath = `${"p".repeat(300)}.ts`;
+  const patch = `*** Begin Patch\n*** Add File: ${longPath}\n+x\n*** End Patch`;
+  const out = formatApplyPatchCallText(patch, theme, { expanded: false }).replace(/\x1b\[[0-9;]*m/g, "");
+  assert.ok(out.includes("…"), "long path should be truncated");
+  assert.ok(!out.includes(longPath), "the full path must not be rendered");
+  assert.ok(out.includes(".ts"), "the filename/extension should be preserved");
+});
+
+test("glimpse lines carry no fabricated line numbers", async () => {
+  const { initTheme } = await import("@earendil-works/pi-coding-agent");
+  const { formatApplyPatchCallText } = await import("../src/patch-preview.ts");
+  initTheme("dark");
+  const theme = globalThis[Symbol.for("@earendil-works/pi-coding-agent:theme")];
+  const patch = ["*** Begin Patch", "*** Update File: a.ts", "@@ ctx", "-old", "+new", "*** End Patch"].join("\n");
+  const out = formatApplyPatchCallText(patch, theme, { expanded: false }).replace(/\x1b\[[0-9;]*m/g, "");
+  assert.match(out, /^-old$/m);
+  assert.match(out, /^\+new$/m);
+  // No synthetic "-1"/"+2" gutter numbers.
+  assert.doesNotMatch(out, /[-+]\d+ (old|new)/);
+});
+
+test("caps a single very long glimpse line", async () => {
+  const { initTheme } = await import("@earendil-works/pi-coding-agent");
+  const { formatApplyPatchCallText } = await import("../src/patch-preview.ts");
+  initTheme("dark");
+  const theme = globalThis[Symbol.for("@earendil-works/pi-coding-agent:theme")];
+  const long = "x".repeat(2000);
+  const patch = `*** Begin Patch\n*** Add File: min.json\n+${long}\n*** End Patch`;
+  const out = formatApplyPatchCallText(patch, theme, { expanded: false }).replace(/\x1b\[[0-9;]*m/g, "");
+  const glimpseLine = out.split("\n").find((l) => l.startsWith("+"));
+  assert.ok(glimpseLine.length < long.length, "long line should be truncated");
+  assert.ok(glimpseLine.endsWith("…"), "truncated line should end with an ellipsis");
+});


### PR DESCRIPTION
## Summary

`apply_patch` (in `pi-codex-tools`) now streams live progress in the Pi TUI while a patch is generated, instead of showing only the tool title. Addresses kata **8wq9**.

Closes the gap found while comparing Codex and Pi: Codex renders a structured diff only *after* parse (its streaming hook `on_patch_apply_output_delta` is a deliberate no-op), while Pi's built-in `write`/`edit` tools stream a live preview. This reconciles both:

- **Liveness** (from `write`): token-by-token streaming preview driven off Pi's existing render-from-streaming-args path.
- **Structure** (from Codex): color-coded diff + per-file `+added -removed` counts/roster.

## What changed

- **`src/patch-preview.ts`** (new): a tolerant partial-patch scanner (`scanPatchPreview`) that never throws on incomplete/streaming input, plus themed formatters reusing Pi's shared `renderDiff` / `keyHint`.
- **`extensions/index.ts`**: wired `renderCall` (live diff glimpse + running `+added -removed` tally + path-aware single-file header + per-file roster for multi-file patches, capped at 10 lines and expandable, cached incrementally on `lastComponent`) and `renderResult` (errors in red; redundant success text hidden — mirrors `write`).
- **`package.json`**: declared `@earendil-works/pi-tui` (peer `*` + dev `^0.82.1`, matching sibling extension packages).
- **README** / **CHANGELOG**: documented the capability.

Patch **execution semantics are unchanged** — this is rendering only, using documented Pi APIs (`renderDiff`, `keyHint`, `Theme`, `Text`/`Container`); no new Pi APIs.

## Validation

- `npm run -w packages/pi-codex-tools check`
- `npm test -w packages/pi-codex-tools` — 31 tests, 30 pass (1 pre-existing skip)
- `npm run validate:packages` — 12 packages
- `npm ci --dry-run`
- `npm run -w packages/pi-codex-tools pack:dry-run` — `src/patch-preview.ts` included, no stray files
- `git diff --check`
- Formatter smoke test (tsx): tally / roster / glimpse / error / success verified across add, update, delete, multi-file, and streaming-prefix cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live `apply_patch` progress in the TUI.
  * Added color-coded diff previews with running added and removed line totals.
  * Added per-file progress for multi-file patches, including paths and statuses.
  * Added expandable and collapsed preview views.
  * Added safe previews for incomplete or truncated patches.

* **Documentation**
  * Documented streaming patch progress and preview behavior.

* **Tests**
  * Added coverage for patch termination, limits, file changes, moves, and line-ending variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->