### PR TITLE
Trim preview header paths to match execution

### DIFF
--- a/packages/pi-codex-tools/CHANGELOG.md
+++ b/packages/pi-codex-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Fixed
+
+- Trim patch header paths in the streaming preview so whitespace-padded headers coalesce and render the same way execution does (it trims via `headerPath`).
+
 ## [0.1.2] - 2026-08-06
 
 ### Added

--- a/packages/pi-codex-tools/src/patch-preview.ts
+++ b/packages/pi-codex-tools/src/patch-preview.ts
@@ -92,7 +92,9 @@ export function scanPatchPreview(input: string): PatchPreview {
           ? "delete"
           : "update";
       const prefix = kind === "add" ? FILE_ADD : kind === "delete" ? FILE_DELETE : FILE_UPDATE;
-      const path = line.slice(prefix.length);
+      // Match parseApplyPatch's headerPath(), which trims paths, so whitespace-padded headers
+      // coalesce and render the same way execution sees them.
+      const path = line.slice(prefix.length).trim();
       const existing = filesByPath.get(path);
       if (existing) {
         // Execution coalesces multiple hunks for the same path; the preview must too, otherwise

--- a/packages/pi-codex-tools/tests/patch-preview.test.mjs
+++ b/packages/pi-codex-tools/tests/patch-preview.test.mjs
@@ -229,6 +229,15 @@ test("coalesces multiple update hunks for the same path into one file", () => {
   assert.equal(preview.totalAdded, 2);
 });
 
+test("trims header paths so whitespace-padded headers coalesce like execution", () => {
+  const preview = scanPatchPreview(
+    ["*** Begin Patch", "*** Add File: a.ts ", "+x", "*** Update File: a.ts", "@@ c", "+y", "*** End Patch"].join("\n"),
+  );
+  assert.equal(preview.files.length, 1, "padded and clean headers must coalesce into one file");
+  assert.equal(preview.files[0].path, "a.ts");
+  assert.equal(preview.totalAdded, 2);
+});
+
 test("collapsed multi-file roster is capped; expansion reveals the rest", async () => {
   const { initTheme } = await import("@earendil-works/pi-coding-agent");
   const { formatApplyPatchCallText } = await import("../src/patch-preview.ts");


### PR DESCRIPTION
## Summary

Follow-up to #112 addressing a Codex review comment landed just after merge.

The streaming preview scanner keyed files on the raw header path, but `parseApplyPatch` trims paths via `headerPath()` (`.slice(marker.length).trim()`). A whitespace-padded header — e.g. `*** Add File: a.ts ` followed by `*** Update File: a.ts` — therefore coalesces into one file at execution time but rendered as two separate preview entries. The scanner now trims the path before lookup/storage, so coalescing and rendering match execution.

## Validation

- `npm run -w packages/pi-codex-tools check`
- `npm test -w packages/pi-codex-tools` — 43 tests, 42 pass (1 pre-existing skip); added `trims header paths so whitespace-padded headers coalesce like execution`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed patch previews so whitespace-padded file paths are trimmed consistently.
  * Ensured equivalent file paths are combined into a single preview entry.
  * Corrected added-line totals and preview rendering for affected patches.

* **Documentation**
  * Added an unreleased changelog entry describing the patch preview improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->