### PR TITLE
Keep Codex provider parallel calls enabled

### DIFF
--- a/packages/pi-codex-tools/CHANGELOG.md
+++ b/packages/pi-codex-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Changed
+
+- Keep provider-side parallel tool calls enabled while preserving sequential `apply_patch` execution.
+
 ### Fixed
 
 - Strip untrusted terminal control sequences from `apply_patch` previews before rendering them in the Pi TUI.

--- a/packages/pi-codex-tools/README.md
+++ b/packages/pi-codex-tools/README.md
@@ -8,7 +8,7 @@ Give grammar-capable OpenAI/Codex models the Codex `apply_patch` tool in Pi with
 - **Capability-based activation** — requires `openai-codex-responses` or `openai-responses` plus `model.compat.supportsOpenAIGrammarTools === true`; model names alone are never enough.
 - **Safe local mutation** — patches are limited to 1 MiB, target files to 64 MiB, stay under Pi's current working directory, reject symlink escapes, use descriptor-anchored no-follow operations on Linux and macOS, fail closed elsewhere, preflight all hunks, and serialize writes with Pi's mutation queue.
 - **Model switching** — supported models replace Pi's `edit` and `write` tools with `apply_patch`; other active tools are preserved. Switching back restores only the file tools that were active before the switch.
-- **Sequential patch calls** — the extension marks patch execution sequential and disables provider-side parallel tool calls when the patch tool is active.
+- **Sequential patch calls** — the extension marks patch execution sequential while leaving provider-side parallel tool calls enabled.
 - **Streaming progress** — while a patch is generated, the TUI shows a live, color-coded glimpse of the content being written (new-file content, or `+`/`-` lines for updates) plus a running `+added -removed` tally and a per-file roster for multi-file patches. It reuses Pi's shared diff rendering and mirrors the built-in `write`/`edit` previews; patch execution is unchanged.
 
 ## Installation

--- a/packages/pi-codex-tools/extensions/index.ts
+++ b/packages/pi-codex-tools/extensions/index.ts
@@ -122,15 +122,4 @@ export default function piCodexTools(pi: ExtensionAPI): void {
   pi.on("model_select", (_event, ctx) => {
     synchronizeTools(ctx);
   });
-
-  pi.on("before_provider_request", (event, ctx) => {
-    if (!supportsOpenAIGrammarTools(ctx.model)) return;
-    if (typeof pi.getActiveTools !== "function" || !pi.getActiveTools().includes(APPLY_PATCH)) return;
-    if (!isRecord(event.payload) || event.payload.parallel_tool_calls !== true) return;
-    return { ...event.payload, parallel_tool_calls: false };
-  });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/pi-codex-tools/tests/extension.test.mjs
+++ b/packages/pi-codex-tools/tests/extension.test.mjs
@@ -33,6 +33,15 @@ function makePi(initialActive = ["read", "write", "edit", "bash"]) {
   };
 }
 
+async function applyProviderRequestHooks(pi, payload, context) {
+  let nextPayload = payload;
+  for (const handler of pi.handlers.get("before_provider_request") ?? []) {
+    const result = await handler({ payload: nextPayload }, context);
+    if (result !== undefined) nextPayload = result;
+  }
+  return nextPayload;
+}
+
 const codexModel = {
   provider: "openai-codex",
   api: "openai-codex-responses",
@@ -63,15 +72,14 @@ test("replaces edit and write while preserving unrelated active tools", async ()
   await pi.handlers.get("session_start")[0]({}, context);
   assert.deepEqual(pi.getActiveTools(), ["read", "bash", "apply_patch"]);
 
-  const rewritten = await pi.handlers.get("before_provider_request")[0](
-    { payload: { model: codexModel.id, parallel_tool_calls: true } },
-    context,
+  assert.equal(pi.tools.get("apply_patch").executionMode, "sequential");
+  assert.deepEqual(
+    await applyProviderRequestHooks(pi, { model: codexModel.id, parallel_tool_calls: true }, context),
+    { model: codexModel.id, parallel_tool_calls: true },
   );
-  assert.deepEqual(rewritten, { model: codexModel.id, parallel_tool_calls: false });
 
   await pi.handlers.get("model_select")[0]({}, { model: ordinaryModel });
   assert.deepEqual(pi.getActiveTools(), ["read", "bash", "edit", "write"]);
-  assert.equal(await pi.handlers.get("before_provider_request")[0]({ payload: { parallel_tool_calls: true } }, { model: ordinaryModel }), undefined);
 });
 
 test("rejects apply_patch execution for unsupported models", async () => {


### PR DESCRIPTION
## Summary

- Remove the extension hook that rewrote `parallel_tool_calls` to `false`.
- Keep `apply_patch` execution sequential through Pi’s tool execution mode.
- Add regression coverage and update package documentation/changelog.

## Validation

- `npm run -w packages/pi-codex-tools check`
- `npm test -w packages/pi-codex-tools`
- `npm run -w packages/pi-codex-tools pack:dry-run`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Patch operations now execute sequentially for safer, more predictable results.
  * Other provider-supported tool calls can continue running in parallel, improving overall responsiveness.
* **Documentation**
  * Updated the changelog and product documentation to describe the revised execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->