### PR TITLE
Let pi-fast start enabled for supported models

### DIFF
--- a/packages/pi-fast/AGENTS.md
+++ b/packages/pi-fast/AGENTS.md
@@ -4,7 +4,7 @@ Root `AGENTS.md` applies.
 
 ## Invariants
 
-- Fast mode is disabled on every new extension instance and is never persisted.
+- Fast mode defaults to disabled unless `pi-fast.enabledByDefault` is explicitly `true` in global Pi settings; command toggles are never persisted.
 - Only provider/model pairs known to advertise Fast support may receive a fast-mode request.
 - OpenAI Codex Fast mode uses the `priority` service tier, which can increase usage.
 - The status indicator must reflect the current model: on, off, or unavailable.

--- a/packages/pi-fast/CHANGELOG.md
+++ b/packages/pi-fast/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Added
+
+- Add the global `pi-fast.enabledByDefault` setting to start sessions with Fast mode enabled for all supported models.
+
 ### Changed
 
 - Share install telemetry mechanics through `@mocito/install-telemetry` while preserving Pi-specific settings and state paths.

--- a/packages/pi-fast/README.md
+++ b/packages/pi-fast/README.md
@@ -2,14 +2,15 @@
 
 Use provider fast modes in Pi when you need lower latency, while keeping the paid path off by default.
 
-`pi-fast` currently supports OpenAI Codex models that advertise Fast processing. It adds Codex's `priority` service tier only after you explicitly enable it for the session.
+`pi-fast` currently supports OpenAI Codex models that advertise Fast processing. It adds Codex's `priority` service tier after you enable it for the session or opt in to the global default.
 
 ## Features
 
 - **On-demand toggle** — use `/fast`, `/fast on`, `/fast off`, or `Ctrl+Shift+F`.
 - **Safe model guard** — only supported `openai-codex` models receive the Fast request field.
 - **Visible state** — the Pi footer shows `Fast on`, `Fast off`, or `Fast n/a`.
-- **Session-local behavior** — Fast mode starts off and is never persisted.
+- **Configurable default** — opt in once to start Fast mode on for every supported model.
+- **Session-local overrides** — command and shortcut changes reset to the configured default for each session.
 
 ## Supported models
 
@@ -65,7 +66,17 @@ or press `Ctrl+Shift+F`.
 
 ## Configuration
 
-There is no Fast-mode configuration. The mode is intentionally disabled when Pi starts and resets when the extension reloads or the session ends.
+Fast mode remains off by default. To start every session with Fast mode enabled for all supported models, add this setting to Pi's global `settings.json` (normally `~/.pi/agent/settings.json`, or the configured agent directory):
+
+```json
+{
+  "pi-fast": {
+    "enabledByDefault": true
+  }
+}
+```
+
+This is a global opt-in because the `priority` service tier can increase provider usage. Unsupported provider/model pairs remain unchanged. `/fast off` disables Fast mode for the current session; starting, switching, or reloading a session restores the configured default.
 
 Install/update telemetry can be disabled with `PI_OFFLINE=1` or `PI_TELEMETRY=0`.
 

--- a/packages/pi-fast/SECURITY.md
+++ b/packages/pi-fast/SECURITY.md
@@ -19,9 +19,9 @@ Report privately through [GitHub Security Advisories](https://github.com/jvm/pi-
 
 `pi-fast` is a Pi package. Pi extensions execute with the same permissions as the local user running Pi. Users should review installed Pi packages and only install packages from sources they trust.
 
-The extension does not read or log prompts, credentials, auth headers, or provider responses. It only inspects the current provider/model identifier and creates an in-memory request payload copy with `service_tier: "priority"` for supported OpenAI Codex models when Fast mode is enabled.
+The extension does not read or log prompts, credentials, auth headers, or provider responses. It reads only the `pi-fast.enabledByDefault` value from global Pi settings, inspects the current provider/model identifier, and creates an in-memory request payload copy with `service_tier: "priority"` for supported OpenAI Codex models when Fast mode is enabled.
 
-Fast mode is off by default and is never persisted. Models without an advertised Fast tier are not modified. The `priority` tier can increase provider usage, so the footer and toggle notifications make the active state visible.
+Fast mode is off by default unless `pi-fast.enabledByDefault` is explicitly `true`. Session toggles are not persisted. Models without an advertised Fast tier are not modified. The `priority` tier can increase provider usage, so the setting is an explicit opt-in and the footer and toggle notifications make the active state visible.
 
 On startup, `@mocito/install-telemetry` sends a best-effort install/update telemetry ping to the configured telemetry endpoint once per package version unless Pi telemetry is disabled, offline mode is enabled, or Pi runs in CI. The ping contains only the package name, version, and parsed platform/runtime/architecture from its User-Agent; it does not include prompts, file paths, config values, environment variables, or API keys.
 

--- a/packages/pi-fast/extensions/index.ts
+++ b/packages/pi-fast/extensions/index.ts
@@ -1,6 +1,7 @@
 import { Key } from "@earendil-works/pi-tui";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { reportInstallTelemetry } from "../src/install-telemetry.js";
+import { isFastModeEnabledByDefault } from "../src/config.js";
 import { applyFastMode, supportsFastMode } from "../src/fast-mode.js";
 
 const STATUS_KEY = "pi-fast";
@@ -69,7 +70,7 @@ export default function piFast(pi: ExtensionAPI): void {
   });
 
   pi.on("session_start", async (_event, ctx) => {
-    enabled = false;
+    enabled = await isFastModeEnabledByDefault();
     updateStatus(ctx);
   });
 

--- a/packages/pi-fast/src/config.ts
+++ b/packages/pi-fast/src/config.ts
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+const SETTINGS_KEY = "pi-fast";
+
+export async function isFastModeEnabledByDefault(
+  settingsPath = join(getAgentDir(), "settings.json"),
+): Promise<boolean> {
+  try {
+    const parsed = JSON.parse(await readFile(settingsPath, "utf-8")) as unknown;
+    if (!isRecord(parsed)) return false;
+
+    const settings = parsed[SETTINGS_KEY];
+    return isRecord(settings) && settings.enabledByDefault === true;
+  } catch (error) {
+    if (isMissingFileError(error)) return false;
+    throw error;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}

--- a/packages/pi-fast/src/config.ts
+++ b/packages/pi-fast/src/config.ts
@@ -14,7 +14,7 @@ export async function isFastModeEnabledByDefault(
     const settings = parsed[SETTINGS_KEY];
     return isRecord(settings) && settings.enabledByDefault === true;
   } catch (error) {
-    if (isMissingFileError(error)) return false;
+    if (error instanceof SyntaxError || isMissingFileError(error)) return false;
     throw error;
   }
 }

--- a/packages/pi-fast/tests/extension.test.mjs
+++ b/packages/pi-fast/tests/extension.test.mjs
@@ -124,6 +124,27 @@ test("enables Fast by default for supported models when configured", async () =>
   }
 });
 
+test("keeps Fast off when global settings contain malformed JSON", async () => {
+  const settingsPath = join(agentDir, "settings.json");
+  await writeFile(settingsPath, "{ malformed", "utf-8");
+
+  try {
+    const pi = makePi();
+    piFast(pi);
+    const context = makeContext({ provider: "openai-codex", id: "gpt-5.4" });
+
+    await pi.handlers.get("session_start")[0]({}, context);
+
+    assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast off" });
+    assert.equal(
+      await pi.handlers.get("before_provider_request")[0]({ payload: {} }, context),
+      undefined,
+    );
+  } finally {
+    await rm(settingsPath, { force: true });
+  }
+});
+
 test("does not render footer status outside TUI", async () => {
   const pi = makePi();
   piFast(pi);

--- a/packages/pi-fast/tests/extension.test.mjs
+++ b/packages/pi-fast/tests/extension.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 process.env.CI = "1";
+const agentDir = await mkdtemp(join(tmpdir(), "pi-fast-extension-test-"));
+process.env.PI_CODING_AGENT_DIR = agentDir;
 
 const { default: piFast } = await import("../extensions/index.ts");
 const { FAST_SERVICE_TIER, applyFastMode, supportsFastMode } = await import("../src/fast-mode.ts");
@@ -90,6 +95,35 @@ test("keeps Fast off by default and rewrites supported provider requests after t
   assert.deepEqual(await beforeRequest({ payload: { model: "gpt-5.4" } }, context), undefined);
 });
 
+test("enables Fast by default for supported models when configured", async () => {
+  const settingsPath = join(agentDir, "settings.json");
+  await writeFile(
+    settingsPath,
+    `${JSON.stringify({ "pi-fast": { enabledByDefault: true } }, null, 2)}\n`,
+    "utf-8",
+  );
+
+  try {
+    const pi = makePi();
+    piFast(pi);
+    const context = makeContext({ provider: "openai-codex", id: "gpt-5.4-mini" });
+    const beforeRequest = pi.handlers.get("before_provider_request")[0];
+
+    await pi.handlers.get("session_start")[0]({}, context);
+    assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast n/a" });
+
+    context.model = { provider: "openai-codex", id: "gpt-5.4" };
+    await pi.handlers.get("model_select")[0]({}, context);
+    assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast on" });
+    assert.deepEqual(
+      await beforeRequest({ payload: { model: "gpt-5.4" } }, context),
+      { model: "gpt-5.4", service_tier: "priority" },
+    );
+  } finally {
+    await rm(settingsPath, { force: true });
+  }
+});
+
 test("does not render footer status outside TUI", async () => {
   const pi = makePi();
   piFast(pi);
@@ -111,4 +145,8 @@ test("does not enable Fast for unsupported models", async () => {
   assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast n/a" });
   assert.equal(context.notifications.at(-1).type, "warning");
   assert.equal(await pi.handlers.get("before_provider_request")[0]({ payload: {} }, context), undefined);
+});
+
+test.after(async () => {
+  await rm(agentDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
**Adds an explicit global opt-in for starting Fast mode enabled on every supported model.** Users who prefer lower latency no longer need to run `/fast` in each session, while the default remains off for everyone else.

Configure the behavior in Pi's global settings:

```json
{
  "pi-fast": {
    "enabledByDefault": true
  }
}
```

The extension reloads this default when a session starts. Unsupported provider/model pairs remain unchanged, and `/fast on` or `/fast off` still overrides the state for the current session.

> Codex's `priority` service tier can increase usage, so enabling it remains an explicit global choice with visible footer status.

**Validated with the package typecheck, all nine tests, and the package dry-run archive.**

_Generated by Pi (model `gpt-5.6-sol`)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fast mode can now be enabled by default through the global `pi-fast.enabledByDefault` setting.
  * Fast mode still activates only for supported models.

* **Bug Fixes**
  * Fast mode now starts disabled when no valid default setting is configured.
  * Session-level toggle changes remain temporary and reset between sessions.

* **Documentation**
  * Added configuration, usage, security, and changelog guidance for the new default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
