### PR TITLE
Release pi-fast 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4841,7 +4841,7 @@
       }
     },
     "packages/pi-fast": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@mocito/install-telemetry": "0.1.1"

--- a/packages/pi-fast/CHANGELOG.md
+++ b/packages/pi-fast/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-08-11
+
 ### Added
 
 - Add the global `pi-fast.enabledByDefault` setting to start sessions with Fast mode enabled for all supported models.

--- a/packages/pi-fast/package.json
+++ b/packages/pi-fast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fast",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Toggle provider fast modes in Pi on demand.",
   "type": "module",
   "license": "MIT",

--- a/packages/pi-fast/tests/install-telemetry.test.mjs
+++ b/packages/pi-fast/tests/install-telemetry.test.mjs
@@ -5,6 +5,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const { reportInstallTelemetry } = await import("../src/install-telemetry.ts");
+const { version: packageVersion } = JSON.parse(
+  await readFile(new URL("../package.json", import.meta.url), "utf8"),
+);
 
 const CI_ENVIRONMENT_VARIABLES = [
   "CI",
@@ -90,7 +93,9 @@ test("retries telemetry after failed and non-OK reports", async () => {
 
     reportInstallTelemetry();
     await waitFor(async () => calls === 3 && (await exists(statePath)));
-    assert.deepEqual(JSON.parse(await readFile(statePath, "utf8")), { lastReportedVersion: "0.1.0" });
+    assert.deepEqual(JSON.parse(await readFile(statePath, "utf8")), {
+      lastReportedVersion: packageVersion,
+    });
 
     reportInstallTelemetry();
     await new Promise((resolve) => setTimeout(resolve, 20));


### PR DESCRIPTION
## Summary

- release the new configurable Fast-mode default as pi-fast 0.1.1
- derive the telemetry assertion from package.json so version bumps do not break release validation

## Validation

- [x] `npm run -w packages/pi-fast check`
- [x] `npm test -w packages/pi-fast`
- [x] `npm run -w packages/pi-fast pack:dry-run`
- [x] `npm run validate:packages`
- [x] `npm ci --dry-run --no-audit --no-fund`
- [x] `git diff --check`

## Security and privacy

- [x] No credential, network, trust-boundary, or telemetry payload behavior changes
- [x] Package contents inspected before publishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the pi-fast package to version 0.1.1.
  - Added release information dated August 11, 2026.

- **Tests**
  - Improved installation telemetry validation to automatically verify the current package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->