### PR TITLE
Fix pi-fast shortcut conflict

### DIFF
--- a/packages/pi-fast/CHANGELOG.md
+++ b/packages/pi-fast/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Changed
+
+- Move the Fast mode shortcut from `Ctrl+Shift+F` to `Ctrl+Shift+R` to avoid Pi's transcript search shortcut.
+
 ## [0.1.1] - 2026-08-11
 
 ### Added

--- a/packages/pi-fast/README.md
+++ b/packages/pi-fast/README.md
@@ -6,7 +6,7 @@ Use provider fast modes in Pi when you need lower latency, while keeping the pai
 
 ## Features
 
-- **On-demand toggle** — use `/fast`, `/fast on`, `/fast off`, or `Ctrl+Shift+F`.
+- **On-demand toggle** — use `/fast`, `/fast on`, `/fast off`, or `Ctrl+Shift+R`.
 - **Safe model guard** — only supported `openai-codex` models receive the Fast request field.
 - **Visible state** — the Pi footer shows `Fast on`, `Fast off`, or `Fast n/a`.
 - **Configurable default** — opt in once to start Fast mode on for every supported model.
@@ -60,7 +60,7 @@ Start a supported Codex model, then use either:
 /fast
 ```
 
-or press `Ctrl+Shift+F`.
+or press `Ctrl+Shift+R`.
 
 `/fast` toggles the current state. `/fast on`, `/fast off`, and `/fast toggle` select it explicitly. When active, supported Codex requests include `service_tier: "priority"`, which upstream describes as faster processing with increased usage.
 

--- a/packages/pi-fast/extensions/index.ts
+++ b/packages/pi-fast/extensions/index.ts
@@ -59,7 +59,7 @@ export default function piFast(pi: ExtensionAPI): void {
     },
   });
 
-  pi.registerShortcut(Key.ctrlShift("f"), {
+  pi.registerShortcut(Key.ctrlShift("r"), {
     description: "Toggle Fast mode",
     handler: toggle,
   });

--- a/packages/pi-fast/tests/extension.test.mjs
+++ b/packages/pi-fast/tests/extension.test.mjs
@@ -86,7 +86,7 @@ test("keeps Fast off by default and rewrites supported provider requests after t
     { model: "gpt-5.4", service_tier: "priority" },
   );
 
-  await pi.shortcuts.get("ctrl+shift+f").handler(context);
+  await pi.shortcuts.get("ctrl+shift+r").handler(context);
   assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast off" });
 
   await pi.commands.get("fast").handler("on", context);


### PR DESCRIPTION
## Summary
- move the Fast mode shortcut to Ctrl+Shift+R
- retain a quick Fast mode toggle without conflicting with Pi transcript search
- update regression coverage and user documentation

## Validation
- npm run -w packages/pi-fast check
- npm run -w packages/pi-fast test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fast mode can now be toggled with `Ctrl+Shift+R`.

* **Documentation**
  * Updated the Fast mode shortcut instructions to reflect the new key combination.

* **Bug Fixes**
  * Avoided conflict with the transcript search shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->