### PR TITLE
fix(pi-skillful): support Pi Web and stabilize descriptions

### DIFF
--- a/packages/pi-skillful/CHANGELOG.md
+++ b/packages/pi-skillful/CHANGELOG.md
@@ -14,7 +14,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 - Let `enableInstallTelemetry: false` override an enabled `PI_TELEMETRY` environment flag.
 - Support `/skillful` in [Pi Web](https://github.com/agegr/pi-web) through its RPC custom-component bridge and keep the active Global/Project scope visible with its plain theme. Other compatible RPC clients may also work, but have not been tested.
-- Keep description previews at two lines so the menu does not resize while navigating, with a bounded, scrollable view for the complete description.
+- Keep description previews at two lines so the menu does not resize while navigating, with a bounded, scrollable view opened by the configurable `descriptionKey` (`Space` by default) while Pi's Confirm action retains its existing on/off behavior.
 
 ## [0.4.0] - 2026-07-28
 

--- a/packages/pi-skillful/CHANGELOG.md
+++ b/packages/pi-skillful/CHANGELOG.md
@@ -13,6 +13,8 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 ### Fixed
 
 - Let `enableInstallTelemetry: false` override an enabled `PI_TELEMETRY` environment flag.
+- Support `/skillful` in [Pi Web](https://github.com/agegr/pi-web) through its RPC custom-component bridge and keep the active Global/Project scope visible with its plain theme. Other compatible RPC clients may also work, but have not been tested.
+- Keep description previews at two lines so the menu does not resize while navigating, with a bounded, scrollable view for the complete description.
 
 ## [0.4.0] - 2026-07-28
 

--- a/packages/pi-skillful/README.md
+++ b/packages/pi-skillful/README.md
@@ -54,7 +54,8 @@ Configuration is stored under the `skillful` key in Pi settings:
 ```json
 {
   "skillful": {
-    "hiddenSkills": ["pdf", "xlsx"]
+    "hiddenSkills": ["pdf", "xlsx"],
+    "descriptionKey": "space"
   }
 }
 ```
@@ -64,7 +65,7 @@ Supported scopes:
 - Global: `~/.pi/agent/settings.json`
 - Project: `.pi/settings.json`
 
-Project visibility and toggle slots inherit global settings until changed in the Project tab. When either is changed, Pi Skillful writes a full project override containing both `hiddenSkills` and `toggleSlots`. If the project state is changed back to match global, those project override keys are removed so the project inherits global again.
+Project visibility, toggle slots, and `descriptionKey` inherit global settings. Changing visibility or slots in the Project tab writes a full project override containing both `hiddenSkills` and `toggleSlots`; matching values remove those keys so the project inherits global settings again. An explicitly configured project `descriptionKey` overrides the global key.
 
 Open the menu with:
 
@@ -74,9 +75,9 @@ Open the menu with:
 
 **Pi Web support.** The menu works in Pi's terminal interface and in [Pi Web](https://github.com/agegr/pi-web) through its RPC custom-component bridge. The integration is capability-based, so other compatible RPC clients may also work, but they have not been tested. The active Global/Project scope remains explicit with Pi Web's plain theme; clients without custom-component support receive a warning instead of failing silently.
 
-**Stable descriptions.** Description previews stay at two lines while navigating, so different description lengths do not resize the menu. Press `Enter` to open the complete description in a bounded, scrollable view.
+**Stable descriptions.** Description previews stay at two lines while navigating, so different description lengths do not resize the menu. Press `descriptionKey` (`Space` by default) to open or close the complete description in a bounded, scrollable view.
 
-The menu lists configurable skills alphabetically. Press `Space` to toggle the selected skill, including while filtering, and `1` through `9` to assign or clear that scope's session toggle slot. In the Project tab, inherited on/off values are shown normally; project overrides are highlighted. Visibility and toggle slots are independent.
+The menu lists configurable skills alphabetically. The configured Pi Confirm action (`Enter` by default) continues to toggle the selected skill, including while filtering; `1` through `9` assigns or clears that scope's session toggle slot. In the Project tab, inherited on/off values are shown normally; project overrides are highlighted. Visibility and toggle slots are independent.
 
 Project settings are read and the Project tab is available only when Pi trusts the current project. In an untrusted project, `pi-skillful` ignores `.pi/settings.json` and exposes only global settings.
 
@@ -95,7 +96,8 @@ Assign skills to up to nine prompt-editor slots with JSON settings:
       "2": "code-review",
       "3": "git"
     },
-    "toggleModifier": "alt"
+    "toggleModifier": "alt",
+    "descriptionKey": "space"
   }
 }
 ```
@@ -103,6 +105,10 @@ Assign skills to up to nine prompt-editor slots with JSON settings:
 Configured slots appear on the prompt editor's top border as `N skill-name`. Project `toggleSlots`, when defined as part of a project override, replace global `toggleSlots`; otherwise global slots are used and shown in the Project tab. Long names are truncated per slot when needed so all configured slot numbers remain visible. Active slots use the theme accent color; inactive slots use the muted color. Press `alt+1` through `alt+9` by default to toggle a slot for the current session only. Only the configured modifier and assigned slot numbers are consumed while the prompt editor has focus; no modifier-number keys are reserved when no slots are configured.
 
 `toggleModifier` defaults to `"alt"`. Supported values are `"alt"`, `"ctrl"`, `"ctrl+shift"`, `"alt+shift"`, `"ctrl+alt"`, and `"ctrl+alt+shift"`. Change it if your terminal reserves `alt+number` shortcuts. An explicitly configured project value takes precedence over the global value, including explicit `"alt"`. Unsupported explicit values fall back to `"alt"` in that scope.
+
+`descriptionKey` defaults to `"space"` and accepts Pi key identifiers such as `"ctrl+o"`. Invalid or empty values fall back to `"space"`. If it conflicts with an existing menu action, that action keeps its behavior and the description shortcut is not shown.
+
+Available key combinations depend on the client. In [Pi Web](https://github.com/badlogic/pi-web), prefer printable keys or simple combinations such as `"ctrl+o"` and `"alt+o"`; function keys, Super, and multi-modifier combinations may not be transmitted by its input bridge.
 
 On app startup, non-hidden skills are active and hidden skills are inactive. Within a running Pi process, `/new` preserves the current toggle state for the new session. Resuming, forking, cloning, reloading, or restarting Pi resets toggle state from settings. Inline `/skill:name` invocation remains explicit and works even when that skill is inactive. Skills bundled in Pi packages are never modified by these toggles.
 

--- a/packages/pi-skillful/README.md
+++ b/packages/pi-skillful/README.md
@@ -72,7 +72,11 @@ Open the menu with:
 /skillful
 ```
 
-The menu lists configurable skills alphabetically. Toggle a skill off or on in the active scope. Use the Global/Project tabs to choose which settings file to edit. In the Project tab, inherited on/off values are shown normally; project overrides are highlighted. Press `1` through `9` on a selected skill to assign or clear that scope's session toggle slot. Visibility and toggle slots are independent.
+**Pi Web support.** The menu works in Pi's terminal interface and in [Pi Web](https://github.com/agegr/pi-web) through its RPC custom-component bridge. The integration is capability-based, so other compatible RPC clients may also work, but they have not been tested. The active Global/Project scope remains explicit with Pi Web's plain theme; clients without custom-component support receive a warning instead of failing silently.
+
+**Stable descriptions.** Description previews stay at two lines while navigating, so different description lengths do not resize the menu. Press `Enter` to open the complete description in a bounded, scrollable view.
+
+The menu lists configurable skills alphabetically. Press `Space` to toggle the selected skill, including while filtering, and `1` through `9` to assign or clear that scope's session toggle slot. In the Project tab, inherited on/off values are shown normally; project overrides are highlighted. Visibility and toggle slots are independent.
 
 Project settings are read and the Project tab is available only when Pi trusts the current project. In an untrusted project, `pi-skillful` ignores `.pi/settings.json` and exposes only global settings.
 

--- a/packages/pi-skillful/src/config.ts
+++ b/packages/pi-skillful/src/config.ts
@@ -1,3 +1,4 @@
+import type { KeyId } from "@earendil-works/pi-tui";
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -20,6 +21,8 @@ export interface SkillToggleConfig {
 }
 
 export interface SkillfulSettings extends SkillToggleConfig {
+  descriptionKey: KeyId;
+  descriptionKeyDefined: boolean;
   hiddenSkills: string[];
   hiddenSkillsDefined: boolean;
   visibleSkills: string[];
@@ -38,6 +41,7 @@ interface PiSettingsDocument {
 
 export const SKILLFUL_SETTINGS_KEY = "skillful";
 export const SKILL_TOGGLE_SLOTS: SkillToggleSlot[] = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
+export const DEFAULT_DESCRIPTION_KEY: KeyId = "space";
 export const DEFAULT_TOGGLE_MODIFIER: SkillToggleModifier = "alt";
 
 const SUPPORTED_TOGGLE_MODIFIERS_SET: ReadonlySet<string> = new Set(SUPPORTED_TOGGLE_MODIFIERS);
@@ -90,6 +94,28 @@ export function normalizeToggleSlots(value: unknown): Partial<Record<SkillToggle
   return result;
 }
 
+const DESCRIPTION_KEY_MODIFIERS = new Set(["ctrl", "shift", "alt", "super"]);
+const DESCRIPTION_SPECIAL_KEYS = new Set(
+  "escape esc enter return tab space backspace delete insert clear home end pageup pagedown up down left right".split(" "),
+);
+const DESCRIPTION_KEY_CHARACTERS = "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()-_=[]{}`~\\|;:'\",.<>/?";
+
+export function normalizeDescriptionKey(value: unknown): KeyId {
+  if (typeof value !== "string") return DEFAULT_DESCRIPTION_KEY;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return DEFAULT_DESCRIPTION_KEY;
+
+  const parts = normalized.split("+");
+  const base = parts.pop() || "";
+  const validBase =
+    (base.length === 1 && DESCRIPTION_KEY_CHARACTERS.includes(base)) ||
+    DESCRIPTION_SPECIAL_KEYS.has(base) ||
+    /^f(?:[1-9]|1[0-2])$/.test(base);
+  const validModifiers =
+    new Set(parts).size === parts.length && parts.every((part) => DESCRIPTION_KEY_MODIFIERS.has(part));
+  return validBase && validModifiers ? (normalized as KeyId) : DEFAULT_DESCRIPTION_KEY;
+}
+
 export function normalizeToggleModifier(value: unknown): SkillToggleModifier {
   if (typeof value !== "string") return DEFAULT_TOGGLE_MODIFIER;
   const normalized = value.trim().toLowerCase();
@@ -137,7 +163,10 @@ export async function readEffectiveSkillfulSettings(
   const scoped = await readScopedSkillfulSettings(cwd, projectTrusted);
   const hiddenSkills = normalizeSkillNames(effectiveHiddenSkillSet(scoped));
   const toggleSlots = scoped.project.toggleSlotsDefined ? scoped.project.toggleSlots : scoped.global.toggleSlots;
+  const descriptionKey = scoped.project.descriptionKeyDefined ? scoped.project.descriptionKey : scoped.global.descriptionKey;
   return {
+    descriptionKey,
+    descriptionKeyDefined: scoped.global.descriptionKeyDefined || scoped.project.descriptionKeyDefined,
     hiddenSkills,
     hiddenSkillsDefined: scoped.global.hiddenSkillsDefined || scoped.project.hiddenSkillsDefined,
     visibleSkills: [],
@@ -255,6 +284,8 @@ function settingsFromRecord(value: unknown): SkillfulSettings {
   const skillful = value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 
   return {
+    descriptionKey: normalizeDescriptionKey(skillful.descriptionKey),
+    descriptionKeyDefined: Object.hasOwn(skillful, "descriptionKey"),
     hiddenSkills: normalizeSkillNames(stringArray(skillful.hiddenSkills)),
     hiddenSkillsDefined: Object.hasOwn(skillful, "hiddenSkills"),
     visibleSkills: normalizeSkillNames(stringArray(skillful.visibleSkills)),

--- a/packages/pi-skillful/src/extensions/skill-visibility.ts
+++ b/packages/pi-skillful/src/extensions/skill-visibility.ts
@@ -9,6 +9,7 @@ import {
 import {
   type Component,
   Key,
+  type KeyId,
   type KeybindingsManager,
   matchesKey,
   type SettingItem,
@@ -50,6 +51,24 @@ function formatKeyList(keys: string[], fallback: string): string {
   return labels.join("/") || fallback;
 }
 
+function canonicalKeyId(key: string, legacyControls = false): string {
+  const parts = key.toLowerCase().split("+");
+  const base = parts.pop() || "";
+  const aliases: Record<string, string> = { esc: "escape", return: "enter" };
+  const canonical = [...new Set(parts)].sort().concat(aliases[base] || base).join("+");
+  if (!legacyControls) return canonical;
+  const legacyAliases: Record<string, string> = {
+    "ctrl+@": "ctrl+space",
+    "ctrl+h": "backspace",
+    "ctrl+i": "tab",
+    "ctrl+j": "enter",
+    "ctrl+m": "enter",
+    "ctrl+[": "escape",
+    "ctrl+?": "backspace",
+  };
+  return legacyAliases[canonical] || canonical;
+}
+
 interface SkillVisibilityStore {
   hiddenSkillsByCwd: Map<string, Set<string>>;
   theme: Theme | null;
@@ -80,9 +99,11 @@ type SkillListItem = LoadedSkillInfo;
 type HiddenSkillsByScope = Record<SkillfulScope, Set<string>>;
 type ToggleSlotsByScope = Record<SkillfulScope, Partial<Record<SkillToggleSlot, string>>>;
 type DefinedByScope = Record<SkillfulScope, boolean>;
+type DescriptionKeysByScope = Record<SkillfulScope, KeyId>;
 
 interface SkillfulVisibilityMenuOptions {
   cwd: string;
+  descriptionKeysByScope: DescriptionKeysByScope;
   projectTrusted: boolean;
   rpcAnsiFallback: boolean;
   skills: SkillListItem[];
@@ -146,6 +167,12 @@ export default function skillVisibility(pi: ExtensionAPI) {
       const opened = await ctx.ui.custom<true>((tui, theme, keybindings, done) =>
         new SkillfulVisibilityMenu({
           cwd: ctx.cwd,
+          descriptionKeysByScope: {
+            global: scoped.global.descriptionKey,
+            project: scoped.project.descriptionKeyDefined
+              ? scoped.project.descriptionKey
+              : scoped.global.descriptionKey,
+          },
           projectTrusted,
           rpcAnsiFallback: ctx.mode === "rpc",
           skills,
@@ -254,6 +281,7 @@ function getSkillItems(pi: ExtensionAPI): SkillListItem[] {
 
 class SkillfulVisibilityMenu implements Component {
   private readonly cwd: string;
+  private readonly descriptionKeysByScope: DescriptionKeysByScope;
   private readonly projectTrusted: boolean;
   private readonly rpcAnsiFallback: boolean;
   private readonly scopes: SkillfulScope[];
@@ -278,6 +306,7 @@ class SkillfulVisibilityMenu implements Component {
 
   constructor(options: SkillfulVisibilityMenuOptions) {
     this.cwd = options.cwd;
+    this.descriptionKeysByScope = options.descriptionKeysByScope;
     this.projectTrusted = options.projectTrusted;
     this.rpcAnsiFallback = options.rpcAnsiFallback;
     this.scopes = options.projectTrusted ? SCOPES : ["global"];
@@ -316,10 +345,11 @@ class SkillfulVisibilityMenu implements Component {
 
   handleInput(data: string): void {
     if (this.descriptionExpanded) {
-      if (
-        this.keybindings.matches(data, "tui.select.cancel") ||
-        this.keybindings.matches(data, "tui.select.confirm")
-      ) {
+      if (this.keybindings.matches(data, "tui.select.confirm")) {
+        this.toggleSelectedSkill();
+        return;
+      }
+      if (this.keybindings.matches(data, "tui.select.cancel")) {
         this.descriptionExpanded = false;
         this.tui.requestRender();
         return;
@@ -335,19 +365,25 @@ class SkillfulVisibilityMenu implements Component {
       if (scrollDelta !== 0) {
         this.descriptionScroll = Math.max(0, this.descriptionScroll + scrollDelta);
         this.tui.requestRender();
+        return;
       }
-      return;
-    }
-    if (this.keybindings.matches(data, "tui.select.confirm")) {
-      if (this.selectedSkillName()) {
-        this.descriptionExpanded = true;
-        this.descriptionScroll = 0;
+      if (matchesKey(data, this.descriptionKeysByScope[this.scope])) {
+        this.descriptionExpanded = false;
         this.tui.requestRender();
       }
       return;
     }
-    if (data === " ") {
+    if (this.keybindings.matches(data, "tui.select.confirm")) {
       this.toggleSelectedSkill();
+      return;
+    }
+    if (
+      this.keybindings.matches(data, "tui.select.cancel") ||
+      this.keybindings.matches(data, "tui.select.up") ||
+      this.keybindings.matches(data, "tui.select.down")
+    ) {
+      this.settingsList.handleInput(data);
+      this.tui.requestRender();
       return;
     }
     if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
@@ -360,6 +396,14 @@ class SkillfulVisibilityMenu implements Component {
     }
     if (/^[1-9]$/.test(data)) {
       this.toggleSelectedSkillSlot(data as SkillToggleSlot);
+      return;
+    }
+    if (matchesKey(data, this.descriptionKeysByScope[this.scope])) {
+      if (this.selectedSkillName()) {
+        this.descriptionExpanded = true;
+        this.descriptionScroll = 0;
+        this.tui.requestRender();
+      }
       return;
     }
 
@@ -396,10 +440,14 @@ class SkillfulVisibilityMenu implements Component {
     this.descriptionScroll = Math.min(this.descriptionScroll, maxScroll);
     const visibleLines = descriptionLines.slice(this.descriptionScroll, this.descriptionScroll + pageSize);
     const visibleEnd = this.descriptionScroll + visibleLines.length;
+    const descriptionBackKeys = this.descriptionKeyConflictsWithExistingAction(true)
+      ? []
+      : [this.descriptionKeysByScope[this.scope]];
     const backKeys = formatKeyList(
-      [...this.keybindings.getKeys("tui.select.confirm"), ...this.keybindings.getKeys("tui.select.cancel")],
-      "Confirm/Cancel",
+      [...descriptionBackKeys, ...this.keybindings.getKeys("tui.select.cancel")],
+      "Description/Cancel",
     );
+    const confirmKeys = formatKeyList(this.keybindings.getKeys("tui.select.confirm"), "Confirm");
     const scrollKeys = formatKeyList(
       [...this.keybindings.getKeys("tui.select.up"), ...this.keybindings.getKeys("tui.select.down")],
       "Up/Down",
@@ -412,7 +460,7 @@ class SkillfulVisibilityMenu implements Component {
       "",
       ...visibleLines.map((line) => truncateToWidth(this.theme.fg("dim", `  ${line}`), width)),
       "",
-      truncateToWidth(this.theme.fg("dim", `  ${backKeys} back${scrollHelp}`), width),
+      truncateToWidth(this.theme.fg("dim", `  ${backKeys} back · ${confirmKeys} on/off${scrollHelp}`), width),
       ...this.bottomBorder.render(width),
     ];
   }
@@ -441,11 +489,29 @@ class SkillfulVisibilityMenu implements Component {
       .join(" ");
   }
 
+  private descriptionKeyConflictsWithExistingAction(includePaging = false): boolean {
+    const keys = [
+      ...this.keybindings.getKeys("tui.select.confirm"),
+      ...this.keybindings.getKeys("tui.select.cancel"),
+      ...this.keybindings.getKeys("tui.select.up"),
+      ...this.keybindings.getKeys("tui.select.down"),
+      ...(includePaging
+        ? [...this.keybindings.getKeys("tui.select.pageUp"), ...this.keybindings.getKeys("tui.select.pageDown")]
+        : [Key.tab, Key.right, Key.shift(Key.tab), Key.left, ...SKILL_TOGGLE_SLOTS]),
+    ];
+    const legacyControls = this.tui.terminal?.kittyProtocolActive !== true;
+    const descriptionKey = canonicalKeyId(this.descriptionKeysByScope[this.scope], legacyControls);
+    return keys.some((key) => canonicalKeyId(key, legacyControls) === descriptionKey);
+  }
+
   private renderHelp(): string {
-    const scopeHelp = this.projectTrusted ? "Tab/←/→ switch scope · " : "";
+    const scopeHelp = this.projectTrusted ? "Tab/←/→ scope · " : "";
     const confirmKeys = formatKeyList(this.keybindings.getKeys("tui.select.confirm"), "Confirm");
+    const descriptionHelp = this.descriptionKeyConflictsWithExistingAction()
+      ? ""
+      : `${formatKeyList([this.descriptionKeysByScope[this.scope]], "Description")} details · `;
     const cancelKeys = formatKeyList(this.keybindings.getKeys("tui.select.cancel"), "Cancel");
-    return `  ${scopeHelp}1-9 assign/clear toggle · ${confirmKeys} details · Space on/off · ${cancelKeys} close`;
+    return `  Type to search · ${scopeHelp}1-9 slot · ${confirmKeys} on/off · ${descriptionHelp}${cancelKeys} close`;
   }
 
   private switchScope(direction: 1 | -1): void {

--- a/packages/pi-skillful/src/extensions/skill-visibility.ts
+++ b/packages/pi-skillful/src/extensions/skill-visibility.ts
@@ -6,7 +6,17 @@ import {
   type Skill,
   type Theme,
 } from "@earendil-works/pi-coding-agent";
-import { type Component, Key, matchesKey, type SettingItem, SettingsList, truncateToWidth, type TUI } from "@earendil-works/pi-tui";
+import {
+  type Component,
+  Key,
+  type KeybindingsManager,
+  matchesKey,
+  type SettingItem,
+  SettingsList,
+  truncateToWidth,
+  type TUI,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
 import {
   normalizeSkillName,
   normalizeSkillNames,
@@ -23,8 +33,22 @@ import { replaceSkillsSection } from "../skill-prompt.js";
 import { isTopLevelSkill, listLoadedSkills, type LoadedSkillInfo } from "../skills.js";
 import { hasActiveSessionSkillToggles, refreshSessionSkillToggles } from "./session-skill-toggles.js";
 const SCOPES: SkillfulScope[] = ["global", "project"];
+const DESCRIPTION_LINES = 2;
+const DESCRIPTION_DETAIL_CHROME_LINES = 6;
+const DESCRIPTION_DETAIL_MAX_LINES = 12;
+const DESCRIPTION_DETAIL_RESERVED_LINES = 2;
 const STORE_KEY = Symbol.for("pi-skillful.skillVisibilityStore");
 const STARTUP_PATCH_KEY = Symbol.for("pi-skillful.startupPatchV3");
+
+function formatKeyList(keys: string[], fallback: string): string {
+  const labels = [...new Set(keys)].map((key) =>
+    key
+      .split("+")
+      .map((part) => (part === "escape" ? "Esc" : `${part.charAt(0).toUpperCase()}${part.slice(1)}`))
+      .join("+"),
+  );
+  return labels.join("/") || fallback;
+}
 
 interface SkillVisibilityStore {
   hiddenSkillsByCwd: Map<string, Set<string>>;
@@ -60,11 +84,13 @@ type DefinedByScope = Record<SkillfulScope, boolean>;
 interface SkillfulVisibilityMenuOptions {
   cwd: string;
   projectTrusted: boolean;
+  rpcAnsiFallback: boolean;
   skills: SkillListItem[];
   hiddenByScope: HiddenSkillsByScope;
   hiddenSkillsDefinedByScope: DefinedByScope;
   toggleSlotsByScope: ToggleSlotsByScope;
   toggleSlotsDefinedByScope: DefinedByScope;
+  keybindings: KeybindingsManager;
   theme: Theme;
   tui: TUI;
   notify: (message: string, type?: "info" | "warning" | "error") => void;
@@ -104,7 +130,7 @@ export default function skillVisibility(pi: ExtensionAPI) {
   pi.registerCommand("skillful", {
     description: "Open the pi-skillful skill visibility menu.",
     handler: async (_args, ctx) => {
-      if (ctx.mode !== "tui") {
+      if (!ctx.hasUI) {
         ctx.ui.notify("/skillful requires interactive UI", "warning");
         return;
       }
@@ -117,10 +143,11 @@ export default function skillVisibility(pi: ExtensionAPI) {
 
       const projectTrusted = ctx.isProjectTrusted();
       const scoped = await readScopedSkillfulSettings(ctx.cwd, projectTrusted);
-      await ctx.ui.custom<void>((tui, theme, _keybindings, done) =>
+      const opened = await ctx.ui.custom<true>((tui, theme, keybindings, done) =>
         new SkillfulVisibilityMenu({
           cwd: ctx.cwd,
           projectTrusted,
+          rpcAnsiFallback: ctx.mode === "rpc",
           skills,
           hiddenByScope: {
             global: new Set(scoped.global.hiddenSkills),
@@ -138,13 +165,15 @@ export default function skillVisibility(pi: ExtensionAPI) {
             global: scoped.global.toggleSlotsDefined,
             project: scoped.project.toggleSlotsDefined,
           },
+          keybindings,
           theme,
           tui,
           notify: (message, type) => ctx.ui.notify(message, type),
           onToggleSlotsChanged: () => refreshSessionSkillToggles(pi, ctx.cwd, projectTrusted, ctx.ui),
-          done,
+          done: () => done(true),
         }),
       );
+      if (opened !== true) ctx.ui.notify("/skillful requires custom UI support", "warning");
     },
   });
 }
@@ -226,12 +255,14 @@ function getSkillItems(pi: ExtensionAPI): SkillListItem[] {
 class SkillfulVisibilityMenu implements Component {
   private readonly cwd: string;
   private readonly projectTrusted: boolean;
+  private readonly rpcAnsiFallback: boolean;
   private readonly scopes: SkillfulScope[];
   private readonly skills: SkillListItem[];
   private readonly hiddenByScope: HiddenSkillsByScope;
   private readonly hiddenSkillsDefinedByScope: DefinedByScope;
   private readonly toggleSlotsByScope: ToggleSlotsByScope;
   private readonly toggleSlotsDefinedByScope: DefinedByScope;
+  private readonly keybindings: KeybindingsManager;
   private readonly theme: Theme;
   private readonly tui: TUI;
   private readonly notify: (message: string, type?: "info" | "warning" | "error") => void;
@@ -241,11 +272,14 @@ class SkillfulVisibilityMenu implements Component {
   private readonly bottomBorder: DynamicBorder;
   private scope: SkillfulScope;
   private settingsList: SettingsList;
+  private descriptionExpanded = false;
+  private descriptionScroll = 0;
   private saveQueue: Promise<void> = Promise.resolve();
 
   constructor(options: SkillfulVisibilityMenuOptions) {
     this.cwd = options.cwd;
     this.projectTrusted = options.projectTrusted;
+    this.rpcAnsiFallback = options.rpcAnsiFallback;
     this.scopes = options.projectTrusted ? SCOPES : ["global"];
     this.scope = options.projectTrusted ? "project" : "global";
     this.skills = options.skills;
@@ -253,6 +287,7 @@ class SkillfulVisibilityMenu implements Component {
     this.hiddenSkillsDefinedByScope = options.hiddenSkillsDefinedByScope;
     this.toggleSlotsByScope = options.toggleSlotsByScope;
     this.toggleSlotsDefinedByScope = options.toggleSlotsDefinedByScope;
+    this.keybindings = options.keybindings;
     this.theme = options.theme;
     this.tui = options.tui;
     this.notify = options.notify;
@@ -264,12 +299,15 @@ class SkillfulVisibilityMenu implements Component {
   }
 
   render(width: number): string[] {
+    if (this.descriptionExpanded) return this.renderDescriptionDetail(width);
     return [
       ...this.topBorder.render(width),
       truncateToWidth(`  ${this.theme.bold(this.theme.fg("accent", "pi-skillful"))}  ${this.renderTabs()}`, width),
       truncateToWidth(this.theme.fg("dim", "  Toggle skills shown in the model-invocation system prompt"), width),
       "",
-      ...this.settingsList.render(width),
+      ...this.settingsList.render(width).slice(0, -2),
+      "",
+      ...this.renderSelectedDescription(width),
       "",
       truncateToWidth(this.theme.fg("dim", this.renderHelp()), width),
       ...this.bottomBorder.render(width),
@@ -277,6 +315,41 @@ class SkillfulVisibilityMenu implements Component {
   }
 
   handleInput(data: string): void {
+    if (this.descriptionExpanded) {
+      if (
+        this.keybindings.matches(data, "tui.select.cancel") ||
+        this.keybindings.matches(data, "tui.select.confirm")
+      ) {
+        this.descriptionExpanded = false;
+        this.tui.requestRender();
+        return;
+      }
+
+      const pageSize = this.descriptionPageSize();
+      let scrollDelta = 0;
+      if (this.keybindings.matches(data, "tui.select.up")) scrollDelta = -1;
+      else if (this.keybindings.matches(data, "tui.select.down")) scrollDelta = 1;
+      else if (this.keybindings.matches(data, "tui.select.pageUp")) scrollDelta = -pageSize;
+      else if (this.keybindings.matches(data, "tui.select.pageDown")) scrollDelta = pageSize;
+
+      if (scrollDelta !== 0) {
+        this.descriptionScroll = Math.max(0, this.descriptionScroll + scrollDelta);
+        this.tui.requestRender();
+      }
+      return;
+    }
+    if (this.keybindings.matches(data, "tui.select.confirm")) {
+      if (this.selectedSkillName()) {
+        this.descriptionExpanded = true;
+        this.descriptionScroll = 0;
+        this.tui.requestRender();
+      }
+      return;
+    }
+    if (data === " ") {
+      this.toggleSelectedSkill();
+      return;
+    }
     if (matchesKey(data, Key.tab) || matchesKey(data, Key.right)) {
       this.switchScope(1);
       return;
@@ -300,20 +373,79 @@ class SkillfulVisibilityMenu implements Component {
     this.settingsList.invalidate();
   }
 
+  private renderSelectedDescription(width: number): string[] {
+    const skill = this.skills.find((candidate) => candidate.name === this.selectedSkillName());
+    const contentWidth = Math.max(1, width - 4);
+    const wrapped = wrapTextWithAnsi(skill?.description || "No skill description provided.", contentWidth);
+    const lines = wrapped.slice(0, DESCRIPTION_LINES);
+
+    if (wrapped.length > DESCRIPTION_LINES) {
+      lines[DESCRIPTION_LINES - 1] = truncateToWidth(`${lines[DESCRIPTION_LINES - 1]}…`, contentWidth, "…");
+    }
+    while (lines.length < DESCRIPTION_LINES) lines.push("");
+
+    return lines.map((line) => truncateToWidth(this.theme.fg("dim", `  ${line}`), width));
+  }
+
+  private renderDescriptionDetail(width: number): string[] {
+    const skill = this.skills.find((candidate) => candidate.name === this.selectedSkillName());
+    const description = skill?.description || "No skill description provided.";
+    const descriptionLines = wrapTextWithAnsi(description, Math.max(1, width - 4));
+    const pageSize = this.descriptionPageSize();
+    const maxScroll = Math.max(0, descriptionLines.length - pageSize);
+    this.descriptionScroll = Math.min(this.descriptionScroll, maxScroll);
+    const visibleLines = descriptionLines.slice(this.descriptionScroll, this.descriptionScroll + pageSize);
+    const visibleEnd = this.descriptionScroll + visibleLines.length;
+    const backKeys = formatKeyList(
+      [...this.keybindings.getKeys("tui.select.confirm"), ...this.keybindings.getKeys("tui.select.cancel")],
+      "Confirm/Cancel",
+    );
+    const scrollKeys = formatKeyList(
+      [...this.keybindings.getKeys("tui.select.up"), ...this.keybindings.getKeys("tui.select.down")],
+      "Up/Down",
+    );
+    const scrollHelp = maxScroll > 0 ? ` · ${scrollKeys} scroll · ${this.descriptionScroll + 1}-${visibleEnd}/${descriptionLines.length}` : "";
+
+    return [
+      ...this.topBorder.render(width),
+      truncateToWidth(`  ${this.theme.bold(this.theme.fg("accent", skill?.name || "Skill description"))}`, width),
+      "",
+      ...visibleLines.map((line) => truncateToWidth(this.theme.fg("dim", `  ${line}`), width)),
+      "",
+      truncateToWidth(this.theme.fg("dim", `  ${backKeys} back${scrollHelp}`), width),
+      ...this.bottomBorder.render(width),
+    ];
+  }
+
+  private descriptionPageSize(): number {
+    return Math.max(
+      1,
+      Math.min(
+        DESCRIPTION_DETAIL_MAX_LINES,
+        this.tui.terminal.rows - DESCRIPTION_DETAIL_CHROME_LINES - DESCRIPTION_DETAIL_RESERVED_LINES,
+      ),
+    );
+  }
+
   private renderTabs(): string {
     return this.scopes
       .map((scope) => {
         const label = scope === "global" ? "Global" : "Project";
-        return scope === this.scope
-          ? this.theme.bg("selectedBg", this.theme.fg("accent", ` ${label} `))
-          : this.theme.fg("muted", ` ${label} `);
+        if (scope !== this.scope) return this.theme.fg("muted", ` ${label} `);
+
+        const plain = `[${label}]`;
+        const selected = this.theme.bg("selectedBg", this.theme.fg("accent", plain));
+        // Pi Web supplies a plain semantic theme but preserves ANSI in custom UI output.
+        return this.rpcAnsiFallback && selected === plain ? `\x1b[96m${selected}\x1b[39m` : selected;
       })
       .join(" ");
   }
 
   private renderHelp(): string {
     const scopeHelp = this.projectTrusted ? "Tab/←/→ switch scope · " : "";
-    return `  ${scopeHelp}1-9 assign/clear toggle · Enter/Space on/off · Esc close`;
+    const confirmKeys = formatKeyList(this.keybindings.getKeys("tui.select.confirm"), "Confirm");
+    const cancelKeys = formatKeyList(this.keybindings.getKeys("tui.select.cancel"), "Cancel");
+    return `  ${scopeHelp}1-9 assign/clear toggle · ${confirmKeys} details · Space on/off · ${cancelKeys} close`;
   }
 
   private switchScope(direction: 1 | -1): void {
@@ -329,7 +461,6 @@ class SkillfulVisibilityMenu implements Component {
       return {
         id: skill.name,
         label: skill.name,
-        description: `${skill.description || "No skill description provided."}\nPress 1-9 to assign or clear this skill's toggle slot in the ${this.scope} scope.`,
         currentValue: this.skillValue(skill.name, hidden),
         values: [this.skillValue(skill.name, false), this.skillValue(skill.name, true)],
       };
@@ -339,14 +470,23 @@ class SkillfulVisibilityMenu implements Component {
       items,
       12,
       getSettingsListTheme(),
-      (id, newValue) => {
-        this.setHidden(this.scope, id, newValue.includes("off"));
-        this.settingsList.updateValue(id, this.skillValue(id, this.isHidden(this.scope, id)));
-        this.persistScope(this.scope);
-      },
+      (id, newValue) => this.updateSkillVisibility(id, newValue.includes("off")),
       () => this.close(),
       { enableSearch: true },
     );
+  }
+
+  private toggleSelectedSkill(): void {
+    const skillName = this.selectedSkillName();
+    if (!skillName) return;
+    this.updateSkillVisibility(skillName, !this.isHidden(this.scope, skillName));
+    this.tui.requestRender();
+  }
+
+  private updateSkillVisibility(skillName: string, hidden: boolean): void {
+    this.setHidden(this.scope, skillName, hidden);
+    this.settingsList.updateValue(skillName, this.skillValue(skillName, hidden));
+    this.persistScope(this.scope);
   }
 
   private isHidden(scope: SkillfulScope, skillName: string): boolean {

--- a/packages/pi-skillful/tests/config.test.mjs
+++ b/packages/pi-skillful/tests/config.test.mjs
@@ -27,6 +27,7 @@ test("trusted projects override global skillful settings", async () => {
       hiddenSkills: ["global-hidden"],
       toggleSlots: { 1: "global-skill" },
       toggleModifier: "ctrl",
+      descriptionKey: "ctrl+o",
     },
   });
   await writeJson(join(cwd, ".pi", "settings.json"), {
@@ -34,6 +35,7 @@ test("trusted projects override global skillful settings", async () => {
       hiddenSkills: ["project-hidden"],
       toggleSlots: { 2: "project-skill" },
       toggleModifier: "alt",
+      descriptionKey: "f2",
     },
   });
 
@@ -42,6 +44,8 @@ test("trusted projects override global skillful settings", async () => {
   assert.deepEqual(settings.hiddenSkills, ["project-hidden"]);
   assert.deepEqual(settings.toggleSlots, { 2: "project-skill" });
   assert.equal(settings.toggleModifier, "alt");
+  assert.equal(settings.descriptionKey, "f2");
+  assert.equal(settings.descriptionKeyDefined, true);
   assert.equal(settings.toggleModifierDefined, true);
 });
 
@@ -52,6 +56,7 @@ test("untrusted projects use only global skillful settings", async () => {
       hiddenSkills: ["global-hidden"],
       toggleSlots: { 1: "global-skill" },
       toggleModifier: "ctrl",
+      descriptionKey: "ctrl+o",
     },
   });
   await writeJson(join(cwd, ".pi", "settings.json"), {
@@ -59,6 +64,7 @@ test("untrusted projects use only global skillful settings", async () => {
       hiddenSkills: ["project-hidden"],
       toggleSlots: { 2: "project-skill" },
       toggleModifier: "alt",
+      descriptionKey: "f2",
     },
   });
 
@@ -67,24 +73,28 @@ test("untrusted projects use only global skillful settings", async () => {
   assert.deepEqual(settings.hiddenSkills, ["global-hidden"]);
   assert.deepEqual(settings.toggleSlots, { 1: "global-skill" });
   assert.equal(settings.toggleModifier, "ctrl");
+  assert.equal(settings.descriptionKey, "ctrl+o");
 });
 
-test("explicit default modifier overrides global modifier", async () => {
+test("explicit default interaction keys override global values", async () => {
   const cwd = await mkdtemp(join(home, "modifier-"));
   const projectPath = join(cwd, ".pi", "settings.json");
-  await writeJson(globalPath, { skillful: { toggleModifier: "ctrl" } });
-  await writeJson(projectPath, { skillful: { toggleModifier: "alt" } });
+  await writeJson(globalPath, { skillful: { toggleModifier: "ctrl", descriptionKey: "ctrl+o" } });
+  await writeJson(projectPath, { skillful: { toggleModifier: "alt", descriptionKey: "space" } });
 
   let settings = await readEffectiveSkillfulSettings(cwd, true);
   assert.equal(settings.toggleModifier, "alt");
+  assert.equal(settings.descriptionKey, "space");
 
   await writeJson(projectPath, { skillful: {} });
   settings = await readEffectiveSkillfulSettings(cwd, true);
   assert.equal(settings.toggleModifier, "ctrl");
+  assert.equal(settings.descriptionKey, "ctrl+o");
 
-  await writeJson(projectPath, { skillful: { toggleModifier: "unsupported" } });
+  await writeJson(projectPath, { skillful: { toggleModifier: "unsupported", descriptionKey: "ctrl+bogus" } });
   settings = await readEffectiveSkillfulSettings(cwd, true);
   assert.equal(settings.toggleModifier, "alt");
+  assert.equal(settings.descriptionKey, "space");
 });
 
 test("project writes require active trust", async () => {

--- a/packages/pi-skillful/tests/skill-visibility.test.mjs
+++ b/packages/pi-skillful/tests/skill-visibility.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { formatSkillsForPrompt, initTheme } from "@earendil-works/pi-coding-agent";
+import { getKeybindings } from "@earendil-works/pi-tui";
 
 const home = await mkdtemp(join(tmpdir(), "pi-skillful-visibility-test-"));
 process.env.HOME = home;
@@ -155,7 +156,7 @@ for (const mode of ["tui", "rpc"]) {
 
     await registeredCommands.get("skillful").handler("", ctx);
     assert.ok(menu.render(120).join("\n").includes("Global"));
-    assert.match(menu.render(120).join("\n"), /Enter details .* Space on\/off .* Esc\/Ctrl\+C close/);
+    assert.match(menu.render(120).join("\n"), /Enter on\/off .* Space details .* Esc\/Ctrl\+C close/);
     assert.equal(menu.render(120).join("\n").includes("\x1b[96m[Global]\x1b[39m"), mode === "rpc");
     assert.ok(!menu.render(120).join("\n").includes("Project"));
 
@@ -213,8 +214,35 @@ test("plain-text RPC menus color the active project and global scopes", async ()
   assert.ok(!menu.render(120).join("\n").includes("[Project]"));
 });
 
+test("legacy control aliases do not advertise conflicting description keys", async () => {
+  const cwd = await mkdtemp(join(home, "menu-key-conflict-"));
+  await writeSettings(globalSettingsPath, { skillful: { descriptionKey: "ctrl+i" } });
+  const { registeredCommands } = registerVisibility([commandForSkill(skill("key-conflict"))]);
+  let menu;
+  const ctx = {
+    cwd,
+    hasUI: true,
+    isProjectTrusted: () => false,
+    mode: "tui",
+    ui: {
+      custom: async (factory) => {
+        menu = factory({ requestRender: () => undefined }, identityTheme, getKeybindings(), () => undefined);
+        return true;
+      },
+      notify: () => undefined,
+    },
+  };
+
+  await registeredCommands.get("skillful").handler("", ctx);
+  assert.doesNotMatch(menu.render(180).join("\n"), /Ctrl\+I details/);
+  menu.handleInput("\t");
+  assert.match(menu.render(180).join("\n"), /Type to search/);
+});
+
 test("skill descriptions keep the menu height stable", async () => {
   const cwd = await mkdtemp(join(home, "menu-description-height-"));
+  await writeSettings(globalSettingsPath, { skillful: { descriptionKey: "ctrl+o" } });
+  await writeSettings(join(cwd, ".pi", "settings.json"), { skillful: { descriptionKey: "space" } });
   const shortSkill = skill("a-short-description");
   const longSkill = skill("b-long-description");
   shortSkill.description = "Short description.";
@@ -232,7 +260,10 @@ test("skill descriptions keep the menu height stable", async () => {
   };
   const detailKeybindings = {
     matches: (data, binding) => detailBindings[binding] === data,
-    getKeys: (binding) => (detailBindings[binding] ? [binding === "tui.select.confirm" ? "enter" : detailBindings[binding]] : []),
+    getKeys: (binding) => {
+      const key = detailBindings[binding];
+      return key ? [key === "\r" ? "enter" : key === " " ? "space" : key] : [];
+    },
   };
   const ctx = {
     cwd,
@@ -249,6 +280,14 @@ test("skill descriptions keep the menu height stable", async () => {
   };
 
   await registeredCommands.get("skillful").handler("", ctx);
+  assert.match(menu.render(180).join("\n"), /Space details/);
+  menu.handleInput("\t");
+  assert.match(menu.render(180).join("\n"), /Ctrl\+O details/);
+  menu.handleInput("\x0f");
+  assert.match(menu.render(40)[1], /a-short-description/);
+  menu.handleInput("\x0f");
+  menu.handleInput("\t");
+  assert.match(menu.render(180).join("\n"), /Space details/);
   const shortRender = menu.render(40);
   menu.handleInput("\x1b[B");
   const longRender = menu.render(40);
@@ -257,26 +296,38 @@ test("skill descriptions keep the menu height stable", async () => {
   assert.match(longRender.join("\n"), /Long description text/);
   assert.equal(longRender.length, shortRender.length);
   assert.doesNotMatch(longRender.join("\n"), /FULL DESCRIPTION END|Enter\/Space to change/);
-  assert.match(menu.render(180).join("\n"), /Enter details .* Q close/);
+  assert.match(menu.render(180).join("\n"), /Type to search .* Enter on\/off .* Space details .* Q close/);
 
   menu.handleInput("b");
+  detailBindings["tui.select.confirm"] = " ";
+  const conflictHelp = menu.render(180).join("\n");
+  assert.match(conflictHelp, /Space on\/off .* Q close/);
+  assert.doesNotMatch(conflictHelp, /details/);
   menu.handleInput(" ");
   const filteredRender = menu.render(40);
   assert.match(filteredRender.join("\n"), /b-long-description.*off/);
+  detailBindings["tui.select.confirm"] = "\r";
+  assert.match(menu.render(180).join("\n"), /Enter on\/off .* Space details/);
 
-  menu.handleInput("\r");
+  menu.handleInput(" ");
   const detailRender = menu.render(40);
   assert.equal(detailRender.length, tui.terminal.rows - 2);
   assert.match(detailRender[1], /b-long-description/);
   assert.doesNotMatch(detailRender.join("\n"), /FULL\s+DESCRIPTION END/);
-  assert.match(detailRender.join("\n"), /Enter\/Q back · K\/J scroll/);
+  assert.match(menu.render(180).join("\n"), /Space\/Q back · Enter on\/off · K\/J scroll/);
 
-  menu.handleInput("\x1b");
-  assert.doesNotMatch(menu.render(40).join("\n"), /FULL\s+DESCRIPTION END/);
+  menu.handleInput("\r");
+  assert.match(menu.render(40)[1], /b-long-description/);
+  menu.handleInput(" ");
+  const returnedRender = menu.render(40);
+  assert.match(returnedRender.join("\n"), /b-long-description.*on/);
+  assert.equal(returnedRender.length, filteredRender.length);
+
+  menu.handleInput(" ");
   for (let page = 0; page < 20; page += 1) menu.handleInput("n");
   assert.match(menu.render(40).join("\n"), /FULL\s+DESCRIPTION END/);
   menu.handleInput("q");
-  assert.equal(menu.render(40).length, filteredRender.length);
+  assert.equal(menu.render(40).length, returnedRender.length);
 });
 
 test("startup patch colors the built-in skill list from effective settings", async () => {

--- a/packages/pi-skillful/tests/skill-visibility.test.mjs
+++ b/packages/pi-skillful/tests/skill-visibility.test.mjs
@@ -20,6 +20,11 @@ const identityTheme = {
   bold: (text) => text,
   fg: (_color, text) => text,
 };
+const defaultKeybindings = {
+  matches: (data, binding) =>
+    binding === "tui.select.confirm" ? data === "\r" : binding === "tui.select.cancel" && ["\x03", "\x1b"].includes(data),
+  getKeys: (binding) => (binding === "tui.select.confirm" ? ["enter"] : ["escape", "ctrl+c"]),
+};
 
 function skill(name, scope = "user") {
   const path = join(home, `${name}.md`);
@@ -123,35 +128,155 @@ test("trusted project visibility settings override global settings", async () =>
   assert.ok(!result.systemPrompt.includes(`<name>${projectSkill.name}</name>`));
 });
 
-test("untrusted projects expose only global settings in the menu", async () => {
-  const cwd = await mkdtemp(join(home, "menu-untrusted-"));
-  const loadedSkill = skill("menu-skill");
-  const projectPath = join(cwd, ".pi", "settings.json");
-  const projectSettings = { skillful: { hiddenSkills: [loadedSkill.name] } };
-  await writeSettings(globalSettingsPath, { skillful: {} });
-  await writeSettings(projectPath, projectSettings);
+for (const mode of ["tui", "rpc"]) {
+  test(`untrusted projects expose only global settings in the menu in ${mode} mode`, async () => {
+    const cwd = await mkdtemp(join(home, `menu-untrusted-${mode}-`));
+    const loadedSkill = skill(`menu-skill-${mode}`);
+    const projectPath = join(cwd, ".pi", "settings.json");
+    const projectSettings = { skillful: { hiddenSkills: [loadedSkill.name] } };
+    await writeSettings(globalSettingsPath, { skillful: {} });
+    await writeSettings(projectPath, projectSettings);
+    const { registeredCommands } = registerVisibility([commandForSkill(loadedSkill)]);
+    let menu;
+    const tui = { requestRender: () => undefined };
+    const ctx = {
+      cwd,
+      hasUI: true,
+      isProjectTrusted: () => false,
+      mode,
+      ui: {
+        custom: async (factory) => {
+          menu = factory(tui, identityTheme, defaultKeybindings, () => undefined);
+          return true;
+        },
+        notify: () => undefined,
+      },
+    };
+
+    await registeredCommands.get("skillful").handler("", ctx);
+    assert.ok(menu.render(120).join("\n").includes("Global"));
+    assert.match(menu.render(120).join("\n"), /Enter details .* Space on\/off .* Esc\/Ctrl\+C close/);
+    assert.equal(menu.render(120).join("\n").includes("\x1b[96m[Global]\x1b[39m"), mode === "rpc");
+    assert.ok(!menu.render(120).join("\n").includes("Project"));
+
+    menu.handleInput("\t");
+    assert.ok(!menu.render(120).join("\n").includes("Project"));
+    assert.deepEqual(JSON.parse(await readFile(projectPath, "utf-8")), projectSettings);
+  });
+}
+
+test("RPC clients without custom component support receive a warning", async () => {
+  const loadedSkill = skill("unsupported-rpc-menu");
   const { registeredCommands } = registerVisibility([commandForSkill(loadedSkill)]);
+  const notifications = [];
+  const ctx = {
+    cwd: home,
+    hasUI: true,
+    isProjectTrusted: () => false,
+    mode: "rpc",
+    ui: {
+      custom: async () => undefined,
+      notify: (message, type) => notifications.push({ message, type }),
+    },
+  };
+
+  await registeredCommands.get("skillful").handler("", ctx);
+
+  assert.deepEqual(notifications, [{ message: "/skillful requires custom UI support", type: "warning" }]);
+});
+
+test("plain-text RPC menus color the active project and global scopes", async () => {
+  const cwd = await mkdtemp(join(home, "menu-scopes-"));
+  const { registeredCommands } = registerVisibility([commandForSkill(skill("menu-scopes-skill"))]);
   let menu;
   const tui = { requestRender: () => undefined };
   const ctx = {
     cwd,
-    isProjectTrusted: () => false,
-    mode: "tui",
+    hasUI: true,
+    isProjectTrusted: () => true,
+    mode: "rpc",
     ui: {
       custom: async (factory) => {
-        menu = factory(tui, identityTheme, {}, () => undefined);
+        menu = factory(tui, identityTheme, defaultKeybindings, () => undefined);
+        return true;
       },
       notify: () => undefined,
     },
   };
 
   await registeredCommands.get("skillful").handler("", ctx);
-  assert.ok(menu.render(120).join("\n").includes("Global"));
-  assert.ok(!menu.render(120).join("\n").includes("Project"));
+  assert.ok(menu.render(120).join("\n").includes("\x1b[96m[Project]\x1b[39m"));
+  assert.ok(!menu.render(120).join("\n").includes("[Global]"));
 
   menu.handleInput("\t");
-  assert.ok(!menu.render(120).join("\n").includes("Project"));
-  assert.deepEqual(JSON.parse(await readFile(projectPath, "utf-8")), projectSettings);
+  assert.ok(menu.render(120).join("\n").includes("\x1b[96m[Global]\x1b[39m"));
+  assert.ok(!menu.render(120).join("\n").includes("[Project]"));
+});
+
+test("skill descriptions keep the menu height stable", async () => {
+  const cwd = await mkdtemp(join(home, "menu-description-height-"));
+  const shortSkill = skill("a-short-description");
+  const longSkill = skill("b-long-description");
+  shortSkill.description = "Short description.";
+  longSkill.description = `${"Long description text ".repeat(40)}FULL DESCRIPTION END`;
+  const { registeredCommands } = registerVisibility([shortSkill, longSkill].map(commandForSkill));
+  let menu;
+  const tui = { terminal: { rows: 10 }, requestRender: () => undefined };
+  const detailBindings = {
+    "tui.select.confirm": "\r",
+    "tui.select.cancel": "q",
+    "tui.select.up": "k",
+    "tui.select.down": "j",
+    "tui.select.pageUp": "p",
+    "tui.select.pageDown": "n",
+  };
+  const detailKeybindings = {
+    matches: (data, binding) => detailBindings[binding] === data,
+    getKeys: (binding) => (detailBindings[binding] ? [binding === "tui.select.confirm" ? "enter" : detailBindings[binding]] : []),
+  };
+  const ctx = {
+    cwd,
+    hasUI: true,
+    isProjectTrusted: () => true,
+    mode: "tui",
+    ui: {
+      custom: async (factory) => {
+        menu = factory(tui, identityTheme, detailKeybindings, () => undefined);
+        return true;
+      },
+      notify: () => undefined,
+    },
+  };
+
+  await registeredCommands.get("skillful").handler("", ctx);
+  const shortRender = menu.render(40);
+  menu.handleInput("\x1b[B");
+  const longRender = menu.render(40);
+
+  assert.match(shortRender.join("\n"), /Short description/);
+  assert.match(longRender.join("\n"), /Long description text/);
+  assert.equal(longRender.length, shortRender.length);
+  assert.doesNotMatch(longRender.join("\n"), /FULL DESCRIPTION END|Enter\/Space to change/);
+  assert.match(menu.render(180).join("\n"), /Enter details .* Q close/);
+
+  menu.handleInput("b");
+  menu.handleInput(" ");
+  const filteredRender = menu.render(40);
+  assert.match(filteredRender.join("\n"), /b-long-description.*off/);
+
+  menu.handleInput("\r");
+  const detailRender = menu.render(40);
+  assert.equal(detailRender.length, tui.terminal.rows - 2);
+  assert.match(detailRender[1], /b-long-description/);
+  assert.doesNotMatch(detailRender.join("\n"), /FULL\s+DESCRIPTION END/);
+  assert.match(detailRender.join("\n"), /Enter\/Q back · K\/J scroll/);
+
+  menu.handleInput("\x1b");
+  assert.doesNotMatch(menu.render(40).join("\n"), /FULL\s+DESCRIPTION END/);
+  for (let page = 0; page < 20; page += 1) menu.handleInput("n");
+  assert.match(menu.render(40).join("\n"), /FULL\s+DESCRIPTION END/);
+  menu.handleInput("q");
+  assert.equal(menu.render(40).length, filteredRender.length);
 });
 
 test("startup patch colors the built-in skill list from effective settings", async () => {


### PR DESCRIPTION
## Summary

### 1. Pi Web support

- open `/skillful` in [Pi Web](https://github.com/agegr/pi-web) through its RPC custom UI bridge
- keep the active Global/Project scope explicit with Pi Web's plain theme
- use capability detection, which may also support other compatible RPC clients, although only Pi Web has been tested
- warn cleanly when an RPC client does not support custom components

### 2. Stable skill descriptions

- keep description previews at two lines so different lengths do not resize the menu
- open the complete description with `Enter` in a bounded, keybinding-aware scroll view
- use `Space` only for toggling, including while the skill list is filtered

## Validation

- [x] `npm run check`
- [x] `npm test`
- [x] `npm run pack:dry-run`
- [x] `npm run security:audit`

## Security and privacy checklist

- [x] No API keys, tokens, auth headers, local Pi settings, provider configs with secrets, or machine-specific paths are committed.
- [x] No new or changed network calls are introduced.
- [x] No new or changed config values are introduced.
- [x] Logs, errors, fixtures, snapshots, and examples do not expose sensitive values.
- [x] Package `files` entries include only intended runtime/docs assets.
- [x] User-visible behavior is documented in README and CHANGELOG; there are no new security implications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable key for opening scrollable skill descriptions, defaulting to `Space`.
  - Added support for custom navigation, confirmation, cancellation, and paging keybindings.
  - Added filtering, keyboard navigation, and stable two-line skill descriptions.
  - Added Pi Web support for the `/skillful` menu and Global/Project scope selection.

- **Bug Fixes**
  - Improved fallback behavior when custom UI components are unavailable.
  - Improved key conflict handling, description previews, and scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->