### PR TITLE
Add GPT-6 Codex support and reasoning updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each package installs independently. Pick the capability you need, then follow i
 | Use supported provider fast modes on demand | [pi-fast](./packages/pi-fast) | Session-local Fast toggles for provider/model pairs that advertise faster processing. |
 | Give grammar-capable Codex models their native patch tool | [pi-codex-tools](./packages/pi-codex-tools) | Raw `apply_patch` grammar tooling with safe local mutation and model-aware activation. |
 | Use Codex provider-side compaction | [pi-codex-compaction](./packages/pi-codex-compaction) | RemoteCompactionV2 checkpoints for supported OpenAI Codex sessions. |
+| Change Codex thinking effort without changing the cached prefix | [pi-openai-reasoning](./packages/pi-openai-reasoning) | Branch-aware reasoning updates using Pi's existing thinking controls. |
 
 ### Research and create
 

--- a/docs/plans/2026-09-11-gpt6-codex.md
+++ b/docs/plans/2026-09-11-gpt6-codex.md
@@ -1,0 +1,49 @@
+# GPT-6 Codex implementation
+
+## Scope
+
+Implement the agreed Codex-subscription plan. No public OpenAI API access is
+available. Do not generate images, change the image-generation default, vendor
+Codex code, add credential storage, push, or publish.
+
+## Checklist
+
+- [x] Align all shared Pi development dependencies to 0.85.1.
+  `npm ci --dry-run` and root `npm run validate` passed.
+- [ ] Enable Astra in pi-fast; preserve defaults, toggles, and model guards.
+- [ ] Preserve raw grammar tools and their history during compaction.
+- [ ] Apply Fast and reasoning settings to direct compaction requests.
+- [ ] Report cache writes and standard Pi compaction usage.
+- [ ] Cover checkpoint compatibility, cancellation, bounds, retries, and fallback.
+- [ ] Probe configuration_update on the actual Codex backend before enabling it.
+- [ ] Add standalone pi-openai-reasoning with existing thinking controls,
+  stable request effort, branch-local replay, retry safety, and compaction reset.
+  Unsupported backend modes must remain disabled.
+- [ ] Add integration regressions, docs, telemetry, root index, and pack checks.
+- [ ] Run small subscription smoke tests and final full validation.
+
+## Reference evidence
+
+Read-only Scout reference: `openai/codex` commit
+`654b0a77d0d2f81aa21f61caf7af4be88fe550bb` (2026-09-11).
+No source code is copied from this reference.
+
+- `core/src/session/reasoning_effort.rs`: request baseline is separate from
+  selected effort; only harness-authored updates count. Failed compaction does
+  not mutate the pin. Successful compaction permits a new baseline.
+  Current code gates this on ReasoningEffortOverride and responses-lite.
+- `protocol/src/models/configuration_update_tests.rs`: update items contain only
+  type and reasoning effort, not message IDs or roles.
+- `core/src/compact_remote_v2{,_attempt}.rs`: Responses compaction trigger uses
+  normal model-visible tools and service tier. At most two stream retries.
+  Require completion and exactly one checkpoint. Cache writes are usage.
+
+Public API documentation is not proof of Codex backend support.
+Async tool calls and mid-turn steering remain upstream Pi work.
+
+## Impact
+
+Shared development manifests and root lockfile; pi-fast, pi-codex-compaction,
+pi-codex-tools, and new pi-openai-reasoning. Image generation only needs the
+shared dependency check. Root README needs the new package entry. Release
+workflows discover workspaces; do not bump existing releases for this work.

--- a/docs/plans/2026-09-11-gpt6-codex.md
+++ b/docs/plans/2026-09-11-gpt6-codex.md
@@ -20,7 +20,7 @@ Codex code, add credential storage, push, or publish.
   stable request effort, branch-local replay, retry safety, and compaction reset.
   Unsupported backend modes must remain disabled.
 - [x] Add integration regressions, docs, telemetry, root index, and pack checks.
-- [ ] Run small subscription smoke tests and final full validation.
+- [x] Run small subscription smoke tests and final full validation.
 
 ## Reference evidence
 
@@ -55,8 +55,8 @@ Combined live smoke passed: Fast priority, grammar schema, stable low baseline
 with a medium update, remote checkpoint, and continuation recalling ORBIT.
 Usage: 2,052 total tokens including 513 compaction tokens. Separate minimal
 configuration-update probes for high, xhigh and max each completed with 22 tokens.
-Image generation was not run. No credential or conversation data was saved in
-these test records.
+Image generation was not run. No credentials or user conversation data were saved
+in these test records.
 
 `codex-api/src/auth.rs` keeps authentication and refresh provider-owned;
 `codex-api/src/sse/responses.rs` separates cached/write/reasoning counters.
@@ -75,6 +75,25 @@ Root validation and package checks passed on Node 26; reasoning integration test
 also passed on the system Node 24. Semgrep scanned all changed runtime areas,
 including the new package, with zero findings or parse errors. This complements
 the contract tests; it is not proof that all possible defects are absent.
+
+## Final verification
+
+- `npm ci --dry-run`: passed; shared Pi runtime packages resolve to 0.85.1.
+- `npm run validate`: 13 packages; 323 tests passed, zero failed. Two existing
+  pi-codex-tools tests are platform skips: unsupported-filesystem behavior on a
+  supported filesystem, and the macOS-only native errno test on Linux.
+- Node 24: all 39 reasoning and compaction tests passed, including real provider
+  retries and an absolute deadline despite continuing stream heartbeats.
+- `npm pack`: the new package contains only its 11 intended runtime/document
+  files. An isolated install of that tarball and the Pi runtime loader passed
+  without any other Pi extension package installed.
+- Root/package docs, telemetry policy coverage, workspace lock, publish-workflow
+  discovery and package index checked. No workflow or root policy change needed.
+- Image-generation code/defaults unchanged; only its shared Pi dev dependencies
+  changed. Its mocked tests passed. No image-generation request was made.
+- Public API-key support, async tools and mid-turn steering remain explicitly
+  deferred. No private Pi patch, copied Codex source, new credential storage,
+  push or publication was introduced.
 
 ## Impact
 

--- a/docs/plans/2026-09-11-gpt6-codex.md
+++ b/docs/plans/2026-09-11-gpt6-codex.md
@@ -12,14 +12,14 @@ Codex code, add credential storage, push, or publish.
   `npm ci --dry-run` and root `npm run validate` passed.
 - [x] Enable Astra in pi-fast; preserve defaults, toggles, and model guards.
 - [x] Preserve raw grammar tools and their history during compaction.
-- [ ] Apply Fast and reasoning settings to direct compaction requests.
+- [x] Apply Fast and reasoning settings to direct compaction requests.
 - [x] Report cache writes and standard Pi compaction usage.
 - [x] Cover checkpoint compatibility, cancellation, bounds, retries, and fallback.
 - [x] Probe configuration_update on the actual Codex backend before enabling it.
-- [ ] Add standalone pi-openai-reasoning with existing thinking controls,
+- [x] Add standalone pi-openai-reasoning with existing thinking controls,
   stable request effort, branch-local replay, retry safety, and compaction reset.
   Unsupported backend modes must remain disabled.
-- [ ] Add integration regressions, docs, telemetry, root index, and pack checks.
+- [x] Add integration regressions, docs, telemetry, root index, and pack checks.
 - [ ] Run small subscription smoke tests and final full validation.
 
 ## Reference evidence
@@ -50,6 +50,31 @@ versioned synchronous events, not a private registry patch, to supply owned
 grammar metadata and apply direct-request settings. Real Pi loader/runner,
 compaction, session usage, fallback, and continuation tests pass in both load
 orders. Root validation passed after these changes.
+
+Combined live smoke passed: Fast priority, grammar schema, stable low baseline
+with a medium update, remote checkpoint, and continuation recalling ORBIT.
+Usage: 2,052 total tokens including 513 compaction tokens. Separate minimal
+configuration-update probes for high, xhigh and max each completed with 22 tokens.
+Image generation was not run. No credential or conversation data was saved in
+these test records.
+
+`codex-api/src/auth.rs` keeps authentication and refresh provider-owned;
+`codex-api/src/sse/responses.rs` separates cached/write/reasoning counters.
+`core/src/client.rs` merges beta features and supports internal responses-lite
+routing headers. Our successful normal-SSE probe did not need those internal
+headers, so no speculative header is added. Existing Pi OAuth remains the owner
+of credential storage and refresh.
+
+The new package is intentionally Astra-only until other model/backend pairs
+have their own live verification. It changes no unsupported requests or Pro/
+backend multi-agent modes. Tests cover all five standard effort values, branch/
+resume reconstruction, retry recovery, tool continuations, cancellation, actual
+standard-compactor fallback, malformed state, bounds and both load orders.
+
+Root validation and package checks passed on Node 26; reasoning integration tests
+also passed on the system Node 24. Semgrep scanned all changed runtime areas,
+including the new package, with zero findings or parse errors. This complements
+the contract tests; it is not proof that all possible defects are absent.
 
 ## Impact
 

--- a/docs/plans/2026-09-11-gpt6-codex.md
+++ b/docs/plans/2026-09-11-gpt6-codex.md
@@ -10,12 +10,12 @@ Codex code, add credential storage, push, or publish.
 
 - [x] Align all shared Pi development dependencies to 0.85.1.
   `npm ci --dry-run` and root `npm run validate` passed.
-- [ ] Enable Astra in pi-fast; preserve defaults, toggles, and model guards.
-- [ ] Preserve raw grammar tools and their history during compaction.
+- [x] Enable Astra in pi-fast; preserve defaults, toggles, and model guards.
+- [x] Preserve raw grammar tools and their history during compaction.
 - [ ] Apply Fast and reasoning settings to direct compaction requests.
-- [ ] Report cache writes and standard Pi compaction usage.
-- [ ] Cover checkpoint compatibility, cancellation, bounds, retries, and fallback.
-- [ ] Probe configuration_update on the actual Codex backend before enabling it.
+- [x] Report cache writes and standard Pi compaction usage.
+- [x] Cover checkpoint compatibility, cancellation, bounds, retries, and fallback.
+- [x] Probe configuration_update on the actual Codex backend before enabling it.
 - [ ] Add standalone pi-openai-reasoning with existing thinking controls,
   stable request effort, branch-local replay, retry safety, and compaction reset.
   Unsupported backend modes must remain disabled.
@@ -40,6 +40,16 @@ No source code is copied from this reference.
 
 Public API documentation is not proof of Codex backend support.
 Async tool calls and mid-turn steering remain upstream Pi work.
+
+Live Astra probe passed on 2026-09-11: existing Pi OAuth, normal Codex SSE
+transport, request effort low, configuration update medium, 29 total tokens,
+response OK. No extra experimental header was needed.
+
+Pi 0.85.1's public ToolInfo still omits constrainedSampling. The packages use
+versioned synchronous events, not a private registry patch, to supply owned
+grammar metadata and apply direct-request settings. Real Pi loader/runner,
+compaction, session usage, fallback, and continuation tests pass in both load
+orders. Root validation passed after these changes.
 
 ## Impact
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5068,7 +5068,7 @@
       }
     },
     "packages/pi-codex-compaction": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@mocito/install-telemetry": "0.1.1"
@@ -5118,7 +5118,7 @@
       "license": "MIT"
     },
     "packages/pi-codex-tools": {
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@mocito/install-telemetry": "0.1.1",
@@ -5191,7 +5191,7 @@
       }
     },
     "packages/pi-fast": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@mocito/install-telemetry": "0.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4712,6 +4712,10 @@
       "resolved": "packages/pi-insomnia",
       "link": true
     },
+    "node_modules/pi-openai-reasoning": {
+      "resolved": "packages/pi-openai-reasoning",
+      "link": true
+    },
     "node_modules/pi-scout": {
       "resolved": "packages/pi-scout",
       "link": true
@@ -5256,6 +5260,27 @@
         "node": ">=20.6.0"
       },
       "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "*"
+      }
+    },
+    "packages/pi-openai-reasoning": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@mocito/install-telemetry": "0.1.1"
+      },
+      "devDependencies": {
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
+        "@types/node": "^26.2.0",
+        "tsx": "^4.23.5",
+        "typescript": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-ai": "*",
         "@earendil-works/pi-coding-agent": "*"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,14 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -482,9 +483,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -492,22 +493,20 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
-      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
+        "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -534,23 +533,21 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
-      "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.85.1.tgz",
+      "integrity": "sha512-FGRN+OHbWaefBPGaTggAdLjrIHW+s2PzLyglz/5dfLzb9of7uuXMXYC0fJIeZTw+shS32o2cuQ9jF7YSDuL/oQ==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.84.1",
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-client": "^0.84.1",
-        "@earendil-works/pi-protocol": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/chord": "^0.85.1",
+        "@earendil-works/pi-agent-core": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-tui": "^0.85.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
         "diff": "8.0.4",
-        "glob": "13.0.6",
         "grok-mermaid": "0.2.2",
         "highlight.js": "10.7.3",
         "hosted-git-info": "9.0.3",
@@ -564,7 +561,7 @@
         "yaml": "2.9.0"
       },
       "bin": {
-        "pi": "dist/cli.js"
+        "pi": "dist/bundle/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -574,13 +571,14 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -1035,14 +1033,27 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/chord": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "esbuild": "0.28.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.1.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/chord": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -1053,21 +1064,19 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
+        "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -1078,33 +1087,9 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-protocol": "^0.84.1"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "typebox": "1.3.7"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1112,8 +1097,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.85.1.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1122,6 +1107,448 @@
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
@@ -1339,27 +1766,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -1372,26 +1778,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1595,6 +1981,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
@@ -1759,12 +2152,61 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -1883,24 +2325,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
@@ -2119,16 +2543,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2177,14 +2591,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -2250,23 +2661,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
@@ -2388,6 +2782,17 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
       "version": "2.3.0",
@@ -2520,30 +2925,10 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
-      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2551,9 +2936,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
-      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.85.1.tgz",
+      "integrity": "sha512-OIzw9efInmO4WOBnD4TxcTdBjmzvYJpzslkgoUro946nEGoYWg5rwv1p4fDt3/JvMx9QybryUCUwlm7j8Dreig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3031,27 +3416,6 @@
         }
       }
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mocito/install-telemetry": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@mocito/install-telemetry/-/install-telemetry-0.1.1.tgz",
@@ -3077,26 +3441,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -3299,6 +3643,13 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.2.0",
@@ -3853,6 +4204,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
@@ -4257,14 +4615,11 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -4482,6 +4837,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4679,26 +5045,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "packages/pi-agentsmd": {
       "version": "0.1.4",
       "license": "MIT",
@@ -4706,7 +5052,7 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.84.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
         "@types/node": "^26.2.0",
         "typescript": "^7.0.2"
       },
@@ -4724,8 +5070,8 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-coding-agent": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
         "@types/node": "^26.2.0",
         "tsx": "^4.23.5",
         "typescript": "^7.0.2"
@@ -4745,8 +5091,8 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-coding-agent": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
         "@types/node": "^26.2.0",
         "typebox": "^1.3.10",
         "typescript": "^7.0.2"
@@ -4775,9 +5121,9 @@
         "node-gyp-build": "^4.8.4"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-coding-agent": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
+        "@earendil-works/pi-tui": "^0.85.1",
         "@types/node": "^26.2.0",
         "prebuildify": "^6.0.1",
         "tsx": "^4.23.5",
@@ -4809,7 +5155,7 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.84.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
         "@types/node": "^26.2.0",
         "tsx": "^4.23.5",
         "typescript": "^7.0.2"
@@ -4828,7 +5174,7 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.84.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
         "@types/node": "^26.2.0",
         "tsx": "^4.23.5",
         "typescript": "^7.0.2"
@@ -4847,8 +5193,8 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
+        "@earendil-works/pi-tui": "^0.85.1",
         "@types/node": "^26.2.0",
         "tsx": "^4.23.5",
         "typescript": "^7.0.2"
@@ -4869,9 +5215,9 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-coding-agent": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
+        "@earendil-works/pi-tui": "^0.85.1",
         "@types/node": "^26.2.0",
         "tsx": "^4.23.5",
         "typebox": "^1.3.10",
@@ -4901,7 +5247,7 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.84.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
         "@types/node": "^26.2.0",
         "tsx": "^4.23.5",
         "typescript": "^7.0.2"
@@ -4920,7 +5266,7 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.84.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
         "@types/node": "^26.2.0",
         "tsx": "^4.23.5",
         "typebox": "^1.3.10",
@@ -4948,8 +5294,8 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
+        "@earendil-works/pi-tui": "^0.85.1",
         "@types/node": "^26.2.0",
         "typescript": "^7.0.2"
       },
@@ -4968,9 +5314,9 @@
         "@mocito/install-telemetry": "0.1.1"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-coding-agent": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-coding-agent": "^0.85.1",
+        "@earendil-works/pi-tui": "^0.85.1",
         "@types/node": "^26.2.0",
         "tsx": "^4.23.5",
         "typebox": "^1.3.10",

--- a/packages/pi-agentsmd/package.json
+++ b/packages/pi-agentsmd/package.json
@@ -53,7 +53,7 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
     "@types/node": "^26.2.0",
     "typescript": "^7.0.2"
   },

--- a/packages/pi-codex-compaction/CHANGELOG.md
+++ b/packages/pi-codex-compaction/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-09-11
+
 ### Fixed
 
 - Preserve pi-codex-tools grammar metadata and custom-tool history during remote compaction.

--- a/packages/pi-codex-compaction/CHANGELOG.md
+++ b/packages/pi-codex-compaction/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve pi-codex-tools grammar metadata and custom-tool history during remote compaction.
+- Honor pi-fast on direct compaction requests through a public event-bus contract.
+- Include cache writes and standard Pi compaction usage in session totals.
+- Restrict endpoint paths and ports; merge beta features and honor null auth headers.
+- Avoid I/O after pre-cancellation, bound total request time, and close completed SSE streams promptly.
+
 ## [0.1.1] - 2026-08-06
 
 ### Fixed

--- a/packages/pi-codex-compaction/README.md
+++ b/packages/pi-codex-compaction/README.md
@@ -13,7 +13,7 @@ Keep long Pi sessions usable on OpenAI Codex models by replacing Pi's local summ
 - Falls back to standard Pi compaction on failure or when custom compaction instructions are requested.
 - Keeps a bounded readable transcript excerpt so switching models or providers remains usable.
 
-The current Codex catalog includes models such as `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`. Capability detection follows the provider/API contract (`openai-codex` + `openai-codex-responses`) rather than a brittle model-name list.
+The current Codex catalog includes `gpt-6-astra`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`. Capability detection follows the provider/API contract (`openai-codex` + `openai-codex-responses`) rather than a brittle model-name list. Use Pi 0.85.1 or later.
 
 ## Installation
 
@@ -42,6 +42,42 @@ Compaction uses the model active when Pi triggers it. If a session switches from
 If the remote request fails, is cancelled, or returns an unexpected response, Pi's standard compaction path runs. Custom compaction instructions also use Pi's standard path because RemoteCompactionV2 has no documented custom-instructions field. The direct checkpoint request is restricted to `https://chatgpt.com`, rejects redirects, limits request/response size, and never decodes or logs `encrypted_content`. No configuration is required.
 
 ## Development
+
+### Other Codex extensions
+
+With `pi-fast` installed, direct compaction requests use the current Fast toggle.
+With `pi-codex-tools` installed, `apply_patch` keeps its raw grammar definition,
+custom-tool calls, and custom-tool results during compaction. Neither package is
+required. No package reads a private Pi tool registry.
+
+Pi 0.85.1 does not expose grammar metadata in `getAllTools()`. Two synchronous,
+versioned `pi.events` contracts let cooperating extensions supply it:
+
+- `pi-codex-compaction:tools:v1`: `{ model, tools }`, before provider serialization.
+  A tool owner can attach its own `constrainedSampling` metadata.
+- `pi-codex-compaction:request:v1`: `{ ctx, messages, payload }`, after input
+  assembly and before size checks. A listener can replace `payload`. This event
+  is not the general `before_provider_request` chain and does not carry auth.
+
+Other extensions' private request changes are not applied automatically.
+Unknown third-party grammar metadata needs cooperation through the tools event.
+The checkpoint entry includes standard Pi `usage`, including cache reads and
+cache writes, as well as the original bounded token counters in `details`.
+Costs follow Pi's catalog estimates. They are not a ChatGPT subscription bill.
+
+### Reference and smoke test
+
+Behavior was checked against `openai/codex` commit
+`654b0a77d0d2f81aa21f61caf7af4be88fe550bb` (2026-09-11), notably
+`core/src/compact_remote_v2{,_attempt}.rs`. No Codex code was copied.
+RemoteCompactionV2 is a changing Codex protocol, not the public `/responses/compact`
+API. Async tools and mid-turn steering require upstream Pi support.
+
+For a small live test, load this package and select `openai-codex/gpt-6-astra`.
+Send two short messages, run `/compact`, then ask about the first message.
+Repeat with `/fast on` and `pi-codex-tools` loaded. Check that compaction succeeds,
+the continuation retains context, and session usage includes compaction tokens.
+Use only a temporary file if you test `apply_patch`. Do not generate images.
 
 ```bash
 npm install

--- a/packages/pi-codex-compaction/README.md
+++ b/packages/pi-codex-compaction/README.md
@@ -49,6 +49,9 @@ With `pi-fast` installed, direct compaction requests use the current Fast toggle
 With `pi-codex-tools` installed, `apply_patch` keeps its raw grammar definition,
 custom-tool calls, and custom-tool results during compaction. Neither package is
 required. No package reads a private Pi tool registry.
+With `pi-openai-reasoning` installed, verified Astra requests keep the original
+request effort and receive the current effort as a configuration update.
+Failed compaction does not change saved reasoning state.
 
 Pi 0.85.1 does not expose grammar metadata in `getAllTools()`. Two synchronous,
 versioned `pi.events` contracts let cooperating extensions supply it:

--- a/packages/pi-codex-compaction/SECURITY.md
+++ b/packages/pi-codex-compaction/SECURITY.md
@@ -25,4 +25,14 @@ The extension bounds request, compaction input, and response size, validates the
 
 The extension never logs prompts, conversation contents, credentials, authorization headers, or raw provider responses. Install/update telemetry is best-effort and sends only package/version/runtime metadata; it can be disabled with `PI_OFFLINE=1`, `PI_TELEMETRY=0`, or Pi's `enableInstallTelemetry: false` setting.
 
+Direct requests allow only the official `/backend-api/codex/responses` endpoint
+on the default HTTPS port, without query strings or fragments. Total request
+time is limited to five minutes, including retries. Completed streams are closed
+without waiting for a server disconnect. A pre-aborted request does no network I/O.
+Null auth headers remove matching model headers; beta features are merged.
+
+Cooperating local extensions can inspect and transform compaction inputs through
+the documented event bus before size checks. These events contain no credentials.
+They have the same trust level as other installed Pi extensions.
+
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development and validation instructions.

--- a/packages/pi-codex-compaction/extensions/index.ts
+++ b/packages/pi-codex-compaction/extensions/index.ts
@@ -23,10 +23,21 @@ export default function piCodexCompaction(pi: ExtensionAPI): void {
     try {
       const compaction = await createRemoteCompaction(event, ctx, () => {
         const active = new Set(pi.getActiveTools());
-        return pi.getAllTools()
-          .filter((tool) => active.has(tool.name))
-          .map(({ name, description, parameters }) => ({ name, description, parameters }));
-      }, pi.getThinkingLevel?.());
+        const data = {
+          model: ctx.model,
+          tools: pi.getAllTools().filter((tool) => active.has(tool.name)),
+        };
+        // Pi's public ToolInfo omits constrainedSampling. Tool owners can supply
+        // it here without exposing executors or inspecting private registries.
+        pi.events?.emit("pi-codex-compaction:tools:v1", data);
+        return data.tools;
+      }, pi.getThinkingLevel?.(), (payload, messages) => {
+        const data = { payload, messages, ctx };
+        // Synchronous bus contract: apply pure request transforms before bounds
+        // and before network I/O. Never include auth in this event.
+        pi.events?.emit("pi-codex-compaction:request:v1", data);
+        return data.payload;
+      });
       return compaction ? { compaction } : undefined;
     } catch {
       if (!event.signal.aborted && ctx.hasUI) {

--- a/packages/pi-codex-compaction/package.json
+++ b/packages/pi-codex-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-compaction",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Use OpenAI Codex RemoteCompactionV2 for supported Pi sessions.",
   "type": "module",
   "license": "MIT",

--- a/packages/pi-codex-compaction/package.json
+++ b/packages/pi-codex-compaction/package.json
@@ -52,8 +52,8 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.84.1",
-    "@earendil-works/pi-coding-agent": "^0.84.1",
+    "@earendil-works/pi-ai": "^0.85.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
     "@types/node": "^26.2.0",
     "tsx": "^4.23.5",
     "typescript": "^7.0.2"

--- a/packages/pi-codex-compaction/src/codex-wire.ts
+++ b/packages/pi-codex-compaction/src/codex-wire.ts
@@ -5,6 +5,7 @@ const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 const MAX_ENCRYPTED_CONTENT_CHARS = 2_000_000;
 const REQUEST_HEADER_TIMEOUT_MS = 30_000;
 const REQUEST_IDLE_TIMEOUT_MS = 120_000;
+const REQUEST_TOTAL_TIMEOUT_MS = 300_000;
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY_MS = 200;
 const MAX_RETRY_DELAY_MS = 30_000;
@@ -30,12 +31,14 @@ export interface CodexCompactionUsage {
   outputTokens?: number;
   totalTokens?: number;
   cachedInputTokens?: number;
+  cacheWriteInputTokens?: number;
   reasoningTokens?: number;
 }
 
 export interface CodexCompactionResult {
   encryptedContent: string;
   usage?: CodexCompactionUsage;
+  serviceTier?: "default" | "priority" | "flex";
 }
 
 /**
@@ -49,6 +52,7 @@ export async function requestRemoteCompaction(request: CodexCompactionRequest): 
 export async function requestRemoteCompactionWithUsage(
   request: CodexCompactionRequest,
 ): Promise<CodexCompactionResult> {
+  request.signal?.throwIfAborted();
   const endpoint = resolveCodexResponsesUrl(request.model.baseUrl);
   const accountId = extractAccountId(request.apiKey);
   const headers = buildHeaders(request, accountId);
@@ -60,6 +64,7 @@ export async function requestRemoteCompactionWithUsage(
   const requestState = requestSignal(request.signal);
   try {
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      requestState.signal.throwIfAborted();
       requestState.startAttempt();
 
       try {
@@ -116,8 +121,14 @@ export function resolveCodexResponsesUrl(baseUrl: string): string {
   if (url.username || url.password) {
     throw new Error("Codex compaction endpoint must not contain URL credentials");
   }
+  if (url.port || url.search || url.hash) {
+    throw new Error("Codex compaction endpoint must use the default port without query or fragment");
+  }
 
   const path = url.pathname.replace(/\/+$/, "");
+  if (!["/backend-api", "/backend-api/codex", "/backend-api/codex/responses"].includes(path)) {
+    throw new Error("Codex compaction endpoint must use the Codex Responses path");
+  }
   if (path.endsWith("/codex/responses")) {
     return url.toString();
   }
@@ -145,13 +156,15 @@ function buildHeaders(request: CodexCompactionRequest, accountId: string): Heade
   }
   for (const [name, value] of Object.entries(request.authHeaders ?? {})) {
     if (value !== null) headers.set(name, value);
+    else headers.delete(name);
   }
 
   headers.set("Authorization", `Bearer ${request.apiKey}`);
   headers.set("chatgpt-account-id", accountId);
   headers.set("originator", "pi");
   headers.set("OpenAI-Beta", "responses=experimental");
-  headers.set("x-codex-beta-features", BETA_FEATURE);
+  const features = headers.get("x-codex-beta-features")?.split(",").map((part) => part.trim()).filter(Boolean) ?? [];
+  headers.set("x-codex-beta-features", [...new Set([...features, BETA_FEATURE])].join(","));
   headers.set("accept", "text/event-stream");
   headers.set("content-type", "application/json");
 
@@ -212,6 +225,7 @@ async function readCompactionSse(
         throw new CodexCompactionError("Codex compaction response exceeded the size limit", false);
       }
       parser.push(decoder.decode(value, { stream: true }));
+      if (parser.isComplete) return parser.finish();
     }
     parser.push(decoder.decode());
     return parser.finish();
@@ -231,6 +245,11 @@ class CompactionSseParser {
   private status: string | undefined;
   private compactionItems: Array<string | undefined> = [];
   private usage: CodexCompactionUsage | undefined;
+  private serviceTier: CodexCompactionResult["serviceTier"];
+
+  get isComplete(): boolean {
+    return this.completed;
+  }
 
   push(chunk: string): void {
     this.buffer += chunk;
@@ -266,6 +285,7 @@ class CompactionSseParser {
     return {
       encryptedContent,
       ...(this.usage ? { usage: this.usage } : {}),
+      ...(this.serviceTier ? { serviceTier: this.serviceTier } : {}),
     };
   }
 
@@ -298,6 +318,8 @@ class CompactionSseParser {
       const response = isRecord(event.response) ? event.response : undefined;
       this.status = typeof response?.status === "string" ? response.status : undefined;
       this.usage = parseUsage(response?.usage ?? event.usage);
+      const tier = response?.service_tier;
+      this.serviceTier = tier === "default" || tier === "priority" || tier === "flex" ? tier : undefined;
 
       // Codex emits output_item.done before response.completed. Retain this
       // fallback for compact Responses implementations that only return the
@@ -335,12 +357,14 @@ function parseUsage(value: unknown): CodexCompactionUsage | undefined {
   const inputDetails = isRecord(value.input_tokens_details) ? value.input_tokens_details : undefined;
   const outputDetails = isRecord(value.output_tokens_details) ? value.output_tokens_details : undefined;
   const cachedInputTokens = finiteNonNegativeNumber(inputDetails?.cached_tokens);
+  const cacheWriteInputTokens = finiteNonNegativeNumber(inputDetails?.cache_write_tokens);
   const reasoningTokens = finiteNonNegativeNumber(outputDetails?.reasoning_tokens);
   if (
     inputTokens === undefined &&
     outputTokens === undefined &&
     totalTokens === undefined &&
     cachedInputTokens === undefined &&
+    cacheWriteInputTokens === undefined &&
     reasoningTokens === undefined
   ) {
     return undefined;
@@ -350,6 +374,7 @@ function parseUsage(value: unknown): CodexCompactionUsage | undefined {
     ...(outputTokens !== undefined ? { outputTokens } : {}),
     ...(totalTokens !== undefined ? { totalTokens } : {}),
     ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+    ...(cacheWriteInputTokens !== undefined ? { cacheWriteInputTokens } : {}),
     ...(reasoningTokens !== undefined ? { reasoningTokens } : {}),
   };
 }
@@ -432,6 +457,10 @@ interface RequestSignal {
 
 function requestSignal(signal: AbortSignal | undefined): RequestSignal {
   const controller = new AbortController();
+  const totalTimeout = setTimeout(
+    () => controller.abort(new Error("Codex compaction request exceeded the total time limit")),
+    REQUEST_TOTAL_TIMEOUT_MS,
+  );
   let headerTimeout: ReturnType<typeof setTimeout> | undefined;
   let idleTimeout: ReturnType<typeof setTimeout> | undefined;
 
@@ -472,6 +501,7 @@ function requestSignal(signal: AbortSignal | undefined): RequestSignal {
     },
     touch,
     cleanup: () => {
+      clearTimeout(totalTimeout);
       clearTimers();
       signal?.removeEventListener("abort", onAbort);
     },

--- a/packages/pi-codex-compaction/src/remote-compaction.ts
+++ b/packages/pi-codex-compaction/src/remote-compaction.ts
@@ -1,5 +1,5 @@
 import { stream as captureProviderPayload } from "@earendil-works/pi-ai/compat";
-import type { Model, Tool } from "@earendil-works/pi-ai";
+import { calculateCost, type Model, type Tool, type Usage } from "@earendil-works/pi-ai";
 import type { ExtensionContext, SessionBeforeCompactEvent } from "@earendil-works/pi-coding-agent";
 import { convertToLlm, serializeConversation, sessionEntryToContextMessages } from "@earendil-works/pi-coding-agent";
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
@@ -95,11 +95,13 @@ export async function createRemoteCompaction(
   ctx: ExtensionContext,
   getTools: () => readonly ToolInfoLike[],
   thinkingLevel?: string,
+  prepareRequest?: (payload: Record<string, unknown>, messages: readonly AgentMessage[]) => Record<string, unknown>,
 ): Promise<{
   summary: string;
   firstKeptEntryId: string;
   tokensBefore: number;
   details: RemoteCompactionDetails;
+  usage?: Usage;
 } | undefined> {
   // Pi's custom focus is part of the standard summarizer contract. The
   // Responses compaction envelope has no documented equivalent, so do not
@@ -139,16 +141,20 @@ export async function createRemoteCompaction(
   const providerTools = Array.isArray(providerPayload.tools) ? providerPayload.tools : [];
 
   const input = appendCompactionItems(providerInput, event.preparation, compatiblePrevious);
-  const requestBody = {
+  const requestBody = prepareRequest?.({
     ...providerPayload,
+    input,
+  }, messages) ?? { ...providerPayload, input };
+  Object.assign(requestBody, {
     model: model.id,
     store: false,
     stream: true,
-  };
+  });
+  if (!Array.isArray(requestBody.input)) return undefined;
   const boundedInput = boundCompactionInput(
-    input,
+    requestBody.input,
     instructions,
-    providerTools,
+    Array.isArray(requestBody.tools) ? requestBody.tools : providerTools,
     model.contextWindow,
     requestBody,
   );
@@ -171,6 +177,11 @@ export async function createRemoteCompaction(
     summary: `${REMOTE_SUMMARY_MARKER}\n\n${fallback}`,
     firstKeptEntryId: event.preparation.firstKeptEntryId,
     tokensBefore: event.preparation.tokensBefore,
+    ...(result.usage ? { usage: toPiUsage(
+      result.usage,
+      ctx.model!,
+      result.serviceTier && result.serviceTier !== "default" ? result.serviceTier : requestBody.service_tier,
+    ) } : {}),
     details: {
       kind: REMOTE_COMPACTION_KIND,
       version: 2,
@@ -534,7 +545,27 @@ function limitText(text: string, maxChars: number): string {
   return `${text.slice(0, head)}${omission}${text.slice(text.length - (available - head))}`;
 }
 
-type ToolInfoLike = Pick<Tool, "name" | "description" | "parameters">;
+type ToolInfoLike = Tool;
+
+function toPiUsage(raw: CodexCompactionUsage, model: Model<any>, tier: unknown): Usage {
+  const cacheRead = raw.cachedInputTokens ?? 0;
+  const cacheWrite = raw.cacheWriteInputTokens ?? 0;
+  const output = raw.outputTokens ?? 0;
+  const usage: Usage = {
+    input: Math.max(0, (raw.inputTokens ?? 0) - cacheRead - cacheWrite),
+    output,
+    cacheRead,
+    cacheWrite,
+    ...(raw.reasoningTokens !== undefined ? { reasoning: raw.reasoningTokens } : {}),
+    totalTokens: raw.totalTokens ?? (raw.inputTokens ?? 0) + output,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+  calculateCost(model, usage);
+  // Match Pi 0.85.1's catalog estimates, not subscription credit accounting.
+  const multiplier = tier === "priority" ? (model.id === "gpt-5.5" ? 2.5 : 2) : tier === "flex" ? 0.5 : 1;
+  for (const key of ["input", "output", "cacheRead", "cacheWrite", "total"] as const) usage.cost[key] *= multiplier;
+  return usage;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/pi-codex-compaction/tests/extension.test.mjs
+++ b/packages/pi-codex-compaction/tests/extension.test.mjs
@@ -208,6 +208,35 @@ test("bounds retries and does not retry malformed provider data", async (t) => {
   }
 });
 
+test("total deadline stops a stream even when heartbeats prevent idle timeout", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  let streamController;
+  let signal;
+  let attempts = 0;
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    attempts++;
+    signal = init.signal;
+    return new Response(new ReadableStream({
+      start(controller) {
+        streamController = controller;
+        signal.addEventListener("abort", () => controller.error(signal.reason), { once: true });
+      },
+    }));
+  });
+  const failed = assert.rejects(
+    () => requestRemoteCompactionWithUsage({ model, apiKey: token, body: {} }),
+    /total time limit/,
+  );
+  await new Promise(setImmediate);
+  for (let minute = 1; minute <= 5; minute++) {
+    t.mock.timers.tick(60_000);
+    if (!signal.aborted) streamController.enqueue(new TextEncoder().encode(": heartbeat\n\n"));
+    await new Promise(setImmediate);
+  }
+  await failed;
+  assert.equal(attempts, 1);
+});
+
 test("rejects multiple compaction output items", () => {
   const item = (encrypted_content) => `data: ${JSON.stringify({
     type: "response.output_item.done",

--- a/packages/pi-codex-compaction/tests/extension.test.mjs
+++ b/packages/pi-codex-compaction/tests/extension.test.mjs
@@ -113,6 +113,10 @@ test("resolves only HTTPS Codex Responses endpoints", () => {
   assert.throws(() => resolveCodexResponsesUrl("http://localhost:1234"), /HTTPS/);
   assert.throws(() => resolveCodexResponsesUrl("https://example.com/backend-api"), /trusted Codex origin/);
   assert.throws(() => resolveCodexResponsesUrl("https://user:pass@chatgpt.com/backend-api"), /credentials/);
+  for (const url of [
+    "https://chatgpt.com:444/backend-api", "https://chatgpt.com/backend-api?key=x",
+    "https://chatgpt.com/backend-api#fragment", "https://chatgpt.com/other",
+  ]) assert.throws(() => resolveCodexResponsesUrl(url));
 });
 
 test("parses the completed remote compaction checkpoint", () => {
@@ -138,7 +142,7 @@ test("parses usage without exposing the opaque checkpoint", () => {
           input_tokens: 123,
           output_tokens: 7,
           total_tokens: 130,
-          input_tokens_details: { cached_tokens: 80 },
+          input_tokens_details: { cached_tokens: 80, cache_write_tokens: 20 },
           output_tokens_details: { reasoning_tokens: 4 },
         },
       },
@@ -152,9 +156,56 @@ test("parses usage without exposing the opaque checkpoint", () => {
       outputTokens: 7,
       totalTokens: 130,
       cachedInputTokens: 80,
+      cacheWriteInputTokens: 20,
       reasoningTokens: 4,
     },
   });
+});
+
+test("finishes a completed stream without waiting for the server to close it", async (t) => {
+  let cancelled = false;
+  t.mock.method(globalThis, "fetch", async () => new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify({
+        type: "response.completed",
+        response: { status: "completed", output: [{ type: "compaction", encrypted_content: "checkpoint" }] },
+      })}\n\n`));
+    },
+    cancel() { cancelled = true; },
+  })));
+  const result = await requestRemoteCompactionWithUsage({ model, apiKey: token, body: {} });
+  assert.equal(result.encryptedContent, "checkpoint");
+  assert.equal(cancelled, true);
+});
+
+test("retains beta features and stops cancellation during retry without another request", async (t) => {
+  let attempts = 0;
+  const controller = new AbortController();
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    attempts++;
+    assert.equal(new Headers(init.headers).get("x-codex-beta-features"), "other,remote_compaction_v2");
+    queueMicrotask(() => controller.abort(new Error("fixture cancelled")));
+    return new Response("", { status: 429, headers: { "retry-after": "10000" } });
+  });
+  await assert.rejects(() => requestRemoteCompactionWithUsage({
+    model, apiKey: token, body: {}, signal: controller.signal,
+    authHeaders: { "X-Codex-Beta-Features": "other,remote_compaction_v2" },
+  }), /fixture cancelled/);
+  assert.equal(attempts, 1);
+});
+
+test("bounds retries and does not retry malformed provider data", async (t) => {
+  for (const malformed of [false, true]) {
+    let attempts = 0;
+    t.mock.method(globalThis, "fetch", async () => {
+      attempts++;
+      return malformed ? new Response("data: invalid-json\n\n") : new Response("", {
+        status: 503, headers: { "retry-after-ms": "0" },
+      });
+    });
+    await assert.rejects(() => requestRemoteCompactionWithUsage({ model, apiKey: token, body: {} }));
+    assert.equal(attempts, malformed ? 1 : 3);
+  }
 });
 
 test("rejects multiple compaction output items", () => {
@@ -317,9 +368,9 @@ test("keeps the normal prompt envelope while compacting only discardable history
 
 test("honors an already-aborted compaction signal", async () => {
   const originalFetch = globalThis.fetch;
-  let capturedSignal;
-  globalThis.fetch = async (_url, init) => {
-    capturedSignal = init.signal;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
     throw new Error("fetch called");
   };
 
@@ -328,9 +379,9 @@ test("honors an already-aborted compaction signal", async () => {
   try {
     await assert.rejects(
       () => requestRemoteCompaction({ model, apiKey: token, body: {}, signal: controller.signal }),
-      /fetch called/,
+      /cancelled/,
     );
-    assert.equal(capturedSignal.aborted, true);
+    assert.equal(calls, 0);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -401,7 +452,7 @@ test("omits null provider headers", async () => {
 
   try {
     const result = await requestRemoteCompactionWithUsage({
-      model,
+      model: { ...model, headers: { "x-suppressed": "must-remove" } },
       apiKey: token,
       authHeaders: { "x-test": "yes", "x-suppressed": null },
       body: { input: [] },

--- a/packages/pi-codex-compaction/tests/integration.test.mjs
+++ b/packages/pi-codex-compaction/tests/integration.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { codexHarness, compactionResponse, requestBody, textResponse } from "../../../tests/codex-harness.mjs";
+
+process.env.CI = "1";
+process.env.PI_OFFLINE = "1";
+const { default: fast } = await import("../../pi-fast/extensions/index.ts");
+const { default: tools } = await import("../../pi-codex-tools/extensions/index.ts");
+const { default: compaction } = await import("../extensions/index.ts");
+const zeroUsage = {
+  input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+const patch = "*** Begin Patch\n*** Add File: unused.txt\n+fixture\n*** End Patch";
+
+for (const factories of [[fast, tools, compaction], [compaction, tools, fast]]) {
+  test(`real Pi compaction preserves grammar history, Fast, usage and checkpoint (${factories[0].name} first)`, async (t) => {
+    const requests = [];
+    t.mock.method(globalThis, "fetch", async (_url, init) => {
+      requests.push(requestBody(init));
+      return compactionResponse({
+        input_tokens: 100, output_tokens: 5, total_tokens: 105,
+        input_tokens_details: { cached_tokens: 20, cache_write_tokens: 30 },
+      });
+    });
+    const h = await codexHarness(factories);
+    try {
+      // Verify the upstream gap as well as the package bridge.
+      assert.equal(h.api.getAllTools().find((t) => t.name === "apply_patch").constrainedSampling, undefined);
+      assert.ok(h.session.getActiveToolNames().includes("apply_patch"));
+      const messages = [
+        { role: "user", content: "old request", timestamp: 1 },
+        {
+          role: "assistant", provider: h.model.provider, api: h.model.api, model: h.model.id,
+          content: [{ type: "toolCall", id: "call_1|fc_1", name: "apply_patch", arguments: { patch } }],
+          usage: zeroUsage, stopReason: "toolUse", timestamp: 2,
+        },
+        { role: "toolResult", toolCallId: "call_1|fc_1", toolName: "apply_patch", content: [{ type: "text", text: "fixture result" }], isError: false, timestamp: 3 },
+        { role: "user", content: "kept request", timestamp: 4 },
+      ];
+      for (const message of messages) h.sessionManager.appendMessage(message);
+      h.session.agent.state.messages = messages;
+      await h.session.prompt("/fast on");
+      const result = await h.session.compact();
+      assert.equal(requests.length, 1);
+      const body = requests[0];
+      assert.equal(body.service_tier, "priority");
+      assert.equal(body.reasoning.effort, "low");
+      assert.equal(body.tools.find((t) => t.name === "apply_patch").type, "custom");
+      const call = body.input.find((item) => item.type === "custom_tool_call");
+      assert.equal(call.input, patch);
+      assert.equal(call.call_id, "call_1");
+      assert.equal(body.input.find((item) => item.type === "custom_tool_call_output").output, "fixture result");
+      assert.equal(body.input.at(-1).type, "compaction_trigger");
+      assert.equal(JSON.stringify(body.input).includes("kept request"), false);
+      assert.deepEqual(
+        { ...result.usage, cost: undefined },
+        { input: 50, output: 5, cacheRead: 20, cacheWrite: 30, totalTokens: 105, cost: undefined },
+      );
+      const entry = h.sessionManager.getBranch().findLast((e) => e.type === "compaction");
+      assert.deepEqual(entry.usage, result.usage);
+      assert.equal(entry.details.usage.cacheWriteInputTokens, 30);
+      assert.ok(h.session.getSessionStats().tokens.cacheWrite >= 30);
+      assert.deepEqual(h.errors, []);
+
+      // A subsequent request goes through the actual provider hook chain.
+      let replay;
+      h.api.on("before_provider_request", (event) => { replay = event.payload; });
+      // Mock provider transport, after the extension runner rewrites it.
+      t.mock.method(globalThis, "fetch", async (_url, init) => {
+        const next = requestBody(init);
+        if (next.input) replay = next;
+        return textResponse();
+      });
+      await h.session.prompt("continue", { expandPromptTemplates: false });
+      assert.ok(replay.input.some((item) => item.type === "compaction"));
+      assert.equal(replay.service_tier, "priority");
+      assert.equal(h.session.messages.at(-1).stopReason, "stop");
+    } finally { await h.close(); }
+  });
+}
+
+test("a remote rejection uses the actual standard Pi compactor", async (t) => {
+  const requests = [];
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    const body = requestBody(init);
+    requests.push(body);
+    return body.input.some((item) => item.type === "compaction_trigger")
+      ? new Response("fixture rejection", { status: 400 })
+      : textResponse("fallback summary");
+  });
+  const h = await codexHarness([compaction]);
+  try {
+    for (const [index, content] of ["old request", "kept request"].entries()) {
+      h.sessionManager.appendMessage({ role: "user", content, timestamp: index + 1 });
+    }
+    const result = await h.session.compact();
+    assert.equal(result.summary, "fallback summary");
+    assert.notEqual(result.details?.kind, "pi-codex-compaction");
+    assert.equal(requests.length, 2);
+    assert.equal(requests[1].input.some((item) => item.type === "compaction_trigger"), false);
+    assert.deepEqual(h.errors, []);
+  } finally { await h.close(); }
+});

--- a/packages/pi-codex-image-gen/package.json
+++ b/packages/pi-codex-image-gen/package.json
@@ -58,8 +58,8 @@
     "typebox": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.84.1",
-    "@earendil-works/pi-coding-agent": "^0.84.1",
+    "@earendil-works/pi-ai": "^0.85.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
     "@types/node": "^26.2.0",
     "typebox": "^1.3.10",
     "typescript": "^7.0.2"

--- a/packages/pi-codex-tools/CHANGELOG.md
+++ b/packages/pi-codex-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Fixed
+
+- Supply owned apply_patch grammar metadata to pi-codex-compaction through Pi's public event bus.
+
 ## [0.2.3] - 2026-08-11
 
 ### Changed

--- a/packages/pi-codex-tools/CHANGELOG.md
+++ b/packages/pi-codex-tools/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-09-11
+
 ### Fixed
 
 - Supply owned apply_patch grammar metadata to pi-codex-compaction through Pi's public event bus.

--- a/packages/pi-codex-tools/README.md
+++ b/packages/pi-codex-tools/README.md
@@ -40,6 +40,11 @@ These choices are based on the Codex tool specifications in `codex-rs/core/src/t
 
 ## Compatibility notes
 
+With an updated `pi-codex-compaction` installed, the package supplies its owned
+grammar metadata through Pi's public event bus. This keeps raw `apply_patch`
+calls and results intact in direct Codex compaction requests, including Astra.
+No private Pi registry is patched.
+
 `apply_patch` is line-oriented rather than byte-oriented:
 
 - `*** Add File` requires at least one `+` line and writes a trailing newline. A `+`-only hunk creates a one-newline file, not a zero-byte file.

--- a/packages/pi-codex-tools/extensions/index.ts
+++ b/packages/pi-codex-tools/extensions/index.ts
@@ -90,6 +90,20 @@ export default function piCodexTools(pi: ExtensionAPI): void {
 
   let replacedToolsWasActive: Record<ReplacedTool, boolean> | undefined;
 
+  pi.events?.on("pi-codex-compaction:tools:v1", (value) => {
+    const data = value as {
+      model?: ExtensionContext["model"];
+      tools?: Array<{ name: string; parameters: unknown; constrainedSampling?: OpenAIGrammarSampling }>;
+    } | undefined;
+    if (!data || !supportsOpenAIGrammarTools(data.model) || !Array.isArray(data.tools)) return;
+    for (const tool of data.tools) {
+      // Do not attach our grammar to another extension's apply_patch override.
+      if (tool.name === APPLY_PATCH && tool.parameters === APPLY_PATCH_PARAMETERS) {
+        tool.constrainedSampling = createOpenAILarkSampling(APPLY_PATCH_GRAMMAR);
+      }
+    }
+  });
+
   function synchronizeTools(ctx: ExtensionContext): void {
     if (typeof pi.getActiveTools !== "function" || typeof pi.setActiveTools !== "function") return;
 

--- a/packages/pi-codex-tools/package.json
+++ b/packages/pi-codex-tools/package.json
@@ -60,9 +60,9 @@
     "typebox": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.84.1",
-    "@earendil-works/pi-coding-agent": "^0.84.1",
-    "@earendil-works/pi-tui": "^0.84.1",
+    "@earendil-works/pi-ai": "^0.85.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
+    "@earendil-works/pi-tui": "^0.85.1",
     "@types/node": "^26.2.0",
     "prebuildify": "^6.0.1",
     "tsx": "^4.23.5",

--- a/packages/pi-codex-tools/package.json
+++ b/packages/pi-codex-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-tools",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Codex-compatible apply_patch tooling for Pi's grammar-capable OpenAI models.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/pi-compound-engineering/package.json
+++ b/packages/pi-compound-engineering/package.json
@@ -57,7 +57,7 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
     "@types/node": "^26.2.0",
     "tsx": "^4.23.5",
     "typescript": "^7.0.2"

--- a/packages/pi-dcg/package.json
+++ b/packages/pi-dcg/package.json
@@ -53,7 +53,7 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
     "@types/node": "^26.2.0",
     "tsx": "^4.23.5",
     "typescript": "^7.0.2"

--- a/packages/pi-fast/CHANGELOG.md
+++ b/packages/pi-fast/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-09-11
+
 ### Added
 
 - Support GPT-6 Astra Fast mode on the Codex subscription backend.

--- a/packages/pi-fast/CHANGELOG.md
+++ b/packages/pi-fast/CHANGELOG.md
@@ -9,6 +9,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 ### Added
 
 - Support GPT-6 Astra Fast mode on the Codex subscription backend.
+- Apply the current Fast toggle to cooperating Codex compaction requests.
 
 ### Changed
 

--- a/packages/pi-fast/CHANGELOG.md
+++ b/packages/pi-fast/CHANGELOG.md
@@ -6,6 +6,10 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Added
+
+- Support GPT-6 Astra Fast mode on the Codex subscription backend.
+
 ### Changed
 
 - Move the Fast mode shortcut from `Ctrl+Shift+F` to `Ctrl+Shift+R` to avoid Pi's transcript search shortcut.

--- a/packages/pi-fast/README.md
+++ b/packages/pi-fast/README.md
@@ -60,6 +60,8 @@ pi -e /path/to/pi-mono/packages/pi-fast
 ```
 
 This is an npm-compatible TypeScript Pi package. There is no runtime build step.
+With an updated `pi-codex-compaction` installed, the same Fast toggle also applies
+to its direct compaction requests through Pi's event bus.
 
 ## Usage
 

--- a/packages/pi-fast/README.md
+++ b/packages/pi-fast/README.md
@@ -16,6 +16,7 @@ Use provider fast modes in Pi when you need lower latency, while keeping the pai
 
 The current OpenAI Codex catalog advertises Fast support for:
 
+- `gpt-6-astra`
 - `gpt-5.4`
 - `gpt-5.5`
 - `gpt-5.6-luna`
@@ -23,6 +24,14 @@ The current OpenAI Codex catalog advertises Fast support for:
 - `gpt-5.6-terra`
 
 The support list follows the upstream Codex model catalog and may need an update when that catalog changes. Models without an advertised Fast tier are left untouched.
+
+Checked against `openai/codex` commit
+`654b0a77d0d2f81aa21f61caf7af4be88fe550bb` (2026-09-11).
+This package uses the Codex subscription backend, not the public OpenAI API.
+Fast mode consumes more subscription usage. Public API dollar prices and Pi's
+token-cost estimates are not your ChatGPT credit bill. Consult
+[Codex speed documentation](https://developers.openai.com/codex/speed)
+for current plan rates and availability. No latency guarantee is made.
 
 ## Installation
 
@@ -88,3 +97,7 @@ npm run -w packages/pi-fast check
 npm test -w packages/pi-fast
 npm run -w packages/pi-fast pack:dry-run
 ```
+
+Smoke test (Pi 0.85.1 or later): select `openai-codex/gpt-6-astra`, enable
+`/fast on`, and send a short prompt. Check `Fast on`. Switch to a different
+provider and check `Fast n/a`. Switch back, run `/fast off`, and check `Fast off`.

--- a/packages/pi-fast/SECURITY.md
+++ b/packages/pi-fast/SECURITY.md
@@ -23,6 +23,10 @@ The extension does not read or log prompts, credentials, auth headers, or provid
 
 Fast mode is off by default unless `pi-fast.enabledByDefault` is explicitly `true`. Session toggles are not persisted. Models without an advertised Fast tier are not modified. The `priority` tier can increase provider usage, so the setting is an explicit opt-in and the footer and toggle notifications make the active state visible.
 
+The same in-memory service-tier transform applies to the
+`pi-codex-compaction:request:v1` event when that package is installed.
+This does not read the conversation or add a network request.
+
 On startup, `@mocito/install-telemetry` sends a best-effort install/update telemetry ping to the configured telemetry endpoint once per package version unless Pi telemetry is disabled, offline mode is enabled, or Pi runs in CI. The ping contains only the package name, version, and parsed platform/runtime/architecture from its User-Agent; it does not include prompts, file paths, config values, environment variables, or API keys.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development and validation instructions.

--- a/packages/pi-fast/extensions/index.ts
+++ b/packages/pi-fast/extensions/index.ts
@@ -69,6 +69,12 @@ export default function piFast(pi: ExtensionAPI): void {
     return applyFastMode(event.payload, ctx.model);
   });
 
+  pi.events?.on("pi-codex-compaction:request:v1", (value) => {
+    const data = value as { payload: unknown; ctx?: ExtensionContext } | undefined;
+    if (!enabled || !data?.ctx || !supportsFastMode(data.ctx.model)) return;
+    data.payload = applyFastMode(data.payload, data.ctx.model);
+  });
+
   pi.on("session_start", async (_event, ctx) => {
     enabled = await isFastModeEnabledByDefault();
     updateStatus(ctx);

--- a/packages/pi-fast/package.json
+++ b/packages/pi-fast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fast",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Toggle provider fast modes in Pi on demand.",
   "type": "module",
   "license": "MIT",

--- a/packages/pi-fast/package.json
+++ b/packages/pi-fast/package.json
@@ -53,8 +53,8 @@
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.1",
-    "@earendil-works/pi-tui": "^0.84.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
+    "@earendil-works/pi-tui": "^0.85.1",
     "@types/node": "^26.2.0",
     "tsx": "^4.23.5",
     "typescript": "^7.0.2"

--- a/packages/pi-fast/src/fast-mode.ts
+++ b/packages/pi-fast/src/fast-mode.ts
@@ -6,6 +6,7 @@ export interface FastModel {
 }
 
 const OPENAI_CODEX_FAST_MODELS: ReadonlySet<string> = new Set([
+  "gpt-6-astra",
   "gpt-5.4",
   "gpt-5.5",
   "gpt-5.6-luna",

--- a/packages/pi-fast/tests/extension.test.mjs
+++ b/packages/pi-fast/tests/extension.test.mjs
@@ -51,6 +51,9 @@ function makeContext(model, hasUI = true, mode = hasUI ? "tui" : "print") {
 }
 
 test("recognizes only the Codex models with an advertised Fast tier", () => {
+  assert.equal(supportsFastMode({ provider: "openai-codex", id: "gpt-6-astra" }), true);
+  assert.equal(supportsFastMode({ provider: "openai", id: "gpt-6-astra" }), false);
+  assert.equal(supportsFastMode({ provider: "openai-codex", id: "gpt-6-astra-pro" }), false);
   assert.equal(supportsFastMode({ provider: "openai-codex", id: "gpt-5.4" }), true);
   assert.equal(supportsFastMode({ provider: "openai-codex", id: "gpt-5.6-sol" }), true);
   assert.equal(supportsFastMode({ provider: "openai-codex", id: "gpt-5.4-mini" }), false);
@@ -166,6 +169,33 @@ test("does not enable Fast for unsupported models", async () => {
   assert.deepEqual(context.statuses.at(-1), { key: "pi-fast", value: "Fast n/a" });
   assert.equal(context.notifications.at(-1).type, "warning");
   assert.equal(await pi.handlers.get("before_provider_request")[0]({ payload: {} }, context), undefined);
+});
+
+test("Astra toggles preserve request fields and survive model switches without widening support", async () => {
+  const pi = makePi();
+  piFast(pi);
+  const context = makeContext({ provider: "openai-codex", id: "gpt-6-astra" });
+  const request = pi.handlers.get("before_provider_request")[0];
+  const payload = { input: [], reasoning: { effort: "max" }, service_tier: "default" };
+  await pi.handlers.get("session_start")[0]({}, context);
+  assert.equal(await request({ payload }, context), undefined);
+  await pi.commands.get("fast").handler("on", context);
+  assert.deepEqual(await request({ payload }, context), { ...payload, service_tier: "priority" });
+  assert.equal(payload.service_tier, "default");
+  for (const provider of ["openai", "anthropic"]) {
+    context.model = { provider, id: "gpt-6-astra" };
+    await pi.handlers.get("model_select")[0]({}, context);
+    assert.equal(context.statuses.at(-1).value, "Fast n/a");
+    assert.equal(await request({ payload }, context), undefined);
+  }
+  context.model = { provider: "openai-codex", id: "gpt-6-astra" };
+  await pi.handlers.get("model_select")[0]({}, context);
+  assert.equal(context.statuses.at(-1).value, "Fast on");
+  await pi.commands.get("fast").handler("off", context);
+  assert.equal(await request({ payload }, context), undefined);
+  for (const malformed of [undefined, null, [], "payload"]) {
+    assert.equal(applyFastMode(malformed, context.model), malformed);
+  }
 });
 
 test.after(async () => {

--- a/packages/pi-goal/package.json
+++ b/packages/pi-goal/package.json
@@ -53,9 +53,9 @@
     "typebox": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.84.1",
-    "@earendil-works/pi-coding-agent": "^0.84.1",
-    "@earendil-works/pi-tui": "^0.84.1",
+    "@earendil-works/pi-ai": "^0.85.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
+    "@earendil-works/pi-tui": "^0.85.1",
     "@types/node": "^26.2.0",
     "tsx": "^4.23.5",
     "typebox": "^1.3.10",

--- a/packages/pi-insomnia/package.json
+++ b/packages/pi-insomnia/package.json
@@ -52,7 +52,7 @@
     "@earendil-works/pi-coding-agent": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
     "@types/node": "^26.2.0",
     "tsx": "^4.23.5",
     "typescript": "^7.0.2"

--- a/packages/pi-openai-reasoning/.editorconfig
+++ b/packages/pi-openai-reasoning/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/pi-openai-reasoning/.gitignore
+++ b/packages/pi-openai-reasoning/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+*.tgz
+*.tsbuildinfo
+.DS_Store
+.env
+.env.*
+!.env.example
+npm-debug.log*

--- a/packages/pi-openai-reasoning/AGENTS.md
+++ b/packages/pi-openai-reasoning/AGENTS.md
@@ -1,0 +1,27 @@
+# pi-openai-reasoning Guidelines
+
+Root `AGENTS.md` applies.
+
+## Invariants
+
+- Enable only Codex OAuth model/mode pairs verified against the live backend.
+- Use Pi's existing thinking controls; do not register a replacement provider.
+- Keep the request effort fixed within a context window and replay updates at
+  checked history boundaries. Never emit adjacent updates.
+- Persist only bounded effort metadata and SHA-256 history fingerprints in
+  branch-local custom entries. Do not store prompts or credentials.
+- Compaction request transforms are read-only; failed compaction cannot change
+  live state. A successful checkpoint starts a new window.
+- Leave unsupported providers, Pro/multi-agent modes and auto-truncated requests
+  unchanged. Never fall back to a public API key.
+
+## Validation
+
+```bash
+npm run -w packages/pi-openai-reasoning check
+npm test -w packages/pi-openai-reasoning
+npm run -w packages/pi-openai-reasoning pack:dry-run
+```
+
+Use the opt-in live smoke test in README after protocol changes. Never generate
+images for a reasoning smoke test.

--- a/packages/pi-openai-reasoning/CHANGELOG.md
+++ b/packages/pi-openai-reasoning/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [Unreleased]
+
+## [0.1.0] - 2026-09-11
+
+### Added
+
+- Codex-only Astra reasoning updates with a fixed request effort.
+- Branch-local replay, retry stability and compaction integration.
+- Existing Pi thinking controls, OAuth reuse, bounded metadata and install telemetry.

--- a/packages/pi-openai-reasoning/CHANGELOG.md
+++ b/packages/pi-openai-reasoning/CHANGELOG.md
@@ -9,3 +9,7 @@
 - Codex-only Astra reasoning updates with a fixed request effort.
 - Branch-local replay, retry stability and compaction integration.
 - Existing Pi thinking controls, OAuth reuse, bounded metadata and install telemetry.
+
+### Fixed
+
+- Enforce the history byte budget during fingerprint serialization, before fully traversing oversized input items.

--- a/packages/pi-openai-reasoning/CODE_OF_CONDUCT.md
+++ b/packages/pi-openai-reasoning/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+Treat all contributors with respect. Harassment, discrimination, threats and
+publication of private information are not permitted in this project.
+
+Report violations privately to jose@mocito.dev. The maintainer will review
+reports, protect reporter privacy and take proportionate action, including
+removal of content or exclusion from the project.

--- a/packages/pi-openai-reasoning/CONTRIBUTING.md
+++ b/packages/pi-openai-reasoning/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+Use the repository's npm workspace environment.
+
+```bash
+npm run -w packages/pi-openai-reasoning check
+npm test -w packages/pi-openai-reasoning
+npm run -w packages/pi-openai-reasoning pack:dry-run
+```
+
+Keep model eligibility conservative. Backend protocol changes need real Pi
+integration regressions and the documented opt-in smoke test. Normal tests must
+not contact providers. Do not commit credentials, sessions or machine paths.
+Update README, CHANGELOG and SECURITY when their documented behavior changes.
+
+This project follows the [Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/packages/pi-openai-reasoning/LICENSE
+++ b/packages/pi-openai-reasoning/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jose Mocito
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/pi-openai-reasoning/README.md
+++ b/packages/pi-openai-reasoning/README.md
@@ -49,8 +49,10 @@ the current settings through its versioned public event bus.
 If history changes outside normal append/branch/compaction operations, the package
 starts a new baseline rather than placing an update at an unchecked position.
 It stops rewriting above 20,000 input items, 16 MiB of serialized history or 128
-effort changes in a context window. Pi's normal effort handling then remains in
-use. This can reduce cache reuse; no cache-hit or cost saving is guaranteed.
+effort changes in a context window. The byte budget is checked during JSON
+serialization, including within individual input items. Pi's normal effort
+handling then remains in use. This can reduce cache reuse; no cache-hit or cost
+saving is guaranteed.
 Uninstalling the package leaves normal Pi messages and thinking settings intact.
 
 ## Protocol reference

--- a/packages/pi-openai-reasoning/README.md
+++ b/packages/pi-openai-reasoning/README.md
@@ -1,0 +1,91 @@
+# pi-openai-reasoning
+
+Change reasoning effort in long Codex conversations without changing the original
+request effort and needlessly invalidating its cached prefix.
+
+- Uses Pi's existing thinking controls. No new command or provider.
+- Keeps effort updates at stable positions across retries, resume, forks and trees.
+- Works alone, or with `pi-fast`, `pi-codex-tools` and `pi-codex-compaction`.
+
+## Installation
+
+Requires Pi 0.85.1 or later and an existing Pi `openai-codex` OAuth login.
+
+```bash
+pi install npm:pi-openai-reasoning
+```
+
+For local development:
+
+```bash
+pi -e /path/to/pi-mono/packages/pi-openai-reasoning
+```
+
+Installing the package enables this behavior for supported requests. It does not
+change your selected effort. Use Pi's thinking selector or SDK `setThinkingLevel`.
+There is no public OpenAI API support in this first version and no API-key fallback.
+
+## Support and limits
+
+The verified model is `openai-codex/gpt-6-astra`, standard single-agent Responses,
+with `low`, `medium`, `high`, `xhigh` or `max` effort. Other models/providers,
+Pro mode, backend multi-agent requests, server auto-compaction/truncation, stored
+conversation references and requests already containing configuration updates are
+left unchanged. This package does not add async tools or mid-turn steering.
+
+The first request pins the effort for its current context window. Later changes
+use `configuration_update` input items before new user input, or after tool
+history when no new user input exists. All other request fields remain intact.
+An identical retry retains its previous selection, even if the thinking selector
+changed meanwhile. The change applies when history advances.
+
+State is reconstructed from the active session branch on every request. It stores
+efforts, item positions and SHA-256 history fingerprints, not duplicate prompts.
+After successful compaction, a new request baseline and an explicit effort update
+after the checkpoint restore the selected effort. Failed compaction cannot change
+the saved pin. With `pi-codex-compaction`, direct checkpoint requests also receive
+the current settings through its versioned public event bus.
+
+If history changes outside normal append/branch/compaction operations, the package
+starts a new baseline rather than placing an update at an unchecked position.
+It stops rewriting above 20,000 input items, 16 MiB of serialized history or 128
+effort changes in a context window. Pi's normal effort handling then remains in
+use. This can reduce cache reuse; no cache-hit or cost saving is guaranteed.
+Uninstalling the package leaves normal Pi messages and thinking settings intact.
+
+## Protocol reference
+
+The implementation is original Pi code. It was informed by read-only study of
+`openai/codex` commit `654b0a77d0d2f81aa21f61caf7af4be88fe550bb` (2026-09-11):
+`core/src/session/reasoning_effort.rs`, its tests, and RemoteCompactionV2.
+No Codex code is copied or vendored.
+
+The Codex backend accepted Astra `configuration_update` values through `max` in
+live subscription probes on 2026-09-11 without additional beta headers. The
+combined Fast + grammar + reasoning + remote-compaction smoke test also passed:
+the continuation recalled the test word, and Pi recorded compaction usage. Public
+[reasoning documentation](https://developers.openai.com/api/docs/guides/reasoning)
+describes the input shape, but is not treated as proof of Codex support.
+
+## Development and smoke test
+
+```bash
+npm run -w packages/pi-openai-reasoning check
+npm test -w packages/pi-openai-reasoning
+npm run -w packages/pi-openai-reasoning pack:dry-run
+```
+
+Tests mock network access. The separate live smoke test uses your existing Codex
+subscription and consumes usage. It sends short text prompts, changes effort,
+compacts and checks continuation. It never generates images.
+
+```bash
+PI_CODEX_LIVE_SMOKE=1 PI_TELEMETRY=0 npm run -w packages/pi-openai-reasoning smoke:live
+```
+
+In the TUI, use the existing thinking selector for low/high, send a short prompt
+after each change, then `/compact` and continue. The selector should still show
+the effective effort. Print, JSON and RPC requests use the same hooks without UI.
+
+Telemetry is best-effort, once per version, with a five-second timeout.
+Disable it with `PI_OFFLINE=1`, `PI_TELEMETRY=0`, or `enableInstallTelemetry: false`.

--- a/packages/pi-openai-reasoning/SECURITY.md
+++ b/packages/pi-openai-reasoning/SECURITY.md
@@ -18,6 +18,10 @@ or credentials. Fingerprints are not encryption: treat session metadata as
 private. Imported state is validated before use, and only the active branch is
 read. No project settings are read. No prompt or provider data is logged.
 
+Fingerprint serialization stops at the remaining history byte budget, including
+for individual strings. Unsupported JSON containers use normal Pi handling
+instead. This bounds the extension's fingerprint work, not Pi's own request size.
+
 The compaction event bus shares request data with installed cooperating local
 extensions. Those extensions have the same trust level as Pi itself. Temporary
 compaction transforms do not commit reasoning state.

--- a/packages/pi-openai-reasoning/SECURITY.md
+++ b/packages/pi-openai-reasoning/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+Security fixes apply to the latest released version.
+Report suspected vulnerabilities privately through
+[GitHub Security Advisories](https://github.com/jvm/pi-mono/security/advisories/new).
+
+## Security model
+
+Pi extensions run with the user's permissions. Install only trusted packages.
+This extension transforms in-memory Codex request bodies through documented Pi
+hooks. It never reads credentials, adds auth headers, registers a provider or
+sends its own inference requests. Pi owns OAuth storage, refresh and transport.
+Only the official Codex HTTPS origin and known endpoint paths are supported.
+
+Session custom entries contain bounded effort values, positions and SHA-256
+history fingerprints. They contain no prompts, raw reasoning, opaque checkpoints
+or credentials. Fingerprints are not encryption: treat session metadata as
+private. Imported state is validated before use, and only the active branch is
+read. No project settings are read. No prompt or provider data is logged.
+
+The compaction event bus shares request data with installed cooperating local
+extensions. Those extensions have the same trust level as Pi itself. Temporary
+compaction transforms do not commit reasoning state.
+
+Install telemetry sends only package/version/runtime metadata to
+`https://mocito.dev/api/report-install`, once per version, with a five-second
+timeout. It respects CI, `PI_OFFLINE`, `PI_TELEMETRY` and the global
+`enableInstallTelemetry: false` setting. No tokens or conversation data are sent.
+Live smoke tests are explicit opt-in and use the existing subscription.

--- a/packages/pi-openai-reasoning/extensions/index.ts
+++ b/packages/pi-openai-reasoning/extensions/index.ts
@@ -1,0 +1,23 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { reportInstallTelemetry } from "../src/install-telemetry.js";
+import { rewriteReasoning, STATE_TYPE, supportsReasoningUpdates } from "../src/reasoning.js";
+
+export default function piOpenaiReasoning(pi: ExtensionAPI): void {
+  reportInstallTelemetry();
+
+  function rewrite(payload: unknown, ctx: ExtensionContext, compacting = false): unknown {
+    if (!ctx.model || !supportsReasoningUpdates(ctx.model) || !ctx.modelRegistry.isUsingOAuth(ctx.model)) return;
+    const result = rewriteReasoning(payload, ctx.model, ctx.sessionManager.getBranch(), compacting);
+    if (!result) return;
+    if (result.state) pi.appendEntry(STATE_TYPE, result.state);
+    return result.payload;
+  }
+
+  pi.on("before_provider_request", (event, ctx) => rewrite(event.payload, ctx));
+  pi.events.on("pi-codex-compaction:request:v1", (value) => {
+    const data = value as { payload: unknown; ctx?: ExtensionContext } | undefined;
+    if (!data?.ctx) return;
+    const result = rewrite(data.payload, data.ctx, true);
+    if (result !== undefined) data.payload = result;
+  });
+}

--- a/packages/pi-openai-reasoning/index.ts
+++ b/packages/pi-openai-reasoning/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./extensions/index.js";

--- a/packages/pi-openai-reasoning/package.json
+++ b/packages/pi-openai-reasoning/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "pi-openai-reasoning",
+  "version": "0.1.0",
+  "description": "Change Codex reasoning effort without rewriting the cached request prefix.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Jose Mocito",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jvm/pi-mono.git",
+    "directory": "packages/pi-openai-reasoning"
+  },
+  "bugs": { "url": "https://github.com/jvm/pi-mono/issues" },
+  "homepage": "https://github.com/jvm/pi-mono/tree/main/packages/pi-openai-reasoning#readme",
+  "keywords": ["pi-package", "pi-extension", "pi", "openai-codex", "reasoning", "prompt-cache"],
+  "pi": { "extensions": ["./index.ts"] },
+  "files": [
+    "index.ts", "extensions", "src", "README.md", "LICENSE", "CHANGELOG.md",
+    "SECURITY.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md"
+  ],
+  "scripts": {
+    "check": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test tests/*.test.mjs",
+    "pack:dry-run": "npm pack --dry-run",
+    "smoke:live": "node --import tsx tests/live-smoke.mjs"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-ai": "^0.85.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
+    "@types/node": "^26.2.0",
+    "tsx": "^4.23.5",
+    "typescript": "^7.0.2"
+  },
+  "dependencies": { "@mocito/install-telemetry": "0.1.1" },
+  "publishConfig": { "access": "public" },
+  "engines": { "node": ">=20.6.0" }
+}

--- a/packages/pi-openai-reasoning/src/bounded-json.ts
+++ b/packages/pi-openai-reasoning/src/bounded-json.ts
@@ -1,0 +1,70 @@
+/**
+ * Keep native JSON ordering/escaping, but stop its traversal before it builds an
+ * oversized result. Only ordinary JSON containers are needed for provider input.
+ */
+export function boundedStringify(input: unknown, maxBytes: number): string | undefined {
+  let remaining = maxBytes;
+  let root = true;
+  const populated = new WeakSet<object>();
+  const isRawJSON = (JSON as { isRawJSON?: (value: unknown) => boolean }).isRawJSON;
+  const rejected = new Error("JSON fingerprint budget exceeded or unsupported value");
+
+  function spend(bytes: number): void {
+    remaining -= bytes;
+    if (remaining < 0) throw rejected;
+  }
+
+  function quoted(text: string): void {
+    // UTF-16 length is a cheap lower bound, including for a huge single input.
+    if (text.length + 2 > remaining) throw rejected;
+    let bytes = 2;
+    for (let index = 0; index < text.length; index++) {
+      const code = text.charCodeAt(index);
+      if (code === 34 || code === 92 || code === 8 || code === 9 ||
+        code === 10 || code === 12 || code === 13) bytes += 2;
+      else if (code < 32) bytes += 6;
+      else if (code < 128) bytes++;
+      else if (code < 2048) bytes += 2;
+      else if (code >= 0xd800 && code <= 0xdfff) {
+        const next = text.charCodeAt(index + 1);
+        if (code <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
+          bytes += 4;
+          index++;
+        } else bytes += 6; // Native JSON escapes an unpaired surrogate.
+      } else bytes += 3;
+      if (bytes > remaining) throw rejected;
+    }
+    spend(bytes);
+  }
+
+  try {
+    if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) return;
+    return JSON.stringify(input, function (key, value: unknown) {
+      const omitted = value === undefined || typeof value === "function" || typeof value === "symbol";
+      if (omitted && !Array.isArray(this)) return undefined;
+      if (root) root = false;
+      else {
+        if (populated.has(this)) spend(1); // Comma between emitted children.
+        populated.add(this);
+        if (!Array.isArray(this)) {
+          quoted(key);
+          spend(1); // Colon.
+        }
+      }
+      if (value === null || omitted) spend(4);
+      else if (typeof value === "string") quoted(value);
+      else if (typeof value === "number") spend(Number.isFinite(value) ? String(value).length : 4);
+      else if (typeof value === "boolean") spend(value ? 4 : 5);
+      else if (typeof value === "object") {
+        const prototype = Object.getPrototypeOf(value);
+        if (isRawJSON?.(value) ||
+          !Array.isArray(value) && prototype !== Object.prototype && prototype !== null) throw rejected;
+        spend(2); // Opening and closing brackets/braces.
+        populated.delete(value); // A shared, non-cyclic container may recur.
+      } else throw rejected;
+      return value;
+    });
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/pi-openai-reasoning/src/install-telemetry.ts
+++ b/packages/pi-openai-reasoning/src/install-telemetry.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { reportInstallTelemetry as report } from "@mocito/install-telemetry";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+const CI_NAMES = [
+  "APPVEYOR", "BITBUCKET_BUILD_NUMBER", "BUILDKITE", "CIRCLECI", "CODESPACES",
+  "DRONE", "GITHUB_ACTIONS", "GITLAB_CI", "JENKINS_URL", "NETLIFY",
+  "TEAMCITY_VERSION", "TF_BUILD", "TRAVIS", "VERCEL",
+];
+function readJson(path: string): Record<string, unknown> {
+  try {
+    const value = JSON.parse(readFileSync(path, "utf8"));
+    return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  } catch { return {}; }
+}
+function enabledFlag(value: string | undefined): boolean {
+  return value !== undefined && ["1", "true", "yes"].includes(value.toLowerCase());
+}
+export function isInstallTelemetryEnabled(env = process.env, settingsPath = join(getAgentDir(), "settings.json")): boolean {
+  if (enabledFlag(env.CI) || enabledFlag(env.PI_OFFLINE) || CI_NAMES.some((name) =>
+    env[name] && !["0", "false", "no"].includes(env[name]!.toLowerCase()))) return false;
+  if (readJson(settingsPath).enableInstallTelemetry === false) return false;
+  return env.PI_TELEMETRY === undefined || enabledFlag(env.PI_TELEMETRY);
+}
+export function reportInstallTelemetry(): void {
+  try {
+    const manifest = readJson(fileURLToPath(new URL("../package.json", import.meta.url)));
+    void report({
+      endpoint: "https://mocito.dev/api/report-install",
+      tool: "pi-openai-reasoning",
+      version: typeof manifest.version === "string" ? manifest.version : "0.0.0",
+      statePath: join(getAgentDir(), "extensions", "pi-openai-reasoning-install.json"),
+      enabled: isInstallTelemetryEnabled(),
+    }).catch(() => undefined);
+  } catch {
+    // Best effort. The shared reporter enforces a five-second timeout.
+  }
+}

--- a/packages/pi-openai-reasoning/src/reasoning.ts
+++ b/packages/pi-openai-reasoning/src/reasoning.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { Model } from "@earendil-works/pi-ai";
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import { boundedStringify } from "./bounded-json.js";
 
 export const STATE_TYPE = "pi-openai-reasoning:v1";
 const MAX_ITEMS = 20_000;
@@ -145,8 +146,12 @@ function fingerprintPrefixes(input: unknown[], hasCheckpoint: boolean): string[]
   try {
     for (const [index, item] of input.entries()) {
       // Compaction's normal hook may run before or after this extension.
-      const text = JSON.stringify(hasCheckpoint && index === 0 && isCheckpoint(item) ? { type: "checkpoint" } : item);
-      if (text === undefined || (bytes += Buffer.byteLength(text)) > MAX_BYTES) return;
+      const text = boundedStringify(
+        hasCheckpoint && index === 0 && isCheckpoint(item) ? { type: "checkpoint" } : item,
+        MAX_BYTES - bytes,
+      );
+      if (text === undefined) return;
+      bytes += Buffer.byteLength(text);
       hash.update(text).update("\n");
       prefixes.push(hash.copy().digest("hex"));
     }

--- a/packages/pi-openai-reasoning/src/reasoning.ts
+++ b/packages/pi-openai-reasoning/src/reasoning.ts
@@ -1,0 +1,167 @@
+import { createHash } from "node:crypto";
+import type { Model } from "@earendil-works/pi-ai";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+
+export const STATE_TYPE = "pi-openai-reasoning:v1";
+const MAX_ITEMS = 20_000;
+const MAX_BYTES = 16 * 1024 * 1024;
+const MAX_UPDATES = 128;
+type Effort = "low" | "medium" | "high" | "xhigh" | "max";
+type RecordValue = Record<string, unknown>;
+interface Boundary { offset: number; hash: string }
+interface Update extends Boundary { effort: Effort }
+export interface ReasoningState {
+  version: 1;
+  model: string;
+  window: string;
+  baseline: Effort;
+  updates: Update[];
+  last: Boundary;
+}
+
+export function supportsReasoningUpdates(model: Model<any> | undefined): boolean {
+  if (!model || model.provider !== "openai-codex" || model.api !== "openai-codex-responses" ||
+    model.id !== "gpt-6-astra" || !model.reasoning) return false;
+  try {
+    const url = new URL(model.baseUrl);
+    return url.origin === "https://chatgpt.com" && !url.username && !url.password && !url.search && !url.hash &&
+      ["/backend-api", "/backend-api/codex", "/backend-api/codex/responses"].includes(url.pathname.replace(/\/+$/, ""));
+  } catch { return false; }
+}
+
+export function rewriteReasoning(
+  payload: unknown,
+  model: Model<any>,
+  entries: readonly SessionEntry[],
+  compacting = false,
+): { payload: RecordValue; state?: ReasoningState } | undefined {
+  if (!supportsReasoningUpdates(model) || !isRecord(payload) || payload.model !== model.id ||
+    !Array.isArray(payload.input) || !isRecord(payload.reasoning) || !isEffort(payload.reasoning.effort)) return;
+  if ((payload.reasoning.mode !== undefined && payload.reasoning.mode !== "standard") ||
+    payload.multi_agent !== undefined || payload.context_management !== undefined ||
+    payload.previous_response_id !== undefined || payload.conversation !== undefined ||
+    payload.background === true || (payload.truncation !== undefined && payload.truncation !== "disabled")) return;
+  const rawInput = payload.input;
+  if (rawInput.some((item) => isRecord(item) &&
+    (item.type === "configuration_update" || item.type === "agent_message"))) return;
+  const trigger = rawInput.at(-1);
+  if (compacting && (!isRecord(trigger) || trigger.type !== "compaction_trigger")) return;
+  if (!compacting && rawInput.some((item) => isRecord(item) && item.type === "compaction_trigger")) return;
+  const input = compacting ? rawInput.slice(0, -1) : rawInput;
+  const window = [...entries].reverse().find((entry) => entry.type === "compaction")?.id ?? "root";
+  const hashes = fingerprintPrefixes(input, window !== "root");
+  if (!hashes || input.length === 0) return;
+  const selected = payload.reasoning.effort;
+  const previous = findState(entries, model.id, window);
+  const last = { offset: input.length, hash: hashes[input.length] };
+  const valid = previous && (compacting || hashes[previous.last.offset] === previous.last.hash) &&
+    previous.updates.every((update) =>
+      compacting && update.offset > input.length || hashes[update.offset] === update.hash);
+  const baseline = valid ? previous.baseline : selected;
+  let updates = valid ? previous.updates.filter((update) => update.offset <= input.length).map((u) => ({ ...u })) : [];
+  const retry = valid && previous.last.offset === last.offset && previous.last.hash === last.hash;
+
+  if (!valid && window !== "root" && isCheckpoint(input[0])) {
+    // An opaque checkpoint does not retain configuration-update semantics.
+    updates.push({ offset: 1, hash: hashes[1], effort: selected });
+  }
+  const effective = updates.at(-1)?.effort ?? baseline;
+  if (effective !== selected && (compacting || !retry)) {
+    let offset = input.length;
+    if (!compacting && previous && hashes[previous.last.offset] === previous.last.hash) {
+      // Put the update before the next user input, not before an older assistant.
+      const nextUser = input.findIndex((item, index) =>
+        index >= previous.last.offset && isRecord(item) && item.role === "user");
+      if (nextUser >= 0) offset = nextUser;
+    }
+    const tail = updates.at(-1);
+    if (!compacting && tail?.offset === offset && input.length > offset) offset = input.length;
+    if (tail?.offset === offset) {
+      // Only temporary compaction requests can replace a tail already sent.
+      // A normal retry keeps its original selection until history advances.
+      if (compacting) tail.effort = selected;
+    } else {
+      updates.push({ offset, hash: hashes[offset], effort: selected });
+    }
+  }
+  if (updates.length > MAX_UPDATES) {
+    // Stop pinning at the bound. Normal Pi effort remains correct, but this
+    // context window no longer gets cache-preserving effort updates.
+    return;
+  }
+  const output: unknown[] = [];
+  let updateIndex = 0;
+  for (let offset = 0; offset <= input.length; offset++) {
+    const update = updates[updateIndex];
+    if (update?.offset === offset) {
+      output.push({ type: "configuration_update", reasoning: { effort: update.effort } });
+      updateIndex++;
+    }
+    if (offset < input.length) output.push(input[offset]);
+  }
+  if (compacting) output.push(trigger);
+  const state: ReasoningState = { version: 1, model: model.id, window, baseline, updates, last };
+  return {
+    payload: { ...payload, reasoning: { ...payload.reasoning, effort: baseline }, input: output },
+    ...(!compacting && JSON.stringify(state) !== JSON.stringify(previous) ? { state } : {}),
+  };
+}
+
+function findState(entries: readonly SessionEntry[], model: string, window: string): ReasoningState | undefined {
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const entry = entries[index];
+    if (entry.type !== "custom" || entry.customType !== STATE_TYPE) continue;
+    if (isState(entry.data) && entry.data.model === model && entry.data.window === window) return entry.data;
+  }
+  return;
+}
+
+function isState(value: unknown): value is ReasoningState {
+  if (!isRecord(value) || value.version !== 1 || typeof value.model !== "string" || value.model.length > 256 ||
+    Object.keys(value).some((key) => !["version", "model", "window", "baseline", "updates", "last"].includes(key)) ||
+    typeof value.window !== "string" || value.window.length > 256 || !isEffort(value.baseline) ||
+    !isBoundary(value.last) || !Array.isArray(value.updates) || value.updates.length > MAX_UPDATES) return false;
+  let previousOffset = -1;
+  for (const update of value.updates) {
+    if (!isBoundary(update, true) || !isRecord(update) || !isEffort(update.effort) ||
+      update.offset <= previousOffset || update.offset > value.last.offset) return false;
+    previousOffset = update.offset;
+  }
+  return true;
+}
+
+function isBoundary(value: unknown, update = false): value is Boundary {
+  return isRecord(value) && Object.keys(value).every((key) =>
+    key === "offset" || key === "hash" || update && key === "effort") &&
+    Number.isInteger(value.offset) && (value.offset as number) >= 0 &&
+    (value.offset as number) <= MAX_ITEMS && typeof value.hash === "string" && /^[a-f0-9]{64}$/.test(value.hash);
+}
+
+function fingerprintPrefixes(input: unknown[], hasCheckpoint: boolean): string[] | undefined {
+  if (input.length > MAX_ITEMS) return;
+  const hash = createHash("sha256");
+  const prefixes = [hash.copy().digest("hex")];
+  let bytes = 0;
+  try {
+    for (const [index, item] of input.entries()) {
+      // Compaction's normal hook may run before or after this extension.
+      const text = JSON.stringify(hasCheckpoint && index === 0 && isCheckpoint(item) ? { type: "checkpoint" } : item);
+      if (text === undefined || (bytes += Buffer.byteLength(text)) > MAX_BYTES) return;
+      hash.update(text).update("\n");
+      prefixes.push(hash.copy().digest("hex"));
+    }
+  } catch { return; }
+  return prefixes;
+}
+
+function isCheckpoint(item: unknown): boolean {
+  return isRecord(item) && (item.type === "compaction" || item.role === "user" && Array.isArray(item.content) &&
+    item.content.some((part) => isRecord(part) && typeof part.text === "string" &&
+      part.text.startsWith("The conversation history before this point was compacted into the following summary:")));
+}
+function isEffort(value: unknown): value is Effort {
+  return value === "low" || value === "medium" || value === "high" || value === "xhigh" || value === "max";
+}
+function isRecord(value: unknown): value is RecordValue {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/pi-openai-reasoning/tests/bounded-json.test.mjs
+++ b/packages/pi-openai-reasoning/tests/bounded-json.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { boundedStringify } from "../src/bounded-json.ts";
+
+test("bounded JSON preserves native bytes and exact limits", () => {
+  const shared = { a: 1, b: "same" };
+  const values = [
+    null, true, false, 0, -0, 1e100, NaN, Infinity, "",
+    "\"\\\b\t\n\f\r\0\u001f café 🌍 \ud800 \udfff \u2028",
+    [], {}, [undefined, null, () => {}, Symbol("omitted"), , 2],
+    { omitted: undefined, ignored: () => {}, symbol: Symbol("ignored"), "": "", b: 2, "3": 3, "1": 1 },
+    { first: shared, second: shared }, [shared, shared],
+    Object.assign(Object.create(null), { a: "null prototype" }),
+    { toJSON: () => ({ a: 1, b: [2, "three"] }) },
+    new Date("2026-09-11T00:00:00Z"),
+  ];
+  // Cover every UTF-16 code unit, including paired and unpaired surrogates.
+  values.push(Array.from({ length: 65_536 }, (_, code) => String.fromCharCode(code)).join(""));
+  for (const value of values) {
+    const expected = JSON.stringify(value);
+    const bytes = Buffer.byteLength(expected);
+    assert.equal(boundedStringify(value, bytes), expected);
+    assert.equal(boundedStringify(value, bytes - 1), undefined);
+  }
+});
+
+test("bounded JSON stops before later properties and oversized key values", () => {
+  let visited = 0;
+  const value = {
+    text: "x".repeat(1024),
+    get later() { visited++; return "must not visit"; },
+  };
+  assert.equal(boundedStringify(value, 128), undefined);
+  assert.equal(visited, 0);
+  const largeKey = { ["k".repeat(1024)]: "value" };
+  assert.equal(boundedStringify(largeKey, 128), undefined);
+  assert.equal(boundedStringify({ text: "\0".repeat(100), get later() { visited++; } }, 128), undefined);
+  assert.equal(visited, 0);
+});
+
+test("bounded JSON rejects cyclic, boxed, raw and invalid inputs safely", () => {
+  const cyclic = {}; cyclic.self = cyclic;
+  for (const value of [cyclic, 1n, Object("boxed"), undefined, Symbol("unsupported"), () => {}]) {
+    assert.equal(boundedStringify(value, 1024), undefined);
+  }
+  if (JSON.rawJSON) assert.equal(boundedStringify(JSON.rawJSON("123"), 1024), undefined);
+  for (const limit of [-1, NaN, Infinity, 1.5]) assert.equal(boundedStringify({}, limit), undefined);
+});

--- a/packages/pi-openai-reasoning/tests/extension.test.mjs
+++ b/packages/pi-openai-reasoning/tests/extension.test.mjs
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { codexHarness, compactionResponse, requestBody, textResponse } from "../../../tests/codex-harness.mjs";
+
+process.env.CI = "1";
+process.env.PI_OFFLINE = "1";
+const { default: reasoning } = await import("../extensions/index.ts");
+const { STATE_TYPE, rewriteReasoning, supportsReasoningUpdates } = await import("../src/reasoning.ts");
+const { default: compaction } = await import("../../pi-codex-compaction/extensions/index.ts");
+const { default: fast } = await import("../../pi-fast/extensions/index.ts");
+const { default: tools } = await import("../../pi-codex-tools/extensions/index.ts");
+const model = {
+  id: "gpt-6-astra", provider: "openai-codex", api: "openai-codex-responses",
+  baseUrl: "https://chatgpt.com/backend-api", reasoning: true,
+};
+const user = (text) => ({ role: "user", content: [{ type: "input_text", text }] });
+const assistant = (text) => ({ type: "message", role: "assistant", content: [{ type: "output_text", text }] });
+const body = (input, effort = "low") => ({
+  model: model.id, input, reasoning: { effort, summary: "auto" }, tools: [],
+  service_tier: "priority", prompt_cache_key: "fixture", stream: true, store: false,
+});
+const stateEntry = (state) => ({ type: "custom", customType: STATE_TYPE, data: state });
+const updates = (payload) => payload.input.filter((item) => item.type === "configuration_update");
+
+test("real Pi thinking controls pin effort and replay changes in a standalone install", async (t) => {
+  const requests = [];
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    requests.push(requestBody(init));
+    return textResponse();
+  });
+  const h = await codexHarness([reasoning]);
+  try {
+    for (const level of ["low", "high", "max", "medium", "xhigh", "low"]) {
+      h.session.setThinkingLevel(level);
+      await h.session.prompt(`Reply OK at ${level}.`);
+      assert.equal(h.session.messages.at(-1).stopReason, "stop");
+      assert.equal(requests.at(-1).reasoning.effort, "low");
+      assert.equal(updates(requests.at(-1)).at(-1)?.reasoning.effort ?? "low", level);
+      assert.equal(h.session.thinkingLevel, level);
+    }
+    for (let n = 1; n < requests.length; n++) {
+      assert.deepEqual(
+        requests[n].input.slice(0, requests[n - 1].input.length),
+        requests[n - 1].input,
+        "a later request must not move existing updates or history",
+      );
+      assert.equal(requests[n].input.at(-2).type, "configuration_update");
+    }
+    const state = h.sessionManager.getBranch().filter((entry) => entry.customType === STATE_TYPE);
+    assert.equal(state.length, 6);
+    assert.equal(JSON.stringify(state).includes("Reply OK"), false);
+    assert.deepEqual(h.errors, []);
+  } finally { await h.close(); }
+});
+
+test("identical retries and repeated toggles do not duplicate or move updates", () => {
+  const first = rewriteReasoning(body([user("first")]), model, []);
+  const input = [user("first"), assistant("answer"), user("second")];
+  const changed = rewriteReasoning(body(input, "high"), model, [stateEntry(first.state)]);
+  const retry = rewriteReasoning(body(input, "max"), model, [stateEntry(changed.state)]);
+  assert.deepEqual(retry.payload, changed.payload);
+  assert.equal(retry.state, undefined);
+  assert.equal(rewriteReasoning(changed.payload, model, [stateEntry(changed.state)]), undefined);
+  const next = rewriteReasoning(body([...input, assistant("answer"), user("third")], "max"), model, [stateEntry(changed.state)]);
+  assert.deepEqual(updates(next.payload).map((u) => u.reasoning.effort), ["high", "max"]);
+});
+
+test("tool-only continuations and retry recovery never produce adjacent updates", () => {
+  let input = [user("first")];
+  let result = rewriteReasoning(body(input), model, []);
+  input = [...input, { type: "function_call", name: "fixture", call_id: "c", arguments: "{}" },
+    { type: "function_call_output", call_id: "c", output: "ok" }];
+  result = rewriteReasoning(body(input, "high"), model, [stateEntry(result.state)]);
+  assert.equal(result.payload.input.at(-1).type, "configuration_update");
+  input = [...input, user("recovery")];
+  result = rewriteReasoning(body(input, "max"), model, [stateEntry(result.state)]);
+  assert.equal(updates(result.payload).at(-1).reasoning.effort, "max");
+  for (let i = 1; i < result.payload.input.length; i++) {
+    assert.ok(!(result.payload.input[i].type === "configuration_update" &&
+      result.payload.input[i - 1].type === "configuration_update"));
+  }
+});
+
+test("resume, fork and branch traversal use only surviving Pi entries", async (t) => {
+  const requests = [];
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    requests.push(requestBody(init)); return textResponse();
+  });
+  const h = await codexHarness([reasoning]);
+  let entries;
+  try {
+    await h.session.prompt("first");
+    const forkPoint = h.sessionManager.getLeafId();
+    h.session.setThinkingLevel("high");
+    await h.session.prompt("second");
+    entries = structuredClone(h.sessionManager.getBranch());
+    h.sessionManager.branch(forkPoint);
+    h.session.agent.state.messages = h.sessionManager.buildSessionContext().messages;
+    h.session.setThinkingLevel("medium");
+    await h.session.prompt("branch");
+    assert.deepEqual(updates(requests.at(-1)).map((u) => u.reasoning.effort), ["medium"]);
+    assert.equal(requests.at(-1).reasoning.effort, "low");
+  } finally { await h.close(); }
+  // Same Pi session format used by resume/import/fork. No runtime state is shared.
+  const restored = SessionManager.inMemory("/tmp", { id: "restored-fixture" }, entries);
+  const resumed = await codexHarness([reasoning], { sessionManager: restored });
+  try {
+    resumed.session.setThinkingLevel("max");
+    await resumed.session.prompt("resumed");
+    assert.equal(requests.at(-1).reasoning.effort, "low");
+    assert.deepEqual(updates(requests.at(-1)).map((u) => u.reasoning.effort), ["high", "max"]);
+    assert.deepEqual(resumed.errors, []);
+  } finally { await resumed.close(); }
+});
+
+for (const factories of [[reasoning, compaction, fast, tools], [tools, fast, compaction, reasoning]]) {
+  test(`compaction uses current effort without mutating the pin (${factories[0].name} first)`, async (t) => {
+    const requests = [];
+    let failCompaction = true;
+    t.mock.method(globalThis, "fetch", async (_url, init) => {
+      const next = requestBody(init); requests.push(next);
+      return next.input.some((item) => item.type === "compaction_trigger")
+        ? failCompaction ? new Response("", { status: 400 }) : compactionResponse()
+        : textResponse();
+    });
+    const h = await codexHarness(factories);
+    try {
+      await h.session.prompt("/fast on");
+      await h.session.prompt("first");
+      h.session.setThinkingLevel("high");
+      await h.session.prompt("second");
+      h.session.setThinkingLevel("max");
+      const before = structuredClone(h.sessionManager.getBranch().filter((e) => e.customType === STATE_TYPE));
+      // Run the public direct-request event, without installing a failed checkpoint.
+      const normal = requests.at(-1);
+      const data = { ctx: h.ctx, payload: { ...normal,
+        input: [...normal.input.filter((i) => i.type !== "configuration_update"), { type: "compaction_trigger" }],
+        reasoning: { effort: "max" },
+      } };
+      h.api.events.emit("pi-codex-compaction:request:v1", data);
+      assert.equal(data.payload.reasoning.effort, "low");
+      assert.equal(updates(data.payload).at(-1).reasoning.effort, "max");
+      assert.deepEqual(h.sessionManager.getBranch().filter((e) => e.customType === STATE_TYPE), before);
+      failCompaction = false;
+      await h.session.compact();
+      const compact = requests.findLast((r) => r.input.some((i) => i.type === "compaction_trigger"));
+      assert.equal(compact.service_tier, "priority");
+      assert.equal(compact.reasoning.effort, "low");
+      assert.equal(updates(compact).at(-1).reasoning.effort, "max");
+      assert.equal(compact.tools.find((t) => t.name === "apply_patch").type, "custom");
+      await h.session.prompt("after checkpoint");
+      assert.equal(requests.at(-1).reasoning.effort, "max");
+      assert.equal(requests.at(-1).input[0].type, "compaction");
+      assert.deepEqual(requests.at(-1).input[1], { type: "configuration_update", reasoning: { effort: "max" } });
+      h.session.setThinkingLevel("low");
+      await h.session.prompt("after checkpoint change");
+      assert.deepEqual(updates(requests.at(-1)).map((u) => u.reasoning.effort), ["max", "low"]);
+      assert.deepEqual(h.errors, []);
+    } finally { await h.close(); }
+  });
+}
+
+test("unsupported models, endpoints, modes and malformed payloads remain untouched", async () => {
+  for (const other of [
+    { ...model, provider: "openai" }, { ...model, api: "openai-responses" },
+    { ...model, id: "gpt-5.5" }, { ...model, id: "gpt-6-astra-pro" },
+    { ...model, baseUrl: "https://example.com/backend-api" },
+    { ...model, baseUrl: "http://chatgpt.com/backend-api" },
+    { ...model, baseUrl: "https://chatgpt.com:444/backend-api" },
+  ]) {
+    assert.equal(supportsReasoningUpdates(other), false);
+    assert.equal(rewriteReasoning(body([user("test")]), other, []), undefined);
+  }
+  for (const payload of [
+    undefined, null, [], { ...body([]), input: "prompt" },
+    body([user("test")], "none"), body([user("test")], "minimal"),
+    { ...body([user("test")]), reasoning: { effort: "high", mode: "pro" } },
+    { ...body([user("test")]), multi_agent: {} },
+    { ...body([user("test")]), context_management: [] },
+    { ...body([user("test")]), truncation: "auto" },
+    { ...body([user("test")]), previous_response_id: "id" },
+    { ...body([user("test")]), conversation: "id" },
+    body([{ type: "agent_message" }]),
+  ]) assert.equal(rewriteReasoning(payload, model, []), undefined);
+
+  const handlers = new Map();
+  reasoning({
+    on: (name, handler) => handlers.set(name, handler), events: { on() {} },
+    appendEntry() { assert.fail("must not persist with API-key authentication"); },
+  });
+  assert.equal(handlers.get("before_provider_request")({ payload: body([user("test")]) }, {
+    model, modelRegistry: { isUsingOAuth: () => false },
+  }), undefined);
+});
+
+test("malformed persisted state and rewritten history cannot place unchecked updates", () => {
+  const first = rewriteReasoning(body([user("first")]), model, []);
+  for (const malformed of [
+    null, {}, { ...first.state, version: 9 },
+    { ...first.state, baseline: "pro" },
+    { ...first.state, extra: "must not copy unknown state fields" },
+    { ...first.state, last: { ...first.state.last, extra: "not allowed" } },
+    { ...first.state, last: { offset: -1, hash: "not a hash" } },
+    { ...first.state, updates: [{ offset: 1, hash: "x", effort: "high" }] },
+  ]) {
+    const result = rewriteReasoning(body([user("rewritten")], "high"), model, [stateEntry(malformed)]);
+    assert.equal(result.payload.reasoning.effort, "high");
+    assert.deepEqual(updates(result.payload), []);
+  }
+  const result = rewriteReasoning(body([user("rewritten")], "high"), model, [stateEntry(first.state)]);
+  assert.equal(result.payload.reasoning.effort, "high");
+  assert.deepEqual(updates(result.payload), []);
+  const cyclic = {}; cyclic.self = cyclic;
+  assert.equal(rewriteReasoning(body([cyclic]), model, []), undefined);
+  assert.equal(rewriteReasoning(body(Array(20_001).fill(user("x"))), model, []), undefined);
+  assert.equal(rewriteReasoning(body([user("x".repeat(16 * 1024 * 1024))]), model, []), undefined);
+});
+
+test("a user-authored summary prefix is still fingerprinted as user input", () => {
+  const prefix = "The conversation history before this point was compacted into the following summary:";
+  const first = rewriteReasoning(body([user(`${prefix} original`)]), model, []);
+  const result = rewriteReasoning(body([user(`${prefix} different`)], "high"), model, [stateEntry(first.state)]);
+  assert.equal(result.payload.reasoning.effort, "high");
+  assert.deepEqual(updates(result.payload), []);
+});
+
+test("real compaction failure and cancellation leave saved effort metadata intact", async (t) => {
+  let cancel = false;
+  let h;
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    const next = requestBody(init);
+    if (!next.input.some((i) => i.type === "compaction_trigger")) return textResponse();
+    if (cancel) {
+      queueMicrotask(() => h.session.abortCompaction());
+      return new Promise((_resolve, reject) => {
+        const abort = () => reject(new Error("fixture cancellation"));
+        init.signal.addEventListener("abort", abort, { once: true });
+        if (init.signal.aborted) abort();
+      });
+    }
+    return new Response("", { status: 400 });
+  });
+  h = await codexHarness([reasoning, compaction]);
+  try {
+    await h.session.prompt("first");
+    h.session.setThinkingLevel("high");
+    await h.session.prompt("second");
+    const before = structuredClone(h.sessionManager.getBranch().filter((e) => e.customType === STATE_TYPE));
+    cancel = true;
+    await assert.rejects(() => h.session.compact(), /cancel|abort/i);
+    assert.deepEqual(h.sessionManager.getBranch().filter((e) => e.customType === STATE_TYPE), before);
+    assert.equal(h.sessionManager.getBranch().some((e) => e.type === "compaction"), false);
+    cancel = false;
+    const fallback = await h.session.compact();
+    assert.notEqual(fallback.details?.kind, "pi-codex-compaction");
+    assert.deepEqual(h.sessionManager.getBranch().filter((e) => e.customType === STATE_TYPE), before);
+  } finally { await h.close(); }
+});
+
+test("model switches do not apply Astra updates to unsupported models", async (t) => {
+  const requests = [];
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    requests.push(requestBody(init)); return textResponse();
+  });
+  const h = await codexHarness([reasoning]);
+  try {
+    await h.session.prompt("first");
+    h.session.setThinkingLevel("high");
+    await h.session.prompt("second");
+    await h.session.setModel(h.modelRuntime.getModel("openai-codex", "gpt-5.5"));
+    await h.session.prompt("other model");
+    assert.equal(requests.at(-1).reasoning.effort, "high");
+    assert.deepEqual(updates(requests.at(-1)), []);
+    await h.session.setModel(h.model);
+    h.session.setThinkingLevel("medium");
+    await h.session.prompt("back");
+    assert.equal(updates(requests.at(-1)).at(-1).reasoning.effort, "medium");
+  } finally { await h.close(); }
+});
+
+test("bounds effort changes and keeps all unrelated fields unchanged", () => {
+  let input = [user("start")];
+  let result = rewriteReasoning(body(input), model, []);
+  for (let n = 0; n < 128; n++) {
+    input = [...input, assistant("ok"), user(String(n))];
+    const payload = body(input, n % 2 ? "low" : "high");
+    const unchanged = structuredClone(payload);
+    result = rewriteReasoning(payload, model, [stateEntry(result.state)]);
+    assert.deepEqual(payload, unchanged);
+    const { input: _i, reasoning: _r, ...other } = result.payload;
+    const { input: _j, reasoning: _s, ...expected } = payload;
+    assert.deepEqual(other, expected);
+    assert.equal(result.payload.reasoning.summary, "auto");
+  }
+  assert.equal(result.state.updates.length, 128);
+  assert.equal(rewriteReasoning(body([...input, assistant("ok"), user("limit")], "max"), model, [stateEntry(result.state)]), undefined);
+});

--- a/packages/pi-openai-reasoning/tests/extension.test.mjs
+++ b/packages/pi-openai-reasoning/tests/extension.test.mjs
@@ -66,6 +66,33 @@ test("identical retries and repeated toggles do not duplicate or move updates", 
   assert.deepEqual(updates(next.payload).map((u) => u.reasoning.effort), ["high", "max"]);
 });
 
+test("actual provider retries resend the same update without another state entry", async (t) => {
+  const requests = [];
+  let failNext = false;
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    requests.push(requestBody(init));
+    if (failNext) {
+      failNext = false;
+      return new Response(JSON.stringify({ error: { message: "Service unavailable", code: "server_error" } }), {
+        status: 503, headers: { "retry-after-ms": "0" },
+      });
+    }
+    return textResponse();
+  });
+  const h = await codexHarness([reasoning], { retry: { enabled: true, maxRetries: 1, baseDelayMs: 1 } });
+  try {
+    await h.session.prompt("first");
+    h.session.setThinkingLevel("high");
+    failNext = true;
+    await h.session.prompt("retry");
+    assert.equal(h.session.messages.at(-1).stopReason, "stop");
+    assert.equal(requests.length, 3);
+    assert.deepEqual(requests[1], requests[2]);
+    assert.deepEqual(updates(requests[2]).map((u) => u.reasoning.effort), ["high"]);
+    assert.equal(h.sessionManager.getBranch().filter((e) => e.customType === STATE_TYPE).length, 2);
+  } finally { await h.close(); }
+});
+
 test("tool-only continuations and retry recovery never produce adjacent updates", () => {
   let input = [user("first")];
   let result = rewriteReasoning(body(input), model, []);

--- a/packages/pi-openai-reasoning/tests/extension.test.mjs
+++ b/packages/pi-openai-reasoning/tests/extension.test.mjs
@@ -93,6 +93,49 @@ test("actual provider retries resend the same update without another state entry
   } finally { await h.close(); }
 });
 
+test("real Pi request hooks reject an oversized user item before full traversal", async (t) => {
+  let oversized = false;
+  let original;
+  let injected;
+  let laterReads = 0;
+  let checked = 0;
+  const hugeText = "x".repeat(16 * 1024 * 1024);
+  const inject = (pi) => pi.on("before_provider_request", (event) => {
+    if (!oversized) return;
+    original = event.payload;
+    injected = {
+      ...original,
+      input: [{
+        ...user(hugeText),
+        get later() { laterReads++; return "must not traverse after the limit"; },
+      }],
+    };
+    return injected;
+  });
+  const inspect = (pi) => pi.on("before_provider_request", (event, ctx) => {
+    if (!oversized) return;
+    checked++;
+    assert.equal(event.payload, injected, "unsupported history must retain ordinary Pi effort handling");
+    assert.equal(event.payload.reasoning.effort, "high");
+    assert.equal(laterReads, 0);
+    assert.equal(ctx.sessionManager.getBranch().filter((entry) => entry.customType === STATE_TYPE).length, 1);
+    // Do not serialize or send the oversized fixture through the mock transport.
+    return original;
+  });
+  t.mock.method(globalThis, "fetch", async () => textResponse());
+  const h = await codexHarness([inject, reasoning, inspect]);
+  try {
+    await h.session.prompt("first");
+    oversized = true;
+    h.session.setThinkingLevel("high");
+    await h.session.prompt("bounded fixture");
+    assert.equal(checked, 1);
+    assert.equal(laterReads, 0);
+    assert.equal(h.session.messages.at(-1).stopReason, "stop");
+    assert.deepEqual(h.errors, []);
+  } finally { await h.close(); }
+});
+
 test("tool-only continuations and retry recovery never produce adjacent updates", () => {
   let input = [user("first")];
   let result = rewriteReasoning(body(input), model, []);

--- a/packages/pi-openai-reasoning/tests/live-smoke.mjs
+++ b/packages/pi-openai-reasoning/tests/live-smoke.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { codexHarness } from "../../../tests/codex-harness.mjs";
+import reasoning from "../extensions/index.ts";
+import compaction from "../../pi-codex-compaction/extensions/index.ts";
+import fast from "../../pi-fast/extensions/index.ts";
+import tools from "../../pi-codex-tools/extensions/index.ts";
+
+if (process.env.PI_CODEX_LIVE_SMOKE !== "1") {
+  console.error("Set PI_CODEX_LIVE_SMOKE=1 to use subscription usage. No requests sent.");
+  process.exit(1);
+}
+process.env.PI_TELEMETRY = "0";
+const modelRuntime = await ModelRuntime.create({ modelsPath: null, signal: AbortSignal.timeout(30_000) });
+assert.ok(modelRuntime.isUsingOAuth("openai-codex"), "Existing Pi Codex OAuth is required");
+const requests = [];
+const observe = (pi) => pi.on("before_provider_request", (event) => {
+  const body = event.payload;
+  // Record shape only, never prompt text, tokens or opaque response contents.
+  requests.push({
+    effort: body.reasoning?.effort,
+    updates: body.input.filter((i) => i.type === "configuration_update").map((i) => i.reasoning.effort),
+    checkpoint: body.input.some((i) => i.type === "compaction"),
+    fast: body.service_tier === "priority",
+    grammar: body.tools?.find((t) => t.name === "apply_patch")?.type === "custom",
+  });
+});
+const h = await codexHarness([reasoning, compaction, fast, tools, observe], { modelRuntime });
+let timer;
+async function bounded(run) {
+  let expired = false;
+  timer = setTimeout(() => {
+    expired = true;
+    h.session.abortCompaction();
+    void h.session.abort();
+  }, 60_000);
+  try {
+    const result = await run();
+    assert.equal(expired, false, "Smoke deadline exceeded");
+    return result;
+  } finally { clearTimeout(timer); }
+}
+async function prompt(text) {
+  await bounded(() => h.session.prompt(text));
+  assert.equal(h.session.messages.at(-1).stopReason, "stop", "Codex request failed");
+}
+try {
+  h.session.setActiveToolsByName(["apply_patch"]);
+  // Keep the real grammar schema on the wire, but disallow filesystem execution.
+  h.api.on("before_provider_request", (event) => ({ ...event.payload, tool_choice: "none" }));
+  await h.session.prompt("/fast off");
+  await prompt("This is a short protocol test. Remember the word ORBIT. Reply only OK. Do not use tools.");
+  h.session.setThinkingLevel("medium");
+  await prompt("Reply only OK. Do not use tools.");
+  assert.equal(requests[0].effort, "low");
+  assert.equal(requests[1].effort, "low");
+  assert.deepEqual(requests[1].updates, ["medium"]);
+  await h.session.prompt("/fast on");
+  await prompt("Reply only OK. Do not use tools.");
+  assert.equal(requests.at(-1).fast, true);
+  assert.equal(requests.at(-1).grammar, true);
+  const checkpoint = await bounded(() => h.session.compact());
+  assert.equal(checkpoint.details?.kind, "pi-codex-compaction", "Remote compaction fell back");
+  assert.ok(checkpoint.usage?.totalTokens > 0, "Compaction usage missing");
+  await prompt("What word did I ask you to remember? Reply with that word only. Do not use tools.");
+  assert.ok(h.session.messages.at(-1).content.some((c) => c.type === "text" && c.text.includes("ORBIT")));
+  assert.equal(requests.at(-1).checkpoint, true);
+  assert.deepEqual(requests.at(-1).updates, ["medium"]);
+  assert.equal(requests.at(-1).effort, "medium");
+  assert.deepEqual(h.errors, []);
+  console.log(JSON.stringify({
+    passed: true, model: h.model.id, requests,
+    compactionTokens: checkpoint.usage.totalTokens,
+    totalTokens: h.session.getSessionStats().tokens,
+  }));
+} finally {
+  clearTimeout(timer);
+  await h.close();
+}

--- a/packages/pi-openai-reasoning/tsconfig.json
+++ b/packages/pi-openai-reasoning/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["index.ts", "src/**/*.ts", "extensions/**/*.ts"]
+}

--- a/packages/pi-scout/package.json
+++ b/packages/pi-scout/package.json
@@ -52,7 +52,7 @@
     "typebox": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
     "@types/node": "^26.2.0",
     "tsx": "^4.23.5",
     "typebox": "^1.3.10",

--- a/packages/pi-skillful/package.json
+++ b/packages/pi-skillful/package.json
@@ -45,8 +45,8 @@
     "@earendil-works/pi-tui": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.84.1",
-    "@earendil-works/pi-tui": "^0.84.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
+    "@earendil-works/pi-tui": "^0.85.1",
     "@types/node": "^26.2.0",
     "typescript": "^7.0.2"
   },

--- a/packages/pi-web-kit/package.json
+++ b/packages/pi-web-kit/package.json
@@ -58,9 +58,9 @@
     "typebox": "*"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.84.1",
-    "@earendil-works/pi-coding-agent": "^0.84.1",
-    "@earendil-works/pi-tui": "^0.84.1",
+    "@earendil-works/pi-ai": "^0.85.1",
+    "@earendil-works/pi-coding-agent": "^0.85.1",
+    "@earendil-works/pi-tui": "^0.85.1",
     "@types/node": "^26.2.0",
     "tsx": "^4.23.5",
     "typebox": "^1.3.10",

--- a/tests/codex-harness.mjs
+++ b/tests/codex-harness.mjs
@@ -58,7 +58,7 @@ export async function codexHarness(factories, options = {}) {
   if (!model) throw new Error("Pi catalog has no Astra");
   const settingsManager = SettingsManager.inMemory({
     compaction: { enabled: false, reserveTokens: 8192, keepRecentTokens: 1 },
-    retry: { enabled: false },
+    retry: options.retry ?? { enabled: false },
   });
   const sessionManager = options.sessionManager ?? SessionManager.inMemory(dir);
   let api;

--- a/tests/codex-harness.mjs
+++ b/tests/codex-harness.mjs
@@ -51,7 +51,7 @@ export async function codexHarness(factories, options = {}) {
   await credentials.modify("openai-codex", async () => ({
     type: "oauth", access: testToken, refresh: "unused-fixture", expires: Date.now() + 3_600_000,
   }));
-  const modelRuntime = await ModelRuntime.create({
+  const modelRuntime = options.modelRuntime ?? await ModelRuntime.create({
     credentials, modelsPath: null, modelsStorePath: join(dir, "models-store.json"),
   });
   const model = modelRuntime.getModel("openai-codex", "gpt-6-astra");

--- a/tests/codex-harness.mjs
+++ b/tests/codex-harness.mjs
@@ -1,0 +1,87 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import zlib from "node:zlib";
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import {
+  createAgentSession, DefaultResourceLoader, ModelRuntime, SessionManager, SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+export const testToken = [
+  "test-header",
+  Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_fixture" } })).toString("base64url"),
+  "test-signature",
+].join(".");
+
+export function requestBody(init) {
+  const body = new Headers(init.headers).get("content-encoding") === "zstd"
+    ? zlib.zstdDecompressSync(init.body).toString("utf8")
+    : init.body;
+  return JSON.parse(body);
+}
+
+export function compactionResponse(usage = {}) {
+  return new Response([
+    `data: ${JSON.stringify({ type: "response.output_item.done", item: { type: "compaction", encrypted_content: "fixture-checkpoint" } })}`,
+    `data: ${JSON.stringify({ type: "response.completed", response: { status: "completed", usage } })}`,
+    "",
+  ].join("\n\n"), { headers: { "content-type": "text/event-stream" } });
+}
+
+export function textResponse(text = "OK") {
+  const item = {
+    type: "message", id: "msg_fixture", role: "assistant", status: "completed",
+    content: [{ type: "output_text", text, annotations: [] }],
+  };
+  return new Response([
+    { type: "response.output_item.added", item: { ...item, content: [] } },
+    { type: "response.content_part.added", part: { type: "output_text", text: "" } },
+    { type: "response.output_text.delta", delta: text },
+    { type: "response.output_item.done", item },
+    { type: "response.completed", response: { status: "completed", output: [item], usage: { input_tokens: 10, output_tokens: 1, total_tokens: 11 } } },
+  ].map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+/** Real Pi loader, event runner, tool registry, provider serializer and session tree. */
+export async function codexHarness(factories, options = {}) {
+  const dir = await mkdtemp(join(tmpdir(), "pi-codex-contract-"));
+  const credentials = new InMemoryCredentialStore();
+  await credentials.modify("openai-codex", async () => ({
+    type: "oauth", access: testToken, refresh: "unused-fixture", expires: Date.now() + 3_600_000,
+  }));
+  const modelRuntime = await ModelRuntime.create({
+    credentials, modelsPath: null, modelsStorePath: join(dir, "models-store.json"),
+  });
+  const model = modelRuntime.getModel("openai-codex", "gpt-6-astra");
+  if (!model) throw new Error("Pi catalog has no Astra");
+  const settingsManager = SettingsManager.inMemory({
+    compaction: { enabled: false, reserveTokens: 8192, keepRecentTokens: 1 },
+    retry: { enabled: false },
+  });
+  const sessionManager = options.sessionManager ?? SessionManager.inMemory(dir);
+  let api;
+  let ctx;
+  const errors = [];
+  const loader = new DefaultResourceLoader({
+    cwd: dir, agentDir: dir, settingsManager,
+    noExtensions: true, noSkills: true, noPromptTemplates: true, noThemes: true, noContextFiles: true,
+    systemPromptOverride: () => "Test assistant.",
+    extensionFactories: [...factories, (pi) => {
+      api = pi;
+      pi.on("session_start", (_event, context) => { ctx = context; });
+    }],
+  });
+  await loader.reload();
+  const { session, extensionsResult } = await createAgentSession({
+    cwd: dir, agentDir: dir, model, modelRuntime, sessionManager, settingsManager,
+    resourceLoader: loader, thinkingLevel: "low",
+  });
+  if (extensionsResult.errors.length) throw new Error("Fixture extension load failed");
+  await session.bindExtensions({ mode: "print", onError: (error) => errors.push(error) });
+  return {
+    session, sessionManager, modelRuntime, model, api, ctx, errors,
+    async close() { session.dispose(); await rm(dir, { recursive: true, force: true }); },
+  };
+}

--- a/tests/install-telemetry-policy.test.mjs
+++ b/tests/install-telemetry-policy.test.mjs
@@ -14,6 +14,7 @@ const packageNames = [
   "pi-fast",
   "pi-goal",
   "pi-insomnia",
+  "pi-openai-reasoning",
   "pi-scout",
   "pi-skillful",
   "pi-web-kit",


### PR DESCRIPTION
## Summary
- Align shared Pi development dependencies to 0.85.1.
- Add GPT-6 Astra Fast support and apply Fast settings to cooperating remote compaction requests.
- Preserve owned apply_patch grammar and custom-tool history during compaction; include compaction usage in session totals and tighten transport limits and cancellation.
- Add the standalone pi-openai-reasoning extension for verified Codex OAuth Astra requests, using existing Pi thinking controls and branch-local configuration updates.

## Releases
| Package | Version |
| --- | --- |
| pi-fast | 0.1.2 |
| pi-codex-compaction | 0.1.2 |
| pi-codex-tools | 0.2.4 |
| pi-openai-reasoning (new) | 0.1.0 |

Other packages changed only development dependencies and do not need releases. Image-generation runtime behavior and defaults are unchanged.

## Validation
- Fresh npm ci --dry-run and npm run validate passed: 13 packages; 327 passing tests, zero failures, two existing platform skips.
- Production dependency audit: zero vulnerabilities.
- Inspected all four release package file lists, including native assets and attribution.
- Earlier real Pi SDK/Codex subscription smoke tests passed, including reasoning updates, Fast, tool grammar, remote compaction, and continuation.
- Earlier isolated installation/loader test and targeted Node 24 tests passed. Prior targeted Semgrep security scan found no issues.

## Limits and release notes
- Live tests used the Pi SDK, not the interactive terminal application. TUI shortcuts/display and actual apply_patch execution were not exercised live.
- No measured compaction speed or subscription savings claim. The small smoke test reported zero cache reads/writes.
- Remote compaction retains its separate HTTP/SSE request path and conservative input bounds.
- Fast is opt-in and can increase subscription usage.
- Existing Pi OAuth, credential refresh, and normal provider transport remain in use; no public API-key fallback or new credential store was added.
- Publish after merge and passing checks. The new package may need initial npm publication/trusted-publisher setup.

Implementation and verification record: docs/plans/2026-09-11-gpt6-codex.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `pi-openai-reasoning`, enabling reasoning-effort changes during long Codex conversations while preserving request caching and session history.
  - Added GPT-6 Astra support for Fast mode.
  - Compaction now preserves tool metadata, reasoning settings, usage details, and history across supported Codex workflows.
  - Added fallback to standard compaction when remote compaction is unavailable.

- **Bug Fixes**
  - Improved request cancellation, timeout handling, retries, endpoint validation, authentication headers, and stream cleanup.

- **Documentation**
  - Added setup, compatibility, security, and usage guidance for the new reasoning and compaction capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->