### PR TITLE
Improve subscription image generation and Images 2.5 CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Each package installs independently. Pick the capability you need, then follow i
 | Need | Package | What it adds |
 | --- | --- | --- |
 | Search the web, docs, and real code | [pi-web-kit](./packages/pi-web-kit) | Context-efficient web search, page fetch, library docs, and code search tools. |
-| Generate or edit images | [pi-codex-image-gen](./packages/pi-codex-image-gen) | Conversational image generation and editing through `gpt-image-2` and ChatGPT Codex auth. |
+| Generate or edit images | [pi-codex-image-gen](./packages/pi-codex-image-gen) | Conversational image generation and editing through ChatGPT Codex auth, with optional Images 2.5 API controls. |
 
 ### Safety and continuity
 

--- a/packages/pi-codex-image-gen/CHANGELOG.md
+++ b/packages/pi-codex-image-gen/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 - Report backend image metadata, generation stages, byte counts, and elapsed time without guessing the served image model.
 - Support Flare and Sunburst Images 2.5 API model IDs and their September 8 snapshots with `xhigh` and `max` CLI quality settings. Keep existing defaults.
+- Validate documented flexible dimensions for both 2.5 models and the GPT Image 2 dated snapshot in CLI generation, editing, and batch workflows.
 
 ### Changed
 

--- a/packages/pi-codex-image-gen/CHANGELOG.md
+++ b/packages/pi-codex-image-gen/CHANGELOG.md
@@ -6,12 +6,18 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Added
+
+- Support Flare and Sunburst Images 2.5 API model IDs and their September 8 snapshots with `xhigh` and `max` CLI quality settings. Keep existing defaults.
+
 ### Changed
 
+- Describe the Codex image model as backend-selected. Return `backendImageModel: "unknown"` instead of an unverified `gpt-image-2` label.
 - Share install telemetry mechanics through `@mocito/install-telemetry` while preserving Pi-specific settings and state paths.
 
 ### Fixed
 
+- Allow GPT Image 2 native transparency preview with PNG/WebP in the API CLI, and remove outdated older-model fallback requirements from skill guidance.
 - Let `enableInstallTelemetry: false` override an enabled `PI_TELEMETRY` environment flag.
 
 ## [0.1.12] - 2026-07-17

--- a/packages/pi-codex-image-gen/CHANGELOG.md
+++ b/packages/pi-codex-image-gen/CHANGELOG.md
@@ -8,6 +8,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ### Added
 
+- Report backend image metadata, generation stages, byte counts, and elapsed time without guessing the served image model.
 - Support Flare and Sunburst Images 2.5 API model IDs and their September 8 snapshots with `xhigh` and `max` CLI quality settings. Keep existing defaults.
 
 ### Changed
@@ -17,6 +18,8 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ### Fixed
 
+- Identify subscription requests with a Pi User-Agent and distinguish Cloudflare challenges from account/model failures.
+- Bound network time, streamed/error output, prompts, and input images; handle fragmented CRLF streams and incomplete results; avoid quota-error retries and accidental file overwrites.
 - Allow GPT Image 2 native transparency preview with PNG/WebP in the API CLI, and remove outdated older-model fallback requirements from skill guidance.
 - Let `enableInstallTelemetry: false` override an enabled `PI_TELEMETRY` environment flag.
 

--- a/packages/pi-codex-image-gen/CHANGELOG.md
+++ b/packages/pi-codex-image-gen/CHANGELOG.md
@@ -14,7 +14,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ### Changed
 
-- Describe the Codex image model as backend-selected. Return `backendImageModel: "unknown"` instead of an unverified `gpt-image-2` label.
+- Describe the Codex image model as backend-selected. Report its ID only if the backend supplies one; otherwise return `backendImageModel: "unknown"`.
 - Share install telemetry mechanics through `@mocito/install-telemetry` while preserving Pi-specific settings and state paths.
 
 ### Fixed

--- a/packages/pi-codex-image-gen/CONTRIBUTING.md
+++ b/packages/pi-codex-image-gen/CONTRIBUTING.md
@@ -33,9 +33,16 @@ pi -e /path/to/pi-mono/packages/pi-codex-image-gen
 To validate the Python CLI fallback without an API key:
 
 ```bash
-python3 skills/imagegen/scripts/image_gen.py generate --prompt "Test" --out /tmp/test.png --dry-run
-python3 skills/imagegen/scripts/remove_chroma_key.py --help
+uv run --no-project python3 skills/imagegen/scripts/image_gen.py generate --prompt "Test" --model gpt-image-2.5-flare --quality max --dry-run
+uv run --no-project python3 skills/imagegen/scripts/image_gen.py generate --prompt "Test" --background transparent --output-format png --dry-run
+uv run --no-project python3 skills/imagegen/scripts/remove_chroma_key.py --help
 ```
+
+`npm test` requires Python 3 on PATH. CLI regression tests use only its standard library and make dry-run requests. Extension tests mock the backend; neither test path consumes image quota.
+
+The vendored CLI changes for Images 2.5 are limited to documented quality settings and GPT Image 2 transparency preview. They do not change API endpoints, authentication, or defaults.
+
+Optional live smoke test (requires explicit approval to use image quota): load this checkout with `pi -e`, generate one PNG, and edit it using `referencedImagePaths`. Verify inline display and saved bytes. Confirm that progress and the final summary do not claim a specific image model, and that result details contain `backendImageModel: "unknown"`. A successful image does not prove which backend model ran. Never include credentials or raw image payloads in test reports.
 
 ## Pull request checklist
 

--- a/packages/pi-codex-image-gen/CONTRIBUTING.md
+++ b/packages/pi-codex-image-gen/CONTRIBUTING.md
@@ -40,9 +40,31 @@ uv run --no-project python3 skills/imagegen/scripts/remove_chroma_key.py --help
 
 `npm test` requires Python 3 on PATH. CLI regression tests use only its standard library and make dry-run requests. Extension tests mock the backend; neither test path consumes image quota.
 
-The vendored CLI changes for Images 2.5 are limited to documented quality settings and GPT Image 2 transparency preview. They do not change API endpoints, authentication, or defaults.
+The vendored CLI changes for Images 2.5 cover documented quality and flexible size settings plus GPT Image 2 transparency preview. They do not change API endpoints, authentication, or defaults.
 
-Optional live smoke test (requires explicit approval to use image quota): load this checkout with `pi -e`, generate one PNG, and edit it using `referencedImagePaths`. Verify inline display and saved bytes. Confirm that progress and the final summary do not claim a specific image model, and that result details contain `backendImageModel: "unknown"`. A successful image does not prove which backend model ran. Never include credentials or raw image payloads in test reports.
+Optional live smoke test (requires explicit approval to use image quota): load this checkout with `pi -e`, generate one PNG, and edit it using `referencedImagePaths`. Verify inline display and saved bytes. Confirm that progress and the final summary do not invent an image model, and that `backendImageModel` is `"unknown"` unless the backend explicitly reports one. Verify `reportedImage` size/quality/background against the response, then inspect actual pixels for dimensions and alpha. A successful image does not prove which backend model ran. Never include credentials or raw image payloads in test reports.
+
+## Subscription capability check
+
+Checked on September 11, 2026, with a ChatGPT subscription token and no API-key billing. These observations are account- and date-specific, not a public API guarantee.
+
+- Installed Codex `0.153.4` and upstream commit `4dcce4f0c47e0183e4b05ffcbb38b4fffb8b8042` both use the standalone images client for image generation. Its model is hard-coded to `gpt-image-2`; background, size, and quality are automatic.
+- The request path is determined by subscription authentication: `https://chatgpt.com/backend-api/codex/images/generations` (or `images/edits`).
+- A bounded diagnostic using the direct route generated an image. The existing Responses route also generated an image. All six returned PNG files passed Pillow verification and decoding.
+- Requests naming Flare and Sunburst succeeded, but a deliberately invalid model name also succeeded. None reported a served model. Do not interpret HTTP 200 as proof of selectable models.
+- An explicit `1536x1024`, `high`, `transparent` direct request returned `1254x1254`, `low`, `opaque`. Pixel inspection confirmed RGB output without transparency. Do not add guaranteed controls based on the request schema alone.
+- GET diagnostics with the original Python client header returned a Cloudflare challenge. A package-specific Pi User-Agent reached method validation in the Python diagnostic. Cookie-free Node GET requests with the shipping headers reached the Responses route (405), but the direct route still returned a Cloudflare challenge (403). A User-Agent is not a universal challenge fix.
+- The successful live generation probes used a Codex-compatible diagnostic User-Agent, a model-list warmup, and an in-memory allowlisted infrastructure-cookie jar. These were compatibility probes, not a live run of the modified extension. The shipping extension keeps an honest Pi User-Agent and does not copy that cookie/warmup flow.
+- Model selection through the Responses tool, native transparency by prompting, and live editing were not established by this six-request check. Keep them separate from the proven baseline generation result.
+
+Source references:
+
+- [Installed Codex image tool](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/ext/image-generation/src/tool.rs)
+- [Subscription base URL selection](https://github.com/openai/codex/blob/4dcce4f0c47e0183e4b05ffcbb38b4fffb8b8042/codex-rs/model-provider-info/src/lib.rs)
+- [Images endpoint client](https://github.com/openai/codex/blob/4dcce4f0c47e0183e4b05ffcbb38b4fffb8b8042/codex-rs/codex-api/src/endpoint/images.rs)
+- [Codex client headers](https://github.com/openai/codex/blob/4dcce4f0c47e0183e4b05ffcbb38b4fffb8b8042/codex-rs/login/src/auth/default_client.rs)
+
+Future probes should use a known-working control, one changed setting at a time, an invalid-model control for selection claims, and decoded output checks. Obtain a generation budget first, bound time/response sizes, disable automatic retries, and record only sanitized metadata. Do not repeat an ambiguous failed generation automatically.
 
 ## Pull request checklist
 
@@ -60,7 +82,7 @@ Before opening a pull request:
 - When changing tool parameters, update both the Typebox `TOOL_PARAMS` schema and the `promptGuidelines` strings — Pi surfaces both to the model.
 - Treat save-mode names, config file keys, and auth flow as public interface; changes to defaults or precedence are breaking changes.
 - Do not modify `skills/imagegen/scripts/image_gen.py` without a documented reason; it is a vendored fallback.
-- The Codex Responses SSE contract is undocumented and may change. If generation breaks, log raw events before assuming a code bug.
+- The Codex Responses SSE contract is private and may change. If generation breaks, inspect sanitized event types, status codes, and allowlisted output metadata. Never log raw response bodies or auth headers.
 - Avoid requiring `OPENAI_API_KEY` for the normal Pi tool path; auth piggybacks on Pi's `openai-codex` login.
 
 ## Code of conduct

--- a/packages/pi-codex-image-gen/README.md
+++ b/packages/pi-codex-image-gen/README.md
@@ -59,11 +59,13 @@ The tool reports generation stages and the backend's returned size, quality, bac
 
 ### Images 2.5 and API fallback
 
-The optional `skills/imagegen/scripts/image_gen.py` API CLI accepts `--model gpt-image-2.5-flare` or `--model gpt-image-2.5-sunburst`, including their `2026-09-08` snapshots. Both accept `--quality xhigh` and `--quality max` in addition to the existing quality settings. The CLI default remains `gpt-image-2`. For 2.5, use `--size auto` or the existing standard sizes; extended resolution rules are not yet verified.
+The optional `skills/imagegen/scripts/image_gen.py` API CLI accepts `--model gpt-image-2.5-flare` or `--model gpt-image-2.5-sunburst`, including their `2026-09-08` snapshots. Both accept `--quality xhigh` and `--quality max` in addition to the existing quality settings. The CLI default remains `gpt-image-2`. Both 2.5 models support `--size auto` and custom dimensions such as `1536x864`, under the [documented size constraints](skills/imagegen/references/image-api.md#flexible-sizes-gpt-image-2-and-25). Resolutions above `2560x1440` are experimental.
 
 GPT Image 2 now supports native transparency in preview: use `--model gpt-image-2 --background transparent --output-format png` (or `webp`) in confirmed CLI mode. This uses `OPENAI_API_KEY` and separate API billing. The Pi tool still uses chroma-key removal because it has no background parameter.
 
 Public API model selection does not establish support for the same options on the private Codex backend. The extension does not expose Flare/Sunburst selection or claim that your account has received the Images 2.5 rollout.
+
+In subscription tests on September 11, 2026, the direct endpoint accepted Flare, Sunburst, and an invalid model name without reporting a served model. It also returned different size, quality, and background values than requested. The Responses route generated an image successfully. These account-specific results do not justify a guaranteed subscription model selector. See [the investigation and test procedure](CONTRIBUTING.md#subscription-capability-check).
 
 ## Authentication
 

--- a/packages/pi-codex-image-gen/README.md
+++ b/packages/pi-codex-image-gen/README.md
@@ -2,7 +2,7 @@
 
 Create and edit images without leaving [Pi](https://pi.dev).
 
-`pi-codex-image-gen` turns natural-language requests and reference images into PNG, JPEG, or WebP assets through **gpt-image-2**, using your existing ChatGPT Codex login instead of a separate API key.
+`pi-codex-image-gen` turns natural-language requests and reference images into PNG, JPEG, or WebP assets through **Codex image generation**, using your existing ChatGPT Codex login instead of a separate API key.
 
 ## Features
 
@@ -43,7 +43,15 @@ In a Pi session:
 > Generate a pixel-art sword icon, 32×32, with a blue blade and gold hilt
 ```
 
-The agent will invoke `codex_generate_image` with your prompt, optionally include up to five local or recent conversation images for editing, stream the response from the Codex backend, and save the resulting image to disk. The `model` parameter controls the Codex routing model; image generation is always performed by **gpt-image-2** on the backend.
+The agent will invoke `codex_generate_image` with your prompt, optionally include up to five local or recent conversation images for editing, stream the response from the Codex backend, and save the resulting image to disk. The `model` parameter controls the Codex routing model, not the image model. The backend selects the image model; result metadata reports `backendImageModel: "unknown"` rather than an unverified model ID.
+
+### Images 2.5 and API fallback
+
+The optional `skills/imagegen/scripts/image_gen.py` API CLI accepts `--model gpt-image-2.5-flare` or `--model gpt-image-2.5-sunburst`, including their `2026-09-08` snapshots. Both accept `--quality xhigh` and `--quality max` in addition to the existing quality settings. The CLI default remains `gpt-image-2`. For 2.5, use `--size auto` or the existing standard sizes; extended resolution rules are not yet verified.
+
+GPT Image 2 now supports native transparency in preview: use `--model gpt-image-2 --background transparent --output-format png` (or `webp`) in confirmed CLI mode. This uses `OPENAI_API_KEY` and separate API billing. The Pi tool still uses chroma-key removal because it has no background parameter.
+
+Public API model selection does not establish support for the same options on the private Codex backend. The extension does not expose Flare/Sunburst selection or claim that your account has received the Images 2.5 rollout.
 
 ## Authentication
 
@@ -80,7 +88,7 @@ Project config overrides global config only when project trust is active. If pro
 | --------- | ------ | ---------- | ---------------------------------------- |
 | `save`    | string | `"global"` | Default save mode (see below).           |
 | `saveDir` | string | —          | Directory used when `save=custom`.       |
-| `model`   | string | `"gpt-5.5"`| Codex routing model. Image generation is always handled by gpt-image-2. |
+| `model`   | string | `"gpt-5.5"`| Codex routing model, not the backend image model. |
 
 ### Environment variables
 
@@ -117,7 +125,7 @@ Project config overrides global config only when project trust is active. If pro
 1. Resolves auth via Pi's `openai-codex` provider (ChatGPT session token).
 2. Sends a Codex Responses API request to the routing model (default `gpt-5.5`) with the `image_generation` tool enabled.
 3. For edits, attaches the selected local or conversation images to the request.
-4. The backend invokes **gpt-image-2** to generate or edit the image.
+4. The backend selects an image model to generate or edit the image.
 5. Parses the SSE stream and strictly validates the returned base64 and image format.
 6. Saves the image according to the active save mode; persistence failures produce a warning without discarding a valid inline image.
 7. Returns the image data inline plus metadata (model, format, path, revised prompt, usage).

--- a/packages/pi-codex-image-gen/README.md
+++ b/packages/pi-codex-image-gen/README.md
@@ -43,7 +43,19 @@ In a Pi session:
 > Generate a pixel-art sword icon, 32×32, with a blue blade and gold hilt
 ```
 
-The agent will invoke `codex_generate_image` with your prompt, optionally include up to five local or recent conversation images for editing, stream the response from the Codex backend, and save the resulting image to disk. The `model` parameter controls the Codex routing model, not the image model. The backend selects the image model; result metadata reports `backendImageModel: "unknown"` rather than an unverified model ID.
+The agent will invoke `codex_generate_image` with your prompt, optionally include up to five local or recent conversation images for editing, stream the response from the Codex backend, and save the resulting image to disk. The `model` parameter controls the Codex routing model, not the image model. The backend selects the image model; `backendImageModel` is `"unknown"` unless the response explicitly reports an image model.
+
+The tool reports generation stages and the backend's returned size, quality, background, and format in `details.reportedImage`. These are server-reported values, not guarantees inferred from the prompt. `details.byteCount` records decoded bytes; `details.generationDurationMs` records elapsed generation/save time. Check the actual image before using it, especially for exact dimensions or alpha transparency.
+
+### Subscription reliability and limits
+
+- Requests identify this package with a Pi User-Agent. There is no Codex impersonation, browser-cookie import, or paid API fallback.
+- One five-minute network deadline covers the connection, retries, and stream. Escape cancels network work; the remote generation may still finish.
+- Prompts: 32,000 characters. References: five regular PNG/JPEG/WebP files or conversation images, at most 20 MiB each and 50 MiB combined.
+- Responses: 100 MiB total, with at most one 32 MiB decoded output image. Base64 and format signatures are checked; this is not a full image decoder. Backend text and revised prompts are limited to 4,000 characters; HTTP error bodies are read only up to 16 KiB and are not displayed.
+- Transient HTTP failures have bounded retries. Quota exhaustion, moderation errors, failed/incomplete streams, connection errors, and deadlines are not automatically retried. Avoid immediately repeating an ambiguous failure: the first generation may have consumed quota.
+- Local save settings are checked before generation. Existing files are never overwritten; a save failure still returns the inline image and a warning.
+- Cloudflare challenges are reported as connection failures, not as proof that your subscription or image model is unsupported.
 
 ### Images 2.5 and API fallback
 

--- a/packages/pi-codex-image-gen/SECURITY.md
+++ b/packages/pi-codex-image-gen/SECURITY.md
@@ -23,4 +23,10 @@ The maintainer will acknowledge reports as soon as practical and coordinate disc
 
 The extension uses Pi's existing `openai-codex` login to obtain a short-lived JWT. The token is used only for requests to the Codex Responses API and is never written to disk or logged. Do not commit API keys, tokens, or decoded JWT payloads.
 
+Subscription requests use the fixed HTTPS `chatgpt.com/backend-api/codex/responses` endpoint with normal TLS validation, an honest package User-Agent, and redirects disabled. The extension does not import browser cookies, change authentication, or switch to API-key billing. Only backend-reported image metadata and allowlisted numeric usage counters are retained; raw HTTP error bodies are not shown. Known request credentials are redacted from backend text.
+
+Network work has a five-minute deadline and a 100 MiB response bound. Output images are limited to 32 MiB; input images must be regular files and are limited to 20 MiB each and 50 MiB in total. Image checks validate base64 and format signatures, not all image internals. Treat images as untrusted content when opening them in other software.
+
+Generated files are created exclusively with user-only permissions. A repeated backend ID or existing destination produces a save warning rather than overwriting that file. Cancellation and stream failures do not trigger automatic generation retries because the remote operation may already have consumed quota.
+
 At startup, `@mocito/install-telemetry` sends a best-effort install/update ping to the configured telemetry endpoint once per package version unless CI, Pi offline/telemetry settings, or `enableInstallTelemetry: false` disables it. It contains only the package name/version and parsed platform/runtime/architecture; it does not include prompts, file paths, configuration values, credentials, or provider responses.

--- a/packages/pi-codex-image-gen/extensions/index.ts
+++ b/packages/pi-codex-image-gen/extensions/index.ts
@@ -355,7 +355,9 @@ export async function resolveInputImages(
 			if (image.data.length > Math.ceil(MAX_INPUT_IMAGE_BYTES / 3) * 4) throw new Error("Conversation image exceeds 20 MiB.");
 			const format = OUTPUT_FORMATS.find(format => mimeForFormat(format) === image.mimeType);
 			if (!format) throw new Error("Conversation image has an unsupported format.");
-			total += decodeImageData(image.data, format).length;
+			const bytes = decodeImageData(image.data, format);
+			if (bytes.length > MAX_INPUT_IMAGE_BYTES) throw new Error("Conversation image exceeds 20 MiB.");
+			total += bytes.length;
 			if (total > MAX_TOTAL_INPUT_BYTES) throw new Error("Conversation images exceed 50 MiB in total.");
 		}
 		return images;

--- a/packages/pi-codex-image-gen/extensions/index.ts
+++ b/packages/pi-codex-image-gen/extensions/index.ts
@@ -7,13 +7,15 @@
  */
 
 import { readFileSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { mkdir, open, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { StringEnum } from "@earendil-works/pi-ai";
-import { type ExtensionAPI, getAgentDir, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
+import { CONFIG_DIR_NAME, type ExtensionAPI, getAgentDir, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
 import { reportInstallTelemetry } from "../src/install-telemetry.js";
+import { abortable, httpFailure, MAX_IMAGE_BYTES, parseCodexSse, withRequestDeadline, type ParsedCodexResponse } from "../src/codex-response.js";
 
 const PACKAGE_NAME = "pi-codex-image-gen";
 const PROVIDER = "openai-codex";
@@ -26,6 +28,9 @@ const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
 const MAX_RETRY_DELAY_MS = 30_000;
 const MAX_EDIT_IMAGES = 5;
+const MAX_INPUT_IMAGE_BYTES = 20 * 1024 * 1024;
+const MAX_TOTAL_INPUT_BYTES = 50 * 1024 * 1024;
+const MAX_PROMPT_CHARS = 32_000;
 
 const SAVE_MODES = ["none", "project", "global", "custom"] as const;
 type SaveMode = (typeof SAVE_MODES)[number];
@@ -34,11 +39,6 @@ const OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 type OutputFormat = (typeof OUTPUT_FORMATS)[number];
 
 // --- #1: Retry helpers with exponential backoff + jitter ---
-
-function isRetryableStatus(status: number, errorText: string): boolean {
-	if ([429, 500, 502, 503, 504].includes(status)) return true;
-	return /rate.?limit|overloaded|service.?unavailable|upstream.?connect|connection.?refused/i.test(errorText);
-}
 
 export function parseRetryAfter(value: string | null, nowMs = Date.now()): number | undefined {
 	if (!value) return undefined;
@@ -89,9 +89,9 @@ export function abortableDelay(milliseconds: number, signal?: AbortSignal): Prom
 // --- Tool parameter schema ---
 
 const TOOL_PARAMS = Type.Object({
-	prompt: Type.String({ description: "The image prompt. Be specific about subject, composition, style, text, and constraints." }),
+	prompt: Type.String({ minLength: 1, maxLength: MAX_PROMPT_CHARS, description: "The image prompt. Be specific about subject, composition, style, text, and constraints." }),
 	model: Type.Optional(
-		Type.String({ description: `Codex model that should invoke image generation. Defaults to ${DEFAULT_MODEL}.` }),
+		Type.String({ minLength: 1, maxLength: 200, description: `Codex routing model, not an image model selector. Defaults to ${DEFAULT_MODEL}.` }),
 	),
 	outputFormat: Type.Optional(StringEnum(OUTPUT_FORMATS)),
 	save: Type.Optional(StringEnum(SAVE_MODES)),
@@ -130,43 +130,10 @@ interface SaveConfig {
 	outputDir?: string;
 }
 
-interface GeneratedImage {
-	id: string;
-	status: string;
-	result: string;
-	revisedPrompt?: string;
-}
-
-interface ParsedCodexResponse {
-	image?: GeneratedImage;
-	text: string[];
-	responseId?: string;
-	usage?: unknown;
-}
-
 interface InputImage {
 	data: string;
 	mimeType: string;
 }
-
-// --- #11: Typed SSE event discriminated union ---
-
-type CodexSseEvent =
-	| { type: "error"; message?: string; code?: string }
-	| { type: "response.failed"; response?: { error?: { message?: string } } }
-	| { type: "response.created"; response?: { id?: string } }
-	| { type: "response.output_text.delta"; delta?: string }
-	| {
-			type: "response.output_item.done";
-			item?: {
-				type?: string;
-				id?: string | number;
-				status?: string;
-				result?: string;
-				revised_prompt?: string;
-			};
-	  }
-	| { type: "response.completed"; response?: { id?: string; usage?: unknown } };
 
 // --- JWT helpers ---
 
@@ -177,8 +144,8 @@ function decodeJwtPayload(token: string): Record<string, unknown> {
 	}
 	try {
 		return JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) as Record<string, unknown>;
-	} catch (error) {
-		throw new Error(`Failed to decode OpenAI Codex auth token: ${error instanceof Error ? error.message : String(error)}`);
+	} catch {
+		throw new Error("Failed to decode OpenAI Codex auth token. Run /login for openai-codex again.");
 	}
 }
 
@@ -208,7 +175,7 @@ function readConfigFile(path: string): ExtensionConfig {
 export function loadConfig(cwd: string, projectTrusted: boolean, agentDir = getAgentDir()): ExtensionConfig {
 	const globalConfig = readConfigFile(join(agentDir, "extensions", "codex-image-gen.json"));
 	if (!projectTrusted) return globalConfig;
-	const projectConfig = readConfigFile(join(cwd, ".pi", "extensions", "codex-image-gen.json"));
+	const projectConfig = readConfigFile(join(cwd, CONFIG_DIR_NAME, "extensions", "codex-image-gen.json"));
 	return { ...globalConfig, ...projectConfig };
 }
 
@@ -221,7 +188,7 @@ export function resolveUnderCwd(cwd: string, path: string, homeDir = homedir()):
 }
 
 function sanitizePathPart(value: string, fallback: string): string {
-	const sanitized = value
+	const sanitized = value.slice(0, 128)
 		.split("")
 		.map((ch) => (/[a-zA-Z0-9_-]/.test(ch) ? ch : "_"))
 		.join("")
@@ -239,7 +206,7 @@ function resolveSaveConfig(params: ToolParams, cwd: string, sessionId: string, c
 		throw new Error(`Invalid save mode: ${mode}. Expected one of ${SAVE_MODES.join(", ")}.`);
 	}
 	if (mode === "project") {
-		return { mode, outputDir: join(cwd, ".pi", "generated-images", safeSessionId) };
+		return { mode, outputDir: join(cwd, CONFIG_DIR_NAME, "generated-images", safeSessionId) };
 	}
 	if (mode === "global") {
 		return { mode, outputDir: join(getAgentDir(), "generated-images", safeSessionId) };
@@ -270,12 +237,13 @@ function imagePath(outputFormat: OutputFormat, outputDir: string, imageCallId: s
 }
 
 export function decodeImageData(base64Data: string, outputFormat: OutputFormat): Buffer {
+	if (base64Data.length > Math.ceil(MAX_IMAGE_BYTES / 3) * 4) throw new Error("Codex image exceeded the 32 MiB size limit.");
 	const value = base64Data.trim();
-	if (!value || value.length % 4 !== 0 || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+	if (!value || value.length % 4 !== 0 || /[^A-Za-z0-9+/=]/.test(value)) {
 		throw new Error("Codex returned invalid base64 image data.");
 	}
 	const bytes = Buffer.from(value, "base64");
-	if (bytes.length === 0 || bytes.toString("base64") !== value) {
+	if (bytes.length === 0 || bytes.length > MAX_IMAGE_BYTES || bytes.toString("base64") !== value) {
 		throw new Error("Codex returned invalid base64 image data.");
 	}
 	const validSignature =
@@ -294,8 +262,8 @@ async function saveImage(
 ): Promise<string> {
 	const filePath = imagePath(outputFormat, outputDir, imageCallId);
 	await withFileMutationQueue(filePath, async () => {
-		await mkdir(outputDir, { recursive: true });
-		await writeFile(filePath, bytes);
+		await mkdir(outputDir, { recursive: true, mode: 0o700 });
+		await writeFile(filePath, bytes, { flag: "wx", mode: 0o600 });
 	});
 	return filePath;
 }
@@ -322,6 +290,29 @@ function mimeFromBytes(bytes: Buffer, path: string): string {
 	throw new Error(`Referenced image is unavailable or unsupported: ${path}`);
 }
 
+async function readInputImage(path: string): Promise<Buffer> {
+	// O_NONBLOCK prevents named pipes from blocking before the regular-file check.
+	const file = await open(path, constants.O_RDONLY | (constants.O_NONBLOCK ?? 0));
+	try {
+		const info = await file.stat();
+		if (!info.isFile()) throw new Error("Referenced images must be regular files.");
+		if (info.size > MAX_INPUT_IMAGE_BYTES) throw new Error("Referenced image exceeds 20 MiB.");
+		const blocks: Buffer[] = [];
+		let total = 0;
+		while (true) {
+			const block = Buffer.alloc(Math.min(64 * 1024, MAX_INPUT_IMAGE_BYTES + 1 - total));
+			const { bytesRead } = await file.read(block, 0, block.length, null);
+			if (!bytesRead) break;
+			total += bytesRead;
+			if (total > MAX_INPUT_IMAGE_BYTES) throw new Error("Referenced image exceeds 20 MiB.");
+			blocks.push(block.subarray(0, bytesRead));
+		}
+		return Buffer.concat(blocks, total);
+	} finally {
+		await file.close();
+	}
+}
+
 export async function resolveInputImages(
 	params: ToolParams,
 	cwd: string,
@@ -333,19 +324,22 @@ export async function resolveInputImages(
 	}
 	if (paths.length > MAX_EDIT_IMAGES) throw new Error(`referencedImagePaths accepts at most ${MAX_EDIT_IMAGES} paths.`);
 	if (paths.length > 0) {
-		return Promise.all(
-			paths.map(async (path) => {
-				const normalized = path.startsWith("@") ? path.slice(1) : path;
-				const absolutePath = resolveUnderCwd(cwd, normalized);
-				let bytes: Buffer;
-				try {
-					bytes = await readFile(absolutePath);
-				} catch (error) {
-					throw new Error(`Unable to read referenced image at ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`);
-				}
-				return { data: bytes.toString("base64"), mimeType: mimeFromBytes(bytes, absolutePath) };
-			}),
-		);
+		const images: InputImage[] = [];
+		let total = 0;
+		for (const path of paths) {
+			const normalized = path.startsWith("@") ? path.slice(1) : path;
+			const absolutePath = resolveUnderCwd(cwd, normalized);
+			let bytes: Buffer;
+			try {
+				bytes = await readInputImage(absolutePath);
+			} catch (error) {
+				throw new Error(`Unable to read referenced image at ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`);
+			}
+			total += bytes.length;
+			if (total > MAX_TOTAL_INPUT_BYTES) throw new Error("Referenced images exceed 50 MiB in total.");
+			images.push({ data: bytes.toString("base64"), mimeType: mimeFromBytes(bytes, absolutePath) });
+		}
+		return images;
 	}
 	if (params.numLastImagesToInclude !== undefined) {
 		const count = params.numLastImagesToInclude;
@@ -355,6 +349,14 @@ export async function resolveInputImages(
 		const images = selectRecentImages(messages, count);
 		if (images.length !== count) {
 			throw new Error(`Requested the last ${count} conversation images, but only ${images.length} were available.`);
+		}
+		let total = 0;
+		for (const image of images) {
+			if (image.data.length > Math.ceil(MAX_INPUT_IMAGE_BYTES / 3) * 4) throw new Error("Conversation image exceeds 20 MiB.");
+			const format = OUTPUT_FORMATS.find(format => mimeForFormat(format) === image.mimeType);
+			if (!format) throw new Error("Conversation image has an unsupported format.");
+			total += decodeImageData(image.data, format).length;
+			if (total > MAX_TOTAL_INPUT_BYTES) throw new Error("Conversation images exceed 50 MiB in total.");
 		}
 		return images;
 	}
@@ -399,108 +401,6 @@ export function buildRequestBody(
 	};
 }
 
-// --- SSE parsing ---
-
-function parseSseDataLines(chunk: string): string | undefined {
-	const data = chunk
-		.split("\n")
-		.filter((line) => line.startsWith("data:"))
-		.map((line) => line.slice(5).trim())
-		.join("\n")
-		.trim();
-	return data && data !== "[DONE]" ? data : undefined;
-}
-
-async function parseCodexSse(response: Response, signal?: AbortSignal): Promise<ParsedCodexResponse> {
-	if (!response.body) throw new Error("Codex response did not include a stream body.");
-	const reader = response.body.getReader();
-	const decoder = new TextDecoder();
-	let buffer = "";
-	const parsed: ParsedCodexResponse = { text: [] };
-
-	try {
-		while (true) {
-			if (signal?.aborted) throw new Error("Image generation was aborted.");
-			const { done, value } = await reader.read();
-			if (done) break;
-			buffer += decoder.decode(value, { stream: true });
-
-			let separator = buffer.indexOf("\n\n");
-			while (separator !== -1) {
-				const chunk = buffer.slice(0, separator);
-				buffer = buffer.slice(separator + 2);
-				const data = parseSseDataLines(chunk);
-				if (data) handleCodexEvent(JSON.parse(data) as CodexSseEvent, parsed);
-				separator = buffer.indexOf("\n\n");
-			}
-		}
-		const remaining = parseSseDataLines(buffer);
-		if (remaining) handleCodexEvent(JSON.parse(remaining) as CodexSseEvent, parsed);
-	} finally {
-		try {
-			await reader.cancel();
-		} catch {
-			// ignored: stream may already be closed
-		}
-		reader.releaseLock();
-	}
-
-	return parsed;
-}
-
-// --- #11: Typed event handler via discriminated union ---
-
-function handleCodexEvent(event: CodexSseEvent, parsed: ParsedCodexResponse): void {
-	if (!event || typeof event !== "object") return;
-
-	switch (event.type) {
-		case "error": {
-			const e = event as Extract<CodexSseEvent, { type: "error" }>;
-			throw new Error(`Codex error: ${e.message || e.code || JSON.stringify(event)}`);
-		}
-		case "response.failed": {
-			const e = event as Extract<CodexSseEvent, { type: "response.failed" }>;
-			throw new Error(e.response?.error?.message || "Codex response failed.");
-		}
-		case "response.created": {
-			const e = event as Extract<CodexSseEvent, { type: "response.created" }>;
-			if (typeof e.response?.id === "string") {
-				parsed.responseId = e.response.id;
-			}
-			break;
-		}
-		case "response.output_text.delta": {
-			const e = event as Extract<CodexSseEvent, { type: "response.output_text.delta" }>;
-			if (typeof e.delta === "string") {
-				parsed.text.push(e.delta);
-			}
-			break;
-		}
-		case "response.output_item.done": {
-			const e = event as Extract<CodexSseEvent, { type: "response.output_item.done" }>;
-			const item = e.item;
-			if (item?.type === "image_generation_call") {
-				if (typeof item.result !== "string" || item.result.length === 0) {
-					throw new Error("Codex image_generation_call did not contain image data.");
-				}
-				parsed.image = {
-					id: String(item.id || "image_generation"),
-					status: String(item.status || "completed"),
-					result: item.result,
-					revisedPrompt: typeof item.revised_prompt === "string" ? item.revised_prompt : undefined,
-				};
-			}
-			break;
-		}
-		case "response.completed": {
-			const e = event as Extract<CodexSseEvent, { type: "response.completed" }>;
-			if (typeof e.response?.id === "string") parsed.responseId = e.response.id;
-			if (e.response?.usage) parsed.usage = e.response.usage;
-			break;
-		}
-	}
-}
-
 // --- #1: requestImage with retry + backoff + jitter ---
 
 async function requestImage(
@@ -512,41 +412,46 @@ async function requestImage(
 	sessionId: string,
 	inputImages: InputImage[],
 	signal?: AbortSignal,
+	onProgress?: (stage: string) => void,
 ): Promise<ParsedCodexResponse> {
 	const body = JSON.stringify(buildRequestBody(params, model, outputFormat, sessionId, inputImages));
 	const headers: Record<string, string> = {
 		Authorization: `Bearer ${token}`,
 		"chatgpt-account-id": accountId,
 		originator: "pi",
+		"User-Agent": PACKAGE_NAME,
 		"OpenAI-Beta": OPENAI_BETA_HEADER,
 		accept: "text/event-stream",
 		"content-type": "application/json",
 	};
 
-	for (let attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) {
-		if (signal?.aborted) throw new Error("Image generation was aborted.");
-
-		const response = await fetch(CODEX_RESPONSES_URL, {
-			method: "POST",
-			headers,
-			body,
-			signal,
-		});
-
-		if (!response.ok) {
-			const errorText = await response.text();
-			if (attempt <= MAX_RETRIES && isRetryableStatus(response.status, errorText)) {
-				const delay = retryDelayMs(attempt, response.headers.get("retry-after"));
-				await abortableDelay(delay, signal);
-				continue;
+	return withRequestDeadline(signal, async (signal) => {
+		for (let attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) {
+			signal.throwIfAborted();
+			let response: Response;
+			try {
+				response = await abortable(fetch(CODEX_RESPONSES_URL, {
+					method: "POST", headers, body, signal, redirect: "error",
+				}), signal);
+			} catch {
+				signal.throwIfAborted();
+				throw new Error("Codex connection failed. No automatic retry was made; check connectivity before trying again.");
 			}
-			throw new Error(`Codex image generation request failed (${response.status}): ${errorText}`);
+
+			if (!response.ok) {
+				const failure = await httpFailure(response, signal);
+				if (attempt <= MAX_RETRIES && failure.retry) {
+					const delay = retryDelayMs(attempt, response.headers.get("retry-after"));
+					await abortableDelay(delay, signal);
+					continue;
+				}
+				throw new Error(failure.message);
+			}
+
+			return parseCodexSse(response, signal, [token, accountId], onProgress);
 		}
-
-		return parseCodexSse(response, signal);
-	}
-
-	throw new Error("Codex image generation request failed after all retries.");
+		throw new Error("Codex image generation request failed after all retries.");
+	});
 }
 
 // --- Extension entry point ---
@@ -558,7 +463,7 @@ export default function codexImageGen(pi: ExtensionAPI) {
 		name: "codex_generate_image",
 		label: "Codex Image",
 		description:
-			"Generate or edit an image with the OpenAI Codex ChatGPT backend built-in image_generation tool. The backend selects the image model. Accepts up to five local or recent conversation images. Uses the existing openai-codex login; does not require OPENAI_API_KEY.",
+			"Generate or edit an image with the OpenAI Codex ChatGPT backend built-in image_generation tool. The backend selects the image model. Accepts up to five local or recent conversation images (20 MiB each, 50 MiB total). Uses the existing openai-codex login; does not require OPENAI_API_KEY. Network deadline: 5 minutes; output image limit: 32 MiB; backend text is limited to 4,000 characters.",
 		promptSnippet: "Generate or edit bitmap images via the OpenAI Codex ChatGPT backend image_generation tool.",
 		promptGuidelines: [
 			"Use codex_generate_image when the user asks to generate or edit a raster image with OpenAI/Codex image generation.",
@@ -567,17 +472,28 @@ export default function codexImageGen(pi: ExtensionAPI) {
 		parameters: TOOL_PARAMS,
 		executionMode: "parallel", // #4: safe to run concurrently — no shared state, saves serialized per-path
 		async execute(toolCallId, params: ToolParams, signal, onUpdate, ctx) {
+			if (typeof params.prompt !== "string" || !params.prompt.trim() || params.prompt.length > MAX_PROMPT_CHARS) {
+				throw new Error("Image prompt must contain 1 to 32,000 characters.");
+			}
 			const outputFormat = params.outputFormat || "png";
+			if (!OUTPUT_FORMATS.includes(outputFormat)) throw new Error("Unsupported image output format.");
 			const projectTrusted = typeof ctx.isProjectTrusted === "function" && ctx.isProjectTrusted();
 			const config = loadConfig(ctx.cwd, projectTrusted); // #5: load once, pass to resolveSaveConfig
 			const requestedModel = params.model || config.model || DEFAULT_MODEL;
+			if (typeof requestedModel !== "string" || !requestedModel.trim() || requestedModel.length > 200) {
+				throw new Error("Codex routing model must contain 1 to 200 characters.");
+			}
+			if (requestedModel.startsWith("gpt-image-")) {
+				throw new Error("The model parameter selects a Codex routing model, not an image model. Subscription image-model selection is not verified.");
+			}
 			const model = ctx.modelRegistry.find(PROVIDER, requestedModel)?.id || requestedModel; // #6: removed dead FALLBACK_MODEL
+			const sessionId = ctx.sessionManager.getSessionId();
+			const saveConfig = resolveSaveConfig(params, ctx.cwd, sessionId, config);
 			const token = await ctx.modelRegistry.getApiKeyForProvider(PROVIDER);
 			if (!token) {
 				throw new Error(`Missing ${PROVIDER} credentials. Run /login and select ChatGPT Plus/Pro (Codex).`);
 			}
 			const accountId = extractChatGptAccountId(token);
-			const sessionId = ctx.sessionManager.getSessionId();
 			const messages: unknown[] = [];
 			for (const entry of ctx.sessionManager.getBranch()) {
 				if (entry.type === "message") messages.push(entry.message);
@@ -590,14 +506,20 @@ export default function codexImageGen(pi: ExtensionAPI) {
 				details: { provider: PROVIDER, model, outputFormat, inputImageCount: inputImages.length },
 			});
 
-			const parsed = await requestImage(params, token, accountId, model, outputFormat, sessionId, inputImages, signal);
+			const started = Date.now();
+			const parsed = await requestImage(params, token, accountId, model, outputFormat, sessionId, inputImages, signal, (stage) => {
+				onUpdate?.({
+					content: [{ type: "text", text: `Codex image stage: ${stage}.` }],
+					details: { provider: PROVIDER, model, stage },
+				});
+			});
 			if (!parsed.image) {
 				const text = parsed.text.join("").trim();
 				throw new Error(text ? `Codex did not return an image. Response text: ${text}` : "Codex did not return an image.");
 			}
 
 			const imageBytes = decodeImageData(parsed.image.result, outputFormat);
-			const saveConfig = resolveSaveConfig(params, ctx.cwd, sessionId, config);
+			const reportedImage = parsed.image.reported;
 			let savedPath: string | undefined;
 			let attemptedPath: string | undefined;
 			let saveWarning: string | undefined;
@@ -617,6 +539,9 @@ export default function codexImageGen(pi: ExtensionAPI) {
 			const summary = [
 				`Generated image via ${PROVIDER}/${model} using the backend-selected image model.`,
 				`Status: ${parsed.image.status}.`,
+				reportedImage.size ? `Backend-reported size: ${reportedImage.size}.` : undefined,
+				reportedImage.quality ? `Backend-reported quality: ${reportedImage.quality}.` : undefined,
+				reportedImage.background ? `Backend-reported background: ${reportedImage.background}.` : undefined,
 				parsed.image.revisedPrompt ? `Revised prompt: ${parsed.image.revisedPrompt}` : undefined,
 				savedPath ? `Saved image to: ${savedPath}` : "Image was not saved to disk.",
 				saveWarning ? `Warning: ${saveWarning}` : undefined,
@@ -632,7 +557,11 @@ export default function codexImageGen(pi: ExtensionAPI) {
 				details: {
 					provider: PROVIDER,
 					model,
-					backendImageModel: "unknown",
+					backendImageModel: reportedImage.model ?? "unknown",
+					reportedImage,
+					transport: "codex-responses",
+					generationDurationMs: Date.now() - started,
+					byteCount: imageBytes.length,
 					outputFormat,
 					saveMode: saveConfig.mode,
 					savedPath,

--- a/packages/pi-codex-image-gen/extensions/index.ts
+++ b/packages/pi-codex-image-gen/extensions/index.ts
@@ -3,7 +3,7 @@
  *
  * Registers `codex_generate_image`, a tool that uses Pi's existing
  * openai-codex ChatGPT/Codex auth to call the Codex Responses backend with the
- * native `image_generation` tool. The backend maps that tool to gpt-image-2.
+ * native `image_generation` tool. The backend selects the image model.
  */
 
 import { readFileSync } from "node:fs";
@@ -558,8 +558,8 @@ export default function codexImageGen(pi: ExtensionAPI) {
 		name: "codex_generate_image",
 		label: "Codex Image",
 		description:
-			"Generate or edit an image with the OpenAI Codex ChatGPT backend built-in image_generation tool (gpt-image-2). Accepts up to five local or recent conversation images. Uses the existing openai-codex login; does not require OPENAI_API_KEY.",
-		promptSnippet: "Generate or edit bitmap images via the OpenAI Codex ChatGPT backend gpt-image-2 image_generation tool.",
+			"Generate or edit an image with the OpenAI Codex ChatGPT backend built-in image_generation tool. The backend selects the image model. Accepts up to five local or recent conversation images. Uses the existing openai-codex login; does not require OPENAI_API_KEY.",
+		promptSnippet: "Generate or edit bitmap images via the OpenAI Codex ChatGPT backend image_generation tool.",
 		promptGuidelines: [
 			"Use codex_generate_image when the user asks to generate or edit a raster image with OpenAI/Codex image generation.",
 			"Do not use codex_generate_image without a clear image-generation request, because it consumes the user's Codex image quota.",
@@ -586,7 +586,7 @@ export default function codexImageGen(pi: ExtensionAPI) {
 			const inputImages = await resolveInputImages(params, ctx.cwd, messages);
 
 			onUpdate?.({
-				content: [{ type: "text", text: `Requesting gpt-image-2 ${inputImages.length > 0 ? "edit" : "generation"} through ${PROVIDER}/${model}...` }],
+				content: [{ type: "text", text: `Requesting image ${inputImages.length > 0 ? "edit" : "generation"} through ${PROVIDER}/${model}...` }],
 				details: { provider: PROVIDER, model, outputFormat, inputImageCount: inputImages.length },
 			});
 
@@ -615,7 +615,7 @@ export default function codexImageGen(pi: ExtensionAPI) {
 			}
 
 			const summary = [
-				`Generated image via ${PROVIDER}/${model} using backend gpt-image-2.`,
+				`Generated image via ${PROVIDER}/${model} using the backend-selected image model.`,
 				`Status: ${parsed.image.status}.`,
 				parsed.image.revisedPrompt ? `Revised prompt: ${parsed.image.revisedPrompt}` : undefined,
 				savedPath ? `Saved image to: ${savedPath}` : "Image was not saved to disk.",
@@ -632,7 +632,7 @@ export default function codexImageGen(pi: ExtensionAPI) {
 				details: {
 					provider: PROVIDER,
 					model,
-					backendImageModel: "gpt-image-2",
+					backendImageModel: "unknown",
 					outputFormat,
 					saveMode: saveConfig.mode,
 					savedPath,

--- a/packages/pi-codex-image-gen/extensions/index.ts
+++ b/packages/pi-codex-image-gen/extensions/index.ts
@@ -470,6 +470,9 @@ export default function codexImageGen(pi: ExtensionAPI) {
 		promptGuidelines: [
 			"Use codex_generate_image when the user asks to generate or edit a raster image with OpenAI/Codex image generation.",
 			"Do not use codex_generate_image without a clear image-generation request, because it consumes the user's Codex image quota.",
+			"The model parameter selects a Codex routing model, not an image model. Do not pass gpt-image-* IDs.",
+			"Output metadata is backend-reported, not independently verified. Check pixels for dimensions and transparency; do not infer a served model from appearance or a successful request.",
+			"Do not automatically repeat quota, connection, deadline, or incomplete-stream failures. The backend may already have consumed image quota.",
 		],
 		parameters: TOOL_PARAMS,
 		executionMode: "parallel", // #4: safe to run concurrently — no shared state, saves serialized per-path

--- a/packages/pi-codex-image-gen/package.json
+++ b/packages/pi-codex-image-gen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-codex-image-gen",
   "version": "0.1.12",
-  "description": "Image generation for Pi using the ChatGPT Images 2.0 model.",
+  "description": "Image generation and editing for Pi using your ChatGPT Codex login.",
   "type": "module",
   "license": "Apache-2.0",
   "author": "Jose Mocito",

--- a/packages/pi-codex-image-gen/skills/imagegen/SKILL.md
+++ b/packages/pi-codex-image-gen/skills/imagegen/SKILL.md
@@ -16,7 +16,7 @@ Generates or edits images for the current project (for example website assets, g
 This skill has exactly two top-level modes:
 
 - **Default Pi tool mode (preferred):** Pi `codex_generate_image` tool for new image generation, edits using up to five local or recent conversation images, reference variants, and simple transparent-image requests. Does not require `OPENAI_API_KEY`.
-- **Fallback CLI mode:** `scripts/image_gen.py` CLI. Use when the user explicitly asks for the CLI/API/model path, or after the user explicitly confirms a true model-native transparency fallback with `gpt-image-1.5`. Requires `OPENAI_API_KEY`.
+- **Fallback CLI mode:** `scripts/image_gen.py` CLI. Use when the user explicitly asks for the CLI/API/model path, or after the user explicitly confirms a native transparency API fallback. Requires `OPENAI_API_KEY` and separate API billing.
 
 Within CLI fallback, the CLI exposes three subcommands:
 
@@ -30,7 +30,7 @@ Rules:
 - Do not switch to CLI fallback for ordinary generation quality, size, or output file-path control.
 - If the user explicitly asks for a transparent image/background, stay on Pi `codex_generate_image` first: prompt for a flat removable chroma-key background, then remove it locally with the installed helper at `scripts/remove_chroma_key.py`.
 - Never silently switch from Pi `codex_generate_image` or CLI `gpt-image-2` to CLI `gpt-image-1.5`. Treat this as a model/path downgrade and ask the user before doing it, unless the user has already explicitly requested `gpt-image-1.5`, `scripts/image_gen.py`, or CLI fallback.
-- If a transparent request appears too complex for clean chroma-key removal, asks for true/native transparency, or local removal fails validation, explain that true transparency requires CLI `gpt-image-1.5 --background transparent --output-format png` because `gpt-image-2` does not support `background=transparent`, then ask whether to proceed. Run the CLI fallback only after the user confirms.
+- If a transparent request appears too complex for clean chroma-key removal, asks for true/native transparency, or local removal fails validation, offer CLI `gpt-image-2 --background transparent --output-format png` (native transparency preview). Run the CLI fallback only after the user confirms.
 - The word `batch` by itself does not mean CLI fallback. If the user asks for many assets or says to batch-generate assets without explicitly asking for CLI/API/model controls, stay on the Pi tool path and issue one Pi tool call per requested asset or variant.
 - If the Pi tool fails or is unavailable, tell the user the CLI fallback exists and that it requires `OPENAI_API_KEY`. Proceed only if the user explicitly asks for that fallback.
 - If the user explicitly asks for CLI mode, use the bundled `scripts/image_gen.py` workflow. Do not create one-off SDK runners.
@@ -113,7 +113,7 @@ Assume the user wants a new image unless they clearly ask to change an existing 
    - If the user's prompt is already specific and detailed, normalize it into a clear spec without adding creative requirements.
    - If the user's prompt is generic, add tasteful augmentation only when it materially improves output quality.
 10. Use the Pi `codex_generate_image` tool by default for generation and supported existing-image edits. Ask for CLI fallback confirmation only when the request requires unsupported controls such as masks.
-11. For transparent-output requests, follow the transparent image guidance below: generate with Pi `codex_generate_image` on a flat chroma-key background, copy the selected output into the workspace or `tmp/imagegen/`, run the installed `scripts/remove_chroma_key.py` helper, and validate the alpha result before using it. If this path looks unsuitable or fails, ask before switching to CLI `gpt-image-1.5`.
+11. For transparent-output requests, follow the transparent image guidance below: generate with Pi `codex_generate_image` on a flat chroma-key background, copy the selected output into the workspace or `tmp/imagegen/`, run the installed `scripts/remove_chroma_key.py` helper, and validate the alpha result before using it. If this path looks unsuitable or fails, ask before switching to the API CLI.
 12. Inspect outputs and validate: subject, style, composition, text accuracy, and invariants/avoid items.
 13. Iterate with a single targeted change, then re-check.
 14. For preview-only work, render the image inline; the underlying file may remain at the default `<pi-agent-dir>/generated-images/<pi-session-id>/<image-call-id>.*` path.
@@ -154,12 +154,12 @@ Do not use #00ff00 anywhere in the subject.
 No cast shadow, no contact shadow, no reflection, no watermark, and no text unless explicitly requested.
 ```
 
-Do not automatically use CLI `gpt-image-1.5 --background transparent --output-format png` instead of chroma keying. Ask the user first when the user asks for true/native transparency, when local removal fails validation, or when the requested image is complex: hair, fur, feathers, smoke, glass, liquids, translucent materials, reflective objects, soft shadows, realistic product grounding, or subject colors that conflict with all practical key colors.
+Do not automatically use CLI `gpt-image-2 --background transparent --output-format png` instead of chroma keying. Ask the user first when the user asks for true/native transparency, when local removal fails validation, or when the requested image is complex: hair, fur, feathers, smoke, glass, liquids, translucent materials, reflective objects, soft shadows, realistic product grounding, or subject colors that conflict with all practical key colors.
 
 Use a concise confirmation like:
 
 ```text
-This likely needs true native transparency. The default Pi tool path uses a chroma-key background plus local removal, but true transparency requires the CLI fallback with gpt-image-1.5 because gpt-image-2 does not support background=transparent. It also requires OPENAI_API_KEY. Should I proceed with that CLI fallback?
+This likely needs native transparency. The Pi tool uses chroma-key removal. The API CLI supports native transparency in preview with gpt-image-2. It requires OPENAI_API_KEY and separate API billing. Should I use that fallback?
 ```
 
 ## Prompt augmentation
@@ -279,7 +279,7 @@ Constraints: change only the background; keep the product and its edges unchange
 - If the prompt is generic, add only the extra detail that will materially help.
 - If the prompt is already detailed, normalize it instead of expanding it.
 - For CLI fallback only, see `references/cli.md` and `references/image-api.md` for model, `quality`, `input_fidelity`, masks, output format, and output-path guidance.
-- For transparent images, use the built-in-first chroma-key workflow unless the request is complex enough to need true CLI transparency; ask before switching to CLI `gpt-image-1.5`.
+- For transparent images, use the built-in-first chroma-key workflow unless the request needs native CLI transparency; ask before switching to the API CLI.
 
 More principles shared by both modes: `references/prompting.md`.
 Copy/paste specs shared by both modes: `references/sample-prompts.md`.
@@ -291,8 +291,8 @@ Asset-type templates (website assets, game assets, wireframes, logo) are consoli
 
 The fallback CLI defaults to `gpt-image-2`.
 
-- Use `gpt-image-2` for new CLI/API workflows unless the request needs true model-native transparent output.
-- If a transparent request may need CLI fallback, ask before using `gpt-image-1.5` unless the user already explicitly requested `gpt-image-1.5`, `scripts/image_gen.py`, or CLI fallback. Explain that the built-in chroma-key path is the default, but true transparency requires `gpt-image-1.5` because `gpt-image-2` does not support `background=transparent`.
+- Keep `gpt-image-2` as the CLI default. For explicit 2.5 requests, use `gpt-image-2.5-flare` for fast generation or `gpt-image-2.5-sunburst` for editing precision. Both also accept `xhigh` and `max` quality and their `2026-09-08` snapshots. Use `size auto` or standard sizes; extended 2.5 resolution rules are not verified.
+- Native transparency is available in preview with CLI `gpt-image-2 --background transparent --output-format png` (or `webp`). Ask before switching from Pi to this separately billed API path.
 - `gpt-image-2` always uses high fidelity for image inputs; do not set `input_fidelity` with this model.
 - `gpt-image-2` supports `quality` values `low`, `medium`, `high`, and `auto`.
 - Use `quality low` for fast drafts, thumbnails, and quick iterations. Use `medium`, `high`, or `auto` for final assets, dense text, diagrams, identity-sensitive edits, or high-resolution outputs.

--- a/packages/pi-codex-image-gen/skills/imagegen/SKILL.md
+++ b/packages/pi-codex-image-gen/skills/imagegen/SKILL.md
@@ -26,6 +26,8 @@ Within CLI fallback, the CLI exposes three subcommands:
 
 Rules:
 - Use the Pi `codex_generate_image` tool by default for new image generation requests.
+- The tool's `model` parameter selects a Codex routing model, not Flare or Sunburst. Do not claim a specific served image model unless the response reports it. Read `details.reportedImage` for backend-reported output settings, then inspect the actual image; prompt requests for quality, dimensions, or transparency are not guarantees.
+- Do not automatically repeat quota, connection, timeout, or incomplete-stream failures. The remote generation may already have consumed quota.
 - Use `referencedImagePaths` for edits when every target has a local path. Use `numLastImagesToInclude` only when a target is available solely in recent conversation history. Never provide both selectors. Masks and advanced CLI-only controls still require confirmed CLI fallback.
 - Do not switch to CLI fallback for ordinary generation quality, size, or output file-path control.
 - If the user explicitly asks for a transparent image/background, stay on Pi `codex_generate_image` first: prompt for a flat removable chroma-key background, then remove it locally with the installed helper at `scripts/remove_chroma_key.py`.
@@ -39,7 +41,7 @@ Rules:
 Pi tool save-path policy:
 - In Pi tool mode, generated images are saved under Pi's agent directory by default: `<pi-agent-dir>/generated-images/<pi-session-id>/<image-call-id>.*`. The default Pi agent directory is `~/.pi/agent`, but it can be overridden with `PI_CODING_AGENT_DIR`; use Pi's configured agent directory, not a hardcoded home path.
 - Do not describe or rely on OS temp as the default Pi tool destination.
-- Do not describe or rely on a destination-path argument (if any) on the Pi `codex_generate_image` tool. If a specific location is needed, generate first and then copy the selected output from `<pi-agent-dir>/generated-images/<pi-session-id>/<image-call-id>.*`.
+- Use the tool's `save` and `saveDir` controls to choose a save directory. Custom mode appends a session directory; it does not accept an exact output filename. If an exact asset path is needed, copy the generated image there and leave the original in place.
 - Save-path precedence in Pi tool mode:
   1. If the user names a destination, copy the selected output there and leave the original in place.
   2. If the image is meant for the current project, copy the final selected image into the workspace before finishing and leave the original in place.
@@ -291,14 +293,14 @@ Asset-type templates (website assets, game assets, wireframes, logo) are consoli
 
 The fallback CLI defaults to `gpt-image-2`.
 
-- Keep `gpt-image-2` as the CLI default. For explicit 2.5 requests, use `gpt-image-2.5-flare` for fast generation or `gpt-image-2.5-sunburst` for editing precision. Both also accept `xhigh` and `max` quality and their `2026-09-08` snapshots. Use `size auto` or standard sizes; extended 2.5 resolution rules are not verified.
+- Keep `gpt-image-2` as the CLI default. For explicit 2.5 requests, use `gpt-image-2.5-flare` for fast generation or `gpt-image-2.5-sunburst` for editing precision. Both also accept `xhigh` and `max` quality and their `2026-09-08` snapshots. Both support the flexible size constraints below; sizes above `2560x1440` are experimental. Leave 2.5 `input_fidelity` unset; support for that control is not verified.
 - Native transparency is available in preview with CLI `gpt-image-2 --background transparent --output-format png` (or `webp`). Ask before switching from Pi to this separately billed API path.
 - `gpt-image-2` always uses high fidelity for image inputs; do not set `input_fidelity` with this model.
 - `gpt-image-2` supports `quality` values `low`, `medium`, `high`, and `auto`.
 - Use `quality low` for fast drafts, thumbnails, and quick iterations. Use `medium`, `high`, or `auto` for final assets, dense text, diagrams, identity-sensitive edits, or high-resolution outputs.
 - Square images are typically fastest to generate. Use `1024x1024` for fast square drafts.
 - If the user asks for 4K-style output, use `3840x2160` for landscape or `2160x3840` for portrait.
-- `gpt-image-2` size may be `auto` or `WIDTHxHEIGHT` if all constraints hold: max edge `<= 3840px`, both edges multiples of `16px`, long-to-short ratio `<= 3:1`, total pixels between `655,360` and `8,294,400`.
+- GPT Image 2 and 2.5 API size may be `auto` or `WIDTHxHEIGHT` if all constraints hold: max edge `<= 3840px`, both edges multiples of `16px`, long-to-short ratio `<= 3:1`, total pixels between `655,360` and `8,294,400`.
 
 Popular `gpt-image-2` sizes:
 - `1024x1024` square

--- a/packages/pi-codex-image-gen/skills/imagegen/references/cli.md
+++ b/packages/pi-codex-image-gen/skills/imagegen/references/cli.md
@@ -73,7 +73,7 @@ python "$IMAGE_GEN" edit \
 
 `gpt-image-2` is the default model for new CLI fallback work.
 
-For explicit Images 2.5 requests, use `--model gpt-image-2.5-flare` or `--model gpt-image-2.5-sunburst`. Their `2026-09-08` snapshots are also supported. Both accept `--quality xhigh` and `--quality max`. Use `--size auto` or standard sizes; extended 2.5 resolution rules and input-fidelity controls are not verified. These options do not apply to the Pi tool.
+For explicit Images 2.5 requests, use `--model gpt-image-2.5-flare` or `--model gpt-image-2.5-sunburst`. Their `2026-09-08` snapshots are also supported. Both accept `--quality xhigh` and `--quality max`, and the flexible size constraints below, including `1536x864`. Sizes above `2560x1440` are experimental. Leave 2.5 `--input-fidelity` unset; support is not verified. These options do not apply to the Pi tool.
 
 - Use `--quality low` for fast drafts, thumbnails, and quick iterations.
 - Use `--quality medium`, `--quality high`, or `--quality auto` for final assets, dense text, diagrams, identity-sensitive edits, and high-resolution outputs.
@@ -231,7 +231,7 @@ Notes:
 - For many requested deliverable assets, provide one prompt/job per distinct asset and use semantic filenames when possible.
 
 ## CLI notes
-- Supported sizes depend on the model. `gpt-image-2` supports flexible constrained sizes; older GPT Image models support `1024x1024`, `1536x1024`, `1024x1536`, or `auto`.
+- Supported sizes depend on the model. GPT Image 2 and 2.5 (including the documented snapshots) support flexible constrained sizes; older GPT Image models support `1024x1024`, `1536x1024`, `1024x1536`, or `auto`.
 - Native transparent CLI outputs require `output_format` to be `png` or `webp`. GPT Image 2 support is in preview.
 - `--prompt-file`, `--output-compression`, `--moderation`, `--max-attempts`, `--fail-fast`, `--force`, and `--no-augment` are supported.
 - This CLI is intended for GPT Image models. Do not assume older non-GPT image-model behavior applies here.

--- a/packages/pi-codex-image-gen/skills/imagegen/references/cli.md
+++ b/packages/pi-codex-image-gen/skills/imagegen/references/cli.md
@@ -1,6 +1,6 @@
 # CLI reference (`scripts/image_gen.py`)
 
-This file is for the fallback CLI mode only. Read it when the user explicitly asks to use `scripts/image_gen.py` / CLI / API / model controls, or after the user explicitly confirms that a transparent-output request should use the `gpt-image-1.5` true-transparency fallback path.
+This file is for the fallback CLI mode only. Read it when the user requests CLI/API controls or confirms a native transparency API fallback.
 
 `generate-batch` is a CLI subcommand in this fallback path. It is not a top-level mode of the skill.
 The word `batch` in a user request is not CLI opt-in by itself.
@@ -73,12 +73,14 @@ python "$IMAGE_GEN" edit \
 
 `gpt-image-2` is the default model for new CLI fallback work.
 
+For explicit Images 2.5 requests, use `--model gpt-image-2.5-flare` or `--model gpt-image-2.5-sunburst`. Their `2026-09-08` snapshots are also supported. Both accept `--quality xhigh` and `--quality max`. Use `--size auto` or standard sizes; extended 2.5 resolution rules and input-fidelity controls are not verified. These options do not apply to the Pi tool.
+
 - Use `--quality low` for fast drafts, thumbnails, and quick iterations.
 - Use `--quality medium`, `--quality high`, or `--quality auto` for final assets, dense text, diagrams, identity-sensitive edits, and high-resolution outputs.
 - Square images are typically fastest. Use `--size 1024x1024` for quick square drafts.
 - If the user asks for 4K-style output, use `--size 3840x2160` for landscape or `--size 2160x3840` for portrait.
 - Do not pass `--input-fidelity` with `gpt-image-2`; this model always uses high fidelity for image inputs.
-- Do not use `--background transparent` with `gpt-image-2`; the default transparent-image workflow uses Pi `codex_generate_image` on a flat chroma-key background plus local removal. Use `gpt-image-1.5` only after the user explicitly confirms the true-transparent CLI fallback, unless they already requested `gpt-image-1.5`, `scripts/image_gen.py`, or CLI fallback.
+- `gpt-image-2` supports `--background transparent` in preview with PNG or WebP. Confirm the separately billed API fallback before switching from Pi's chroma-key path.
 
 Popular `gpt-image-2` sizes:
 - `1024x1024`
@@ -140,7 +142,7 @@ python "$IMAGE_GEN" generate \
   --out output/imagegen/product-cutout.png
 ```
 
-When using this path, explain briefly that Pi `codex_generate_image` plus chroma-key removal is the default transparent-image path, but this request needs true model-native transparency. `gpt-image-2` does not support `background=transparent`, so `gpt-image-1.5` is required for this confirmed fallback.
+The older-model example above remains available when explicitly requested. Prefer `--model gpt-image-2` for native transparency preview. Explain that this API fallback requires an API key and separate billing; Pi still uses chroma-key removal.
 
 ## Quality, input fidelity, and masks (CLI fallback only)
 These are explicit CLI controls. They are not Pi `codex_generate_image` tool arguments.
@@ -230,7 +232,7 @@ Notes:
 
 ## CLI notes
 - Supported sizes depend on the model. `gpt-image-2` supports flexible constrained sizes; older GPT Image models support `1024x1024`, `1536x1024`, `1024x1536`, or `auto`.
-- True transparent CLI outputs require `output_format` to be `png` or `webp` and are not supported by `gpt-image-2`.
+- Native transparent CLI outputs require `output_format` to be `png` or `webp`. GPT Image 2 support is in preview.
 - `--prompt-file`, `--output-compression`, `--moderation`, `--max-attempts`, `--fail-fast`, `--force`, and `--no-augment` are supported.
 - This CLI is intended for GPT Image models. Do not assume older non-GPT image-model behavior applies here.
 

--- a/packages/pi-codex-image-gen/skills/imagegen/references/image-api.md
+++ b/packages/pi-codex-image-gen/skills/imagegen/references/image-api.md
@@ -1,21 +1,27 @@
 # Image API quick reference
 
-This file is for the fallback CLI mode only. Use it when the user explicitly asks to use `scripts/image_gen.py` / CLI / API / model controls, or after the user explicitly confirms that a transparent-output request should use the `gpt-image-1.5` true-transparency fallback path.
+This file is for the fallback CLI mode only. Use it when the user explicitly requests CLI/API controls or confirms a native transparency API fallback.
 
 These parameters describe the Image API and bundled CLI fallback surface. Do not assume they are normal arguments on the Pi `codex_generate_image` tool.
 
 ## Scope
-- This fallback CLI is intended for GPT Image models (`gpt-image-2`, `gpt-image-1.5`, `gpt-image-1`, and `gpt-image-1-mini`).
+- This fallback CLI supports GPT Image models, including `gpt-image-2.5-flare` and `gpt-image-2.5-sunburst`.
 - The Pi `codex_generate_image` tool and the fallback CLI do not expose the same controls.
 
 ## Model summary
 
 | Model | Quality | Input fidelity | Resolutions | Recommended use |
 | --- | --- | --- | --- | --- |
+| `gpt-image-2.5-flare` | `low`, `medium`, `high`, `xhigh`, `max`, `auto` | Leave unset; not verified | Use `auto` or standard sizes; extended rules not verified | Optional fast generation |
+| `gpt-image-2.5-sunburst` | `low`, `medium`, `high`, `xhigh`, `max`, `auto` | Leave unset; not verified | Use `auto` or standard sizes; extended rules not verified | Optional precision editing |
 | `gpt-image-2` | `low`, `medium`, `high`, `auto` | Always high fidelity for image inputs; do not set `input_fidelity` | `auto` or flexible sizes that satisfy the constraints below | Default for new CLI/API workflows: high-quality generation and editing, text-heavy images, photorealism, compositing, identity-sensitive edits, and workflows where fewer retries matter |
 | `gpt-image-1.5` | `low`, `medium`, `high`, `auto` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | True transparent-background fallback and backward-compatible workflows |
 | `gpt-image-1` | `low`, `medium`, `high`, `auto` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Legacy compatibility |
 | `gpt-image-1-mini` | `low`, `medium`, `high`, `auto` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Cost-sensitive draft batches and lower-stakes previews |
+
+The CLI also recognizes the `2026-09-08` snapshots of both 2.5 models for extended quality settings. Defaults remain unchanged.
+
+Sources: [Flare](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare), [Sunburst](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst), and [image tool options](https://developers.openai.com/api/docs/guides/tools-image-generation).
 
 ## gpt-image-2 sizes
 
@@ -50,7 +56,7 @@ Square images are typically fastest to generate. For 4K-style output, use `3840x
 - `model`: image model
 - `n`: number of images (1-10)
 - `size`: `auto` by default for `gpt-image-2`; flexible `WIDTHxHEIGHT` sizes are allowed only for `gpt-image-2`; older GPT Image models use `1024x1024`, `1536x1024`, `1024x1536`, or `auto`
-- `quality`: `low`, `medium`, `high`, or `auto`
+- `quality`: `low`, `medium`, `high`, or `auto`; the documented 2.5 models also accept `xhigh` and `max`
 - `background`: output transparency behavior (`transparent`, `opaque`, or `auto`) for generated output; this is not the same thing as the prompt's visual scene/backdrop
 - `output_format`: `png` (default), `jpeg`, `webp`
 - `output_compression`: 0-100 (jpeg/webp only)
@@ -68,9 +74,9 @@ Model-specific note for `input_fidelity`:
 
 ## Transparent backgrounds
 
-`gpt-image-2` does not currently support the Image API `background=transparent` parameter. The skill's default transparent-image path is Pi `codex_generate_image` with a flat chroma-key background, followed by local alpha extraction with `python "scripts/remove_chroma_key.py"`.
+`gpt-image-2` supports `background=transparent` in preview with PNG or WebP. The Pi tool has no background parameter, so its default path remains chroma-key generation followed by local alpha extraction.
 
-Use CLI `gpt-image-1.5` with `background=transparent` and a transparent-capable output format such as `png` or `webp` only after the user explicitly confirms that fallback, unless they already requested `gpt-image-1.5`, `scripts/image_gen.py`, or CLI fallback. If the user asks for true/native transparency, the subject is too complex for clean chroma-key removal, or local background removal fails validation, explain the tradeoff and ask before switching.
+Use CLI `gpt-image-2 --background transparent --output-format png` (or `webp`) only after the user chooses the API path. Explain that it requires an API key and separate billing. Do not silently switch to an older model if preview transparency fails.
 
 ## Output
 - `data[]` list with `b64_json` per image

--- a/packages/pi-codex-image-gen/skills/imagegen/references/image-api.md
+++ b/packages/pi-codex-image-gen/skills/imagegen/references/image-api.md
@@ -12,8 +12,8 @@ These parameters describe the Image API and bundled CLI fallback surface. Do not
 
 | Model | Quality | Input fidelity | Resolutions | Recommended use |
 | --- | --- | --- | --- | --- |
-| `gpt-image-2.5-flare` | `low`, `medium`, `high`, `xhigh`, `max`, `auto` | Leave unset; not verified | Use `auto` or standard sizes; extended rules not verified | Optional fast generation |
-| `gpt-image-2.5-sunburst` | `low`, `medium`, `high`, `xhigh`, `max`, `auto` | Leave unset; not verified | Use `auto` or standard sizes; extended rules not verified | Optional precision editing |
+| `gpt-image-2.5-flare` | `low`, `medium`, `high`, `xhigh`, `max`, `auto` | Leave unset; not verified | `auto` or flexible sizes below | Optional fast generation |
+| `gpt-image-2.5-sunburst` | `low`, `medium`, `high`, `xhigh`, `max`, `auto` | Leave unset; not verified | `auto` or flexible sizes below | Optional precision editing |
 | `gpt-image-2` | `low`, `medium`, `high`, `auto` | Always high fidelity for image inputs; do not set `input_fidelity` | `auto` or flexible sizes that satisfy the constraints below | Default for new CLI/API workflows: high-quality generation and editing, text-heavy images, photorealism, compositing, identity-sensitive edits, and workflows where fewer retries matter |
 | `gpt-image-1.5` | `low`, `medium`, `high`, `auto` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | True transparent-background fallback and backward-compatible workflows |
 | `gpt-image-1` | `low`, `medium`, `high`, `auto` | `low`, `high` | `1024x1024`, `1024x1536`, `1536x1024`, `auto` | Legacy compatibility |
@@ -21,16 +21,18 @@ These parameters describe the Image API and bundled CLI fallback surface. Do not
 
 The CLI also recognizes the `2026-09-08` snapshots of both 2.5 models for extended quality settings. Defaults remain unchanged.
 
-Sources: [Flare](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare), [Sunburst](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst), and [image tool options](https://developers.openai.com/api/docs/guides/tools-image-generation).
+Sources: [Flare](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare), [Sunburst](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst), [image generation guide](https://developers.openai.com/api/docs/guides/image-generation.md), and [image tool options](https://developers.openai.com/api/docs/guides/tools-image-generation).
 
-## gpt-image-2 sizes
+## Flexible sizes: GPT Image 2 and 2.5
 
-`gpt-image-2` accepts `auto` or any `WIDTHxHEIGHT` size that satisfies all constraints:
+GPT Image 2 and both 2.5 models accept `auto` or any `WIDTHxHEIGHT` size that satisfies all constraints. The CLI also recognizes their documented dated snapshots.
 
 - Maximum edge length must be less than or equal to `3840px`.
 - Both edges must be multiples of `16px`.
 - Long edge to short edge ratio must not exceed `3:1`.
 - Total pixels must be at least `655,360` and no more than `8,294,400`.
+
+For 2.5, resolutions above `2560x1440` are experimental.
 
 Popular sizes:
 
@@ -55,7 +57,7 @@ Square images are typically fastest to generate. For 4K-style output, use `3840x
 - `prompt`: text prompt
 - `model`: image model
 - `n`: number of images (1-10)
-- `size`: `auto` by default for `gpt-image-2`; flexible `WIDTHxHEIGHT` sizes are allowed only for `gpt-image-2`; older GPT Image models use `1024x1024`, `1536x1024`, `1024x1536`, or `auto`
+- `size`: `auto` by default; GPT Image 2 and 2.5 accept flexible `WIDTHxHEIGHT` sizes under the constraints above; older models use `1024x1024`, `1536x1024`, `1024x1536`, or `auto`
 - `quality`: `low`, `medium`, `high`, or `auto`; the documented 2.5 models also accept `xhigh` and `max`
 - `background`: output transparency behavior (`transparent`, `opaque`, or `auto`) for generated output; this is not the same thing as the prompt's visual scene/backdrop
 - `output_format`: `png` (default), `jpeg`, `webp`
@@ -75,6 +77,8 @@ Model-specific note for `input_fidelity`:
 ## Transparent backgrounds
 
 `gpt-image-2` supports `background=transparent` in preview with PNG or WebP. The Pi tool has no background parameter, so its default path remains chroma-key generation followed by local alpha extraction.
+
+Both 2.5 API models also document native transparency with PNG or WebP. This public API capability does not establish that subscription parameters are honored.
 
 Use CLI `gpt-image-2 --background transparent --output-format png` (or `webp`) only after the user chooses the API path. Explain that it requires an API key and separate billing. Do not silently switch to an older model if preview transparency fails.
 

--- a/packages/pi-codex-image-gen/skills/imagegen/references/prompting.md
+++ b/packages/pi-codex-image-gen/skills/imagegen/references/prompting.md
@@ -79,7 +79,7 @@ Do not add:
 - Ask for crisp edges, generous padding, and no use of the key color inside the subject.
 - After generation, remove the background locally with `python "scripts/remove_chroma_key.py" --input <source> --out <final.png> --auto-key border --soft-matte --transparent-threshold 12 --opaque-threshold 220 --despill` and validate the alpha result before shipping it.
 - Use soft matte and despill for antialiased edges; hard tolerance-only removal is mainly for flat pixel-art or exact-color fixtures.
-- Use CLI `gpt-image-1.5 --background transparent --output-format png` only after the user explicitly confirms the fallback, or when the user already explicitly requested `gpt-image-1.5`, `scripts/image_gen.py`, or CLI fallback. Ask first for true/native transparency requests, failed chroma-key validation, or complex transparent subjects such as hair, fur, glass, smoke, liquids, translucent materials, reflective objects, or soft shadows.
+- Use CLI `gpt-image-2 --background transparent --output-format png` (preview) only after the user chooses the separately billed API fallback. Offer it for native transparency requests, failed chroma-key validation, or complex subjects such as hair, glass, smoke, or soft shadows.
 
 ## Fallback-only execution controls
 - `quality`, `input_fidelity`, explicit masks, output format, and output paths are fallback-only execution controls.
@@ -87,7 +87,7 @@ Do not add:
 - If the user explicitly chooses CLI fallback, see `references/cli.md` and `references/image-api.md` for those controls.
 - In CLI fallback mode, `gpt-image-2` is the default. It supports `quality=low|medium|high|auto`; use `low` for fast drafts and thumbnails, and move to `medium`, `high`, or `auto` for final assets.
 - `gpt-image-2` always uses high fidelity for image inputs, so do not set `input_fidelity` with that model.
-- If a transparent request needs true CLI transparency, ask before using `gpt-image-1.5` unless the user already explicitly chose it. Explain that Pi-tool chroma-key removal is the default path, but `gpt-image-2` does not support `background=transparent`.
+- For native transparency, offer the GPT Image 2 API preview with PNG or WebP. Ask before switching from Pi's chroma-key path to API billing.
 - If the user asks for 4K-style output with `gpt-image-2`, use `3840x2160` for landscape or `2160x3840` for portrait.
 
 ## Use-case tips

--- a/packages/pi-codex-image-gen/skills/imagegen/references/sample-prompts.md
+++ b/packages/pi-codex-image-gen/skills/imagegen/references/sample-prompts.md
@@ -19,7 +19,7 @@ CLI model notes:
 - `gpt-image-2` is the fallback CLI default for new workflows.
 - `gpt-image-2` supports `quality` values `low`, `medium`, `high`, and `auto`.
 - For 4K-style `gpt-image-2` output, use `3840x2160` or `2160x3840`.
-- If transparent output needs true CLI fallback, ask before using `gpt-image-1.5` unless the user already explicitly requested `gpt-image-1.5`, `scripts/image_gen.py`, or CLI fallback. Explain that Pi-tool chroma-key removal is the default path, but `gpt-image-2` does not support `background=transparent`.
+- For native transparency, offer CLI `gpt-image-2 --background transparent --output-format png` (preview). Ask before switching from Pi's chroma-key path to separate API billing.
 - Do not set `input_fidelity` with `gpt-image-2`; image inputs already use high fidelity.
 
 For prompting principles (structure, specificity, invariants, iteration), see `references/prompting.md`.
@@ -395,7 +395,7 @@ Scene/backdrop: perfectly flat solid #00ff00 chroma-key background for local bac
 Constraints: background must be one uniform color with no shadows, gradients, texture, reflections, floor plane, or lighting variation; crisp silhouette; generous padding; no halos or fringing; preserve label text exactly; no restyling; do not use #00ff00 anywhere in the subject
 ```
 
-Post-process note: after Pi tool generation, run `python "scripts/remove_chroma_key.py" --input <source> --out <final.png> --auto-key border --soft-matte --transparent-threshold 12 --opaque-threshold 220 --despill`. Ask before using CLI `gpt-image-1.5 --background transparent --output-format png` for true/native transparency, failed chroma-key validation, or complex subjects such as hair, fur, glass, smoke, liquids, translucent materials, reflections, or soft shadows, unless the user already explicitly requested `gpt-image-1.5`, `scripts/image_gen.py`, or CLI fallback.
+Post-process note: after Pi tool generation, run `python "scripts/remove_chroma_key.py" --input <source> --out <final.png> --auto-key border --soft-matte --transparent-threshold 12 --opaque-threshold 220 --despill`. For native transparency, failed validation, or complex subjects, offer CLI `gpt-image-2 --background transparent --output-format png` (preview). Ask before switching to separate API billing.
 
 ### style-transfer
 ```

--- a/packages/pi-codex-image-gen/skills/imagegen/scripts/image_gen.py
+++ b/packages/pi-codex-image-gen/skills/imagegen/scripts/image_gen.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Fallback CLI for explicit image generation or editing with GPT Image models.
 
-Used only when the user explicitly opts into CLI fallback mode, or when explicit
-transparent output requires the `gpt-image-1.5` fallback path.
+Used only when the user explicitly opts into CLI fallback mode, including
+confirmed native transparency requests with separate API billing.
 
 Defaults to gpt-image-2 and a structured prompt augmentation workflow.
 """
@@ -154,9 +154,19 @@ def _validate_size(size: str, model: str) -> None:
         )
 
 
-def _validate_quality(quality: str) -> None:
-    if quality not in ALLOWED_QUALITIES:
-        _die("quality must be one of low, medium, high, or auto.")
+def _is_gpt_image_2_5(model: str) -> bool:
+    return model in {
+        "gpt-image-2.5-flare",
+        "gpt-image-2.5-flare-2026-09-08",
+        "gpt-image-2.5-sunburst",
+        "gpt-image-2.5-sunburst-2026-09-08",
+    }
+
+
+def _validate_quality(quality: str, model: str) -> None:
+    allowed = ALLOWED_QUALITIES | {"xhigh", "max"} if _is_gpt_image_2_5(model) else ALLOWED_QUALITIES
+    if quality not in allowed:
+        _die(f"quality for {model} must be one of {', '.join(sorted(allowed))}.")
 
 
 def _validate_background(background: Optional[str]) -> None:
@@ -189,11 +199,6 @@ def _validate_model_specific_options(
 ) -> None:
     if model != GPT_IMAGE_2_MODEL:
         return
-    if background == "transparent":
-        _die(
-            "transparent backgrounds are not supported in gpt-image-2, the latest model. "
-            "Use --model gpt-image-1.5 --background transparent --output-format png instead."
-        )
     if input_fidelity is not None:
         _die(
             "input_fidelity is not supported in gpt-image-2 because image inputs always use high fidelity for this model."
@@ -210,7 +215,7 @@ def _validate_generate_payload(payload: Dict[str, Any]) -> None:
     quality = str(payload.get("quality", DEFAULT_QUALITY))
     background = payload.get("background")
     _validate_size(size, model)
-    _validate_quality(quality)
+    _validate_quality(quality, model)
     _validate_background(background)
     _validate_model_specific_options(model=model, background=background)
     oc = payload.get("output_compression")
@@ -978,7 +983,7 @@ def main() -> int:
 
     _validate_model(args.model)
     _validate_size(args.size, args.model)
-    _validate_quality(args.quality)
+    _validate_quality(args.quality, args.model)
     _validate_background(args.background)
     _validate_model_specific_options(
         model=args.model,

--- a/packages/pi-codex-image-gen/skills/imagegen/scripts/image_gen.py
+++ b/packages/pi-codex-image-gen/skills/imagegen/scripts/image_gen.py
@@ -118,7 +118,7 @@ def _parse_size(size: str) -> Optional[Tuple[int, int]]:
     return int(match.group(1)), int(match.group(2))
 
 
-def _validate_gpt_image_2_size(size: str) -> None:
+def _validate_flexible_size(size: str, model: str) -> None:
     if size == "auto":
         return
 
@@ -132,26 +132,30 @@ def _validate_gpt_image_2_size(size: str) -> None:
     total_pixels = width * height
 
     if max_edge > GPT_IMAGE_2_MAX_EDGE:
-        _die("gpt-image-2 size maximum edge length must be less than or equal to 3840px.")
+        _die(f"{model} size maximum edge length must be less than or equal to 3840px.")
     if width % 16 != 0 or height % 16 != 0:
-        _die("gpt-image-2 size width and height must be multiples of 16px.")
+        _die(f"{model} size width and height must be multiples of 16px.")
     if max_edge / min_edge > GPT_IMAGE_2_MAX_RATIO:
-        _die("gpt-image-2 size long edge to short edge ratio must not exceed 3:1.")
+        _die(f"{model} size long edge to short edge ratio must not exceed 3:1.")
     if total_pixels < GPT_IMAGE_2_MIN_PIXELS or total_pixels > GPT_IMAGE_2_MAX_PIXELS:
         _die(
-            "gpt-image-2 size total pixels must be at least 655,360 and no more than 8,294,400."
+            f"{model} size total pixels must be at least 655,360 and no more than 8,294,400."
         )
 
 
 def _validate_size(size: str, model: str) -> None:
-    if model == GPT_IMAGE_2_MODEL:
-        _validate_gpt_image_2_size(size)
+    if _is_gpt_image_2(model) or _is_gpt_image_2_5(model):
+        _validate_flexible_size(size, model)
         return
 
     if size not in ALLOWED_LEGACY_SIZES:
         _die(
             "size must be one of 1024x1024, 1536x1024, 1024x1536, or auto for this GPT Image model."
         )
+
+
+def _is_gpt_image_2(model: str) -> bool:
+    return model in {GPT_IMAGE_2_MODEL, "gpt-image-2-2026-04-21"}
 
 
 def _is_gpt_image_2_5(model: str) -> bool:
@@ -197,7 +201,7 @@ def _validate_model_specific_options(
     background: Optional[str],
     input_fidelity: Optional[str] = None,
 ) -> None:
-    if model != GPT_IMAGE_2_MODEL:
+    if not _is_gpt_image_2(model):
         return
     if input_fidelity is not None:
         _die(

--- a/packages/pi-codex-image-gen/src/codex-response.ts
+++ b/packages/pi-codex-image-gen/src/codex-response.ts
@@ -1,0 +1,271 @@
+// The subscription Responses contract is private. Keep its parser and safety
+// boundaries separate from Pi tool registration and file handling.
+export const REQUEST_TIMEOUT_MS = 5 * 60_000;
+export const MAX_RESPONSE_BYTES = 100 * 1024 * 1024;
+export const MAX_IMAGE_BYTES = 32 * 1024 * 1024;
+const MAX_ERROR_BYTES = 16 * 1024;
+const MAX_TEXT_CHARS = 4000;
+
+export interface ReportedImage {
+	model?: string;
+	size?: string;
+	quality?: string;
+	background?: string;
+	outputFormat?: string;
+}
+
+export interface ParsedCodexResponse {
+	image?: {
+		id: string;
+		status: "completed";
+		result: string;
+		revisedPrompt?: string;
+		reported: ReportedImage;
+	};
+	text: string[];
+	responseId?: string;
+	usage?: unknown;
+}
+
+function object(value: unknown): Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? value as Record<string, unknown> : {};
+}
+
+function text(value: unknown, secrets: string[] = []): string {
+	if (typeof value !== "string") return "";
+	let result = value;
+	for (const secret of secrets) {
+		if (secret) result = result.split(secret).join("[redacted]");
+	}
+	return result.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ").slice(0, MAX_TEXT_CHARS);
+}
+
+function identifier(value: unknown, secrets: string[]): string | undefined {
+	return typeof value === "string" && /^[a-zA-Z0-9_-]{1,128}$/.test(value)
+		&& !secrets.some(secret => secret && value.includes(secret)) ? value : undefined;
+}
+
+export function abortable<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const abort = () => reject(signal.reason);
+		if (signal.aborted) abort();
+		else signal.addEventListener("abort", abort, { once: true });
+		work.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+	});
+}
+
+export async function withRequestDeadline<T>(
+	signal: AbortSignal | undefined,
+	run: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+	const controller = new AbortController();
+	const abort = () => controller.abort(new Error("Image generation was aborted."));
+	if (signal?.aborted) abort();
+	else signal?.addEventListener("abort", abort, { once: true });
+	const timer = setTimeout(() => controller.abort(new Error(
+		"Image generation timed out after 5 minutes. The backend may still finish; no automatic retry was made.",
+	)), REQUEST_TIMEOUT_MS);
+	try {
+		controller.signal.throwIfAborted();
+		return await run(controller.signal);
+	} catch (error) {
+		if (controller.signal.aborted) throw controller.signal.reason;
+		throw error;
+	} finally {
+		clearTimeout(timer);
+		signal?.removeEventListener("abort", abort);
+	}
+}
+
+async function* chunks(response: Response, limit: number, signal: AbortSignal): AsyncGenerator<Uint8Array> {
+	if (!response.body) throw new Error("Codex response did not include a stream body.");
+	const reader = response.body.getReader();
+	let bytes = 0;
+	try {
+		const declared = Number(response.headers.get("content-length"));
+		if (declared > limit) throw new Error("Codex response exceeded the size limit.");
+		while (true) {
+			signal.throwIfAborted();
+			const { done, value } = await abortable(reader.read(), signal);
+			if (done) break;
+			bytes += value.byteLength;
+			if (bytes > limit) throw new Error("Codex response exceeded the size limit.");
+			yield value;
+		}
+	} finally {
+		// Do not let a stalled stream cancellation defeat the request deadline.
+		void reader.cancel().catch(() => undefined);
+		reader.releaseLock();
+	}
+}
+
+const QUOTA_CODES = new Set([
+	"insufficient_quota", "quota_exceeded", "usage_limit_reached", "usage_limit_exceeded",
+	"billing_hard_limit_reached", "billing_not_active",
+]);
+
+function errorHint(error: unknown): string {
+	const { code, type } = object(error);
+	if (QUOTA_CODES.has(String(code)) || QUOTA_CODES.has(String(type))) {
+		return "Codex subscription quota is unavailable or exhausted. Check your plan or wait for its reset.";
+	}
+	if (code === "moderation_blocked" || type === "image_generation_user_error") {
+		return "Codex could not generate this image. Review the prompt and input images before trying again.";
+	}
+	return "Codex could not complete the image request.";
+}
+
+export async function httpFailure(response: Response, signal: AbortSignal): Promise<{ message: string; retry: boolean }> {
+	if (response.headers.get("cf-mitigated") === "challenge") {
+		void response.body?.cancel().catch(() => undefined);
+		return { message: "Codex connection was challenged by Cloudflare. This does not establish model or subscription availability.", retry: false };
+	}
+	let body = "";
+	try {
+		const decoder = new TextDecoder();
+		for await (const chunk of chunks(response, MAX_ERROR_BYTES, signal)) body += decoder.decode(chunk, { stream: true });
+		body += decoder.decode();
+	} catch {
+		signal.throwIfAborted();
+		// A large or unreadable error body is deliberately not exposed.
+	}
+	let error: Record<string, unknown> = {};
+	try {
+		error = object(object(JSON.parse(body)).error);
+	} catch { /* HTML and other non-JSON error bodies are not diagnostics. */ }
+	const terminal = QUOTA_CODES.has(String(error.code)) || QUOTA_CODES.has(String(error.type))
+		|| error.code === "moderation_blocked" || error.type === "image_generation_user_error";
+	const hint = response.status === 401
+		? "Codex login was rejected. Run /login for openai-codex again."
+		: response.status === 403
+			? "Codex access was denied. This can be a connection or account restriction; it does not identify the image model."
+			: errorHint(error);
+	return {
+		message: `Codex image request failed (HTTP ${response.status}). ${hint}`,
+		retry: !terminal && [429, 500, 502, 503, 504].includes(response.status),
+	};
+}
+
+function reportedImage(item: Record<string, unknown>, secrets: string[]): ReportedImage {
+	const reported: ReportedImage = {};
+	const model = item.model;
+	if (typeof model === "string" && /^gpt-image-[a-z0-9.-]{1,80}$/.test(model)
+		&& !secrets.some(secret => secret && model.includes(secret))) reported.model = model;
+	if (typeof item.size === "string" && /^[1-9]\d{0,4}x[1-9]\d{0,4}$/.test(item.size)) reported.size = item.size;
+	if (typeof item.quality === "string" && ["low", "medium", "high", "xhigh", "max", "auto"].includes(item.quality)) reported.quality = item.quality;
+	if (typeof item.background === "string" && ["transparent", "opaque", "auto"].includes(item.background)) reported.background = item.background;
+	if (typeof item.output_format === "string" && ["png", "jpeg", "webp"].includes(item.output_format)) reported.outputFormat = item.output_format;
+	return reported;
+}
+
+export async function parseCodexSse(
+	response: Response,
+	signal: AbortSignal,
+	secrets: string[],
+	onProgress?: (stage: string) => void,
+): Promise<ParsedCodexResponse> {
+	const parsed: ParsedCodexResponse = { text: [] };
+	let completed = false;
+	let textChars = 0;
+	let lastStage: string | undefined;
+	const image = (value: unknown) => {
+		const item = object(value);
+		if (item.type !== "image_generation_call") return;
+		if (parsed.image) throw new Error("Codex returned more than one image. No automatic retry was made.");
+		if (item.status !== "completed") throw new Error("Codex image generation did not complete.");
+		if (typeof item.result !== "string" || !item.result) throw new Error("Codex image_generation_call did not contain image data.");
+		if (item.result.length > Math.ceil(MAX_IMAGE_BYTES / 3) * 4) throw new Error("Codex image exceeded the 32 MiB size limit.");
+		parsed.image = {
+			id: identifier(item.id, secrets) ?? "image_generation",
+			status: "completed",
+			result: item.result,
+			revisedPrompt: text(item.revised_prompt, secrets) || undefined,
+			reported: reportedImage(item, secrets),
+		};
+	};
+	const handle = (frame: string) => {
+		const data = frame.split(/\r?\n/).filter(line => line.startsWith("data:")).map(line => line.slice(5).trim()).join("\n");
+		if (!data || data === "[DONE]") return;
+		let event: Record<string, unknown>;
+		try { event = object(JSON.parse(data)); }
+		catch { throw new Error("Codex returned an invalid stream event. No automatic retry was made."); }
+		switch (event.type) {
+			case "error":
+			case "response.failed":
+				throw new Error(errorHint(object(event.response).error ?? event.error ?? event));
+			case "response.incomplete":
+				throw new Error("Codex response was incomplete. No automatic retry was made.");
+			case "response.created":
+				parsed.responseId = identifier(object(event.response).id, secrets);
+				break;
+			case "response.output_text.delta":
+				if (typeof event.delta === "string" && textChars < MAX_TEXT_CHARS) {
+					const delta = event.delta.slice(0, MAX_TEXT_CHARS - textChars);
+					parsed.text.push(delta);
+					textChars += delta.length;
+				}
+				break;
+			case "response.output_item.done":
+				image(event.item);
+				break;
+			case "response.completed": {
+				const final = object(event.response);
+				parsed.responseId = identifier(final.id, secrets) ?? parsed.responseId;
+				// Usage contains numeric counters only; never persist arbitrary response objects.
+				const usage = object(final.usage);
+				const counters: Record<string, unknown> = Object.fromEntries(
+					["input_tokens", "output_tokens", "total_tokens"].flatMap(key =>
+						typeof usage[key] === "number" && Number.isFinite(usage[key]) && usage[key] >= 0
+							? [[key, usage[key]]] : []),
+				);
+				for (const [key, fields] of [
+					["input_tokens_details", ["cached_tokens"]],
+					["output_tokens_details", ["reasoning_tokens"]],
+				] as const) {
+					const values = object(usage[key]);
+					const details = Object.fromEntries(fields.flatMap(field =>
+						typeof values[field] === "number" && Number.isFinite(values[field]) && values[field] >= 0
+							? [[field, values[field]]] : []));
+					if (Object.keys(details).length) counters[key] = details;
+				}
+				if (Object.keys(counters).length) parsed.usage = counters;
+				if (!parsed.image && Array.isArray(final.output)) final.output.forEach(image);
+				completed = true;
+				break;
+			}
+			case "response.image_generation_call.in_progress":
+			case "response.image_generation_call.generating":
+			case "response.image_generation_call.completed":
+				if (event.type !== lastStage) {
+					lastStage = event.type;
+					onProgress?.(event.type.split(".").at(-1)!);
+				}
+				break;
+		}
+	};
+	const decoder = new TextDecoder();
+	let buffer = "";
+	let scanFrom = 0;
+	for await (const chunk of chunks(response, MAX_RESPONSE_BYTES, signal)) {
+		buffer += decoder.decode(chunk, { stream: true });
+		const separator = /\r?\n\r?\n/g;
+		separator.lastIndex = scanFrom;
+		let match: RegExpExecArray | null;
+		while ((match = separator.exec(buffer))) {
+			handle(buffer.slice(0, match.index));
+			buffer = buffer.slice(match.index + match[0].length);
+			if (completed) break;
+			separator.lastIndex = 0;
+		}
+		if (completed) break;
+		scanFrom = Math.max(0, buffer.length - 3);
+	}
+	if (!completed) {
+		buffer += decoder.decode();
+		if (buffer.trim()) handle(buffer);
+	}
+	if (!completed) throw new Error("Codex stream ended before completion. The backend may still finish; no automatic retry was made.");
+	parsed.text = [text(parsed.text.join(""), secrets)];
+	return parsed;
+}

--- a/packages/pi-codex-image-gen/src/codex-response.ts
+++ b/packages/pi-codex-image-gen/src/codex-response.ts
@@ -38,7 +38,10 @@ function text(value: unknown, secrets: string[] = []): string {
 	for (const secret of secrets) {
 		if (secret) result = result.split(secret).join("[redacted]");
 	}
-	return result.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ").slice(0, MAX_TEXT_CHARS);
+	// Also hide a JWT cut short by the text bound; exact-token matching alone
+	// cannot redact a credential that arrives across the truncation boundary.
+	return result.replace(/\beyJ[A-Za-z0-9_.-]*/g, "[redacted]")
+		.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ").slice(0, MAX_TEXT_CHARS);
 }
 
 function identifier(value: unknown, secrets: string[]): string | undefined {
@@ -87,7 +90,14 @@ async function* chunks(response: Response, limit: number, signal: AbortSignal): 
 		if (declared > limit) throw new Error("Codex response exceeded the size limit.");
 		while (true) {
 			signal.throwIfAborted();
-			const { done, value } = await abortable(reader.read(), signal);
+			let part: ReadableStreamReadResult<Uint8Array>;
+			try {
+				part = await abortable(reader.read(), signal);
+			} catch {
+				signal.throwIfAborted();
+				throw new Error("Codex response stream was interrupted. The backend may still finish; no automatic retry was made.");
+			}
+			const { done, value } = part;
 			if (done) break;
 			bytes += value.byteLength;
 			if (bytes > limit) throw new Error("Codex response exceeded the size limit.");
@@ -102,12 +112,17 @@ async function* chunks(response: Response, limit: number, signal: AbortSignal): 
 
 const QUOTA_CODES = new Set([
 	"insufficient_quota", "quota_exceeded", "usage_limit_reached", "usage_limit_exceeded",
-	"billing_hard_limit_reached", "billing_not_active",
+	"billing_hard_limit_reached", "billing_not_active", "organization_usage_limit_exceeded",
+	"workspace_member_usage_limit_reached",
 ]);
+
+function isQuota(error: Record<string, unknown>): boolean {
+	return [error.code, error.type].some(value => typeof value === "string" && QUOTA_CODES.has(value));
+}
 
 function errorHint(error: unknown): string {
 	const { code, type } = object(error);
-	if (QUOTA_CODES.has(String(code)) || QUOTA_CODES.has(String(type))) {
+	if (isQuota({ code, type })) {
 		return "Codex subscription quota is unavailable or exhausted. Check your plan or wait for its reset.";
 	}
 	if (code === "moderation_blocked" || type === "image_generation_user_error") {
@@ -134,7 +149,7 @@ export async function httpFailure(response: Response, signal: AbortSignal): Prom
 	try {
 		error = object(object(JSON.parse(body)).error);
 	} catch { /* HTML and other non-JSON error bodies are not diagnostics. */ }
-	const terminal = QUOTA_CODES.has(String(error.code)) || QUOTA_CODES.has(String(error.type))
+	const terminal = isQuota(error)
 		|| error.code === "moderation_blocked" || error.type === "image_generation_user_error";
 	const hint = response.status === 401
 		? "Codex login was rejected. Run /login for openai-codex again."

--- a/packages/pi-codex-image-gen/tests/cli.test.mjs
+++ b/packages/pi-codex-image-gen/tests/cli.test.mjs
@@ -63,14 +63,47 @@ test("CLI edit and batch paths retain Images 2.5 quality controls", (t) => {
   t.after(() => rmSync(cwd, { recursive: true, force: true }));
   const image = join(cwd, "input.png");
   writeFileSync(image, Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=", "base64"));
-  const edit = cli(["edit", "--image", image, "--prompt", "test", "--model", "gpt-image-2.5-sunburst", "--quality", "max"]);
+  const edit = cli(["edit", "--image", image, "--prompt", "test", "--model", "gpt-image-2.5-sunburst", "--quality", "max", "--size", "1536x864"]);
   assert.equal(edit.status, 0, edit.stderr);
   assert.equal(JSON.parse(edit.stdout).quality, "max");
+  assert.equal(JSON.parse(edit.stdout).size, "1536x864");
   const jobs = join(cwd, "jobs.jsonl");
-  writeFileSync(jobs, JSON.stringify({ prompt: "test", model: "gpt-image-2.5-flare", quality: "xhigh" }));
+  writeFileSync(jobs, JSON.stringify({ prompt: "test", model: "gpt-image-2.5-flare", quality: "xhigh", size: "3840x2160" }));
   const batch = cli(["generate-batch", "--input", jobs, "--out-dir", join(cwd, "out")]);
   assert.equal(batch.status, 0, batch.stderr);
   assert.match(batch.stdout, /"quality": "xhigh"/);
+  assert.match(batch.stdout, /"size": "3840x2160"/);
   writeFileSync(jobs, JSON.stringify({ prompt: "test", model: "gpt-image-2", quality: "max" }));
   assert.notEqual(cli(["generate-batch", "--input", jobs, "--out-dir", join(cwd, "out")]).status, 0);
+});
+
+test("CLI recognizes documented 2.5 custom sizes and snapshot IDs", () => {
+  for (const model of ["gpt-image-2.5-flare", "gpt-image-2.5-sunburst",
+    "gpt-image-2.5-flare-2026-09-08", "gpt-image-2.5-sunburst-2026-09-08",
+    "gpt-image-2-2026-04-21"]) {
+    const result = cli(["generate", "--prompt", "test", "--model", model, "--size", "1536x864"]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).size, "1536x864");
+  }
+  for (const size of ["1024x640", "3840x2160", "3840x1280"]) {
+    assert.equal(cli(["generate", "--prompt", "test", "--model", "gpt-image-2.5-flare", "--size", size]).status, 0);
+  }
+});
+
+test("CLI rejects invalid 2.5 dimensions and keeps older models on standard sizes", () => {
+  for (const [size, message] of [
+    ["3841x2160", /maximum edge/],
+    ["1000x1000", /multiples of 16/],
+    ["1024x320", /ratio/],
+    ["256x256", /total pixels/],
+    ["3840x3840", /total pixels/],
+    ["not-a-size", /WIDTHxHEIGHT/],
+  ]) {
+    const result = cli(["generate", "--prompt", "test", "--model", "gpt-image-2.5-sunburst", "--size", size]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, message);
+  }
+  const legacy = cli(["generate", "--prompt", "test", "--model", "gpt-image-1.5", "--size", "1536x864"]);
+  assert.notEqual(legacy.status, 0);
+  assert.match(legacy.stderr, /one of/);
 });

--- a/packages/pi-codex-image-gen/tests/cli.test.mjs
+++ b/packages/pi-codex-image-gen/tests/cli.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const script = fileURLToPath(new URL("../skills/imagegen/scripts/image_gen.py", import.meta.url));
+
+// Standard-library-only dry runs: no SDK, API key, or network access needed.
+// Use python3 directly so the package test also runs on CI without uv installed.
+function cli(args) {
+  const result = spawnSync("python3", [script, ...args, "--dry-run"], {
+    encoding: "utf8",
+    timeout: 10_000,
+    maxBuffer: 1024 * 1024,
+    env: { ...process.env, OPENAI_API_KEY: "" },
+  });
+  assert.ifError(result.error);
+  return result;
+}
+
+test("CLI accepts both Images 2.5 models and snapshots with extended quality", () => {
+  for (const model of ["gpt-image-2.5-flare", "gpt-image-2.5-sunburst",
+    "gpt-image-2.5-flare-2026-09-08", "gpt-image-2.5-sunburst-2026-09-08"]) {
+    for (const quality of ["xhigh", "max"]) {
+      const result = cli(["generate", "--prompt", "test", "--model", model, "--quality", quality]);
+      assert.equal(result.status, 0, result.stderr);
+      const payload = JSON.parse(result.stdout);
+      assert.equal(payload.model, model);
+      assert.equal(payload.quality, quality);
+    }
+  }
+});
+
+test("CLI preserves defaults and rejects extended quality for older or unknown models", () => {
+  const result = cli(["generate", "--prompt", "test"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).model, "gpt-image-2");
+  for (const model of ["gpt-image-2", "gpt-image-1.5", "gpt-image-2.5-unknown"]) {
+    const rejected = cli(["generate", "--prompt", "test", "--model", model, "--quality", "max"]);
+    assert.notEqual(rejected.status, 0);
+    assert.match(rejected.stderr, /quality/);
+  }
+});
+
+test("CLI allows GPT Image 2 transparent PNG/WebP but rejects JPEG", () => {
+  for (const format of ["png", "webp", "jpeg"]) {
+    const result = cli(["generate", "--prompt", "test", "--background", "transparent", "--output-format", format]);
+    if (format === "jpeg") {
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /transparent background requires/);
+    } else {
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(JSON.parse(result.stdout).background, "transparent");
+    }
+  }
+});
+
+test("CLI edit and batch paths retain Images 2.5 quality controls", (t) => {
+  const cwd = mkdtempSync(join(tmpdir(), "imagegen-cli-"));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  const image = join(cwd, "input.png");
+  writeFileSync(image, Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=", "base64"));
+  const edit = cli(["edit", "--image", image, "--prompt", "test", "--model", "gpt-image-2.5-sunburst", "--quality", "max"]);
+  assert.equal(edit.status, 0, edit.stderr);
+  assert.equal(JSON.parse(edit.stdout).quality, "max");
+  const jobs = join(cwd, "jobs.jsonl");
+  writeFileSync(jobs, JSON.stringify({ prompt: "test", model: "gpt-image-2.5-flare", quality: "xhigh" }));
+  const batch = cli(["generate-batch", "--input", jobs, "--out-dir", join(cwd, "out")]);
+  assert.equal(batch.status, 0, batch.stderr);
+  assert.match(batch.stdout, /"quality": "xhigh"/);
+  writeFileSync(jobs, JSON.stringify({ prompt: "test", model: "gpt-image-2", quality: "max" }));
+  assert.notEqual(cli(["generate-batch", "--input", jobs, "--out-dir", join(cwd, "out")]).status, 0);
+});

--- a/packages/pi-codex-image-gen/tests/image-generation.test.mjs
+++ b/packages/pi-codex-image-gen/tests/image-generation.test.mjs
@@ -140,6 +140,26 @@ test("tool edit request includes local image content", async (t) => {
   assert.equal(requestBody.input[0].content[1].type, "input_image");
 });
 
+test("tool leaves image model selection to Codex and does not claim a model ID", async (t) => {
+  const cwd = await mkdtemp(join(tmpdir(), "imagegen-model-"));
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  let body;
+  globalThis.fetch = async (_url, init) => {
+    body = JSON.parse(init.body);
+    return sseResponse();
+  };
+  const tool = createTool();
+  const updates = [];
+  const result = await tool.execute("call", { prompt: "test", save: "none" }, undefined,
+    (update) => updates.push(update), context(cwd));
+  assert.equal(body.model, "gpt-5.5");
+  assert.deepEqual(body.tools, [{ type: "image_generation", output_format: "png" }]);
+  assert.equal(result.details.backendImageModel, "unknown");
+  assert.doesNotMatch(JSON.stringify([tool.description, tool.promptSnippet, updates, result]), /gpt-image-/);
+});
+
 test("retry loop honors Retry-After and remains bounded", async (t) => {
   const cwd = await mkdtemp(join(tmpdir(), "imagegen-retry-"));
   t.after(() => rm(cwd, { recursive: true, force: true }));

--- a/packages/pi-codex-image-gen/tests/image-generation.test.mjs
+++ b/packages/pi-codex-image-gen/tests/image-generation.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, open, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, open, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";

--- a/packages/pi-codex-image-gen/tests/image-generation.test.mjs
+++ b/packages/pi-codex-image-gen/tests/image-generation.test.mjs
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, open, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { MAX_RESPONSE_BYTES, REQUEST_TIMEOUT_MS } from "../.test-dist/src/codex-response.js";
 
 import extension, {
   abortableDelay,
@@ -228,4 +229,218 @@ test("malformed backend payload fails before saving or returning image content",
   globalThis.fetch = async () => sseResponse("!!!!");
   await assert.rejects(createTool().execute("call", { prompt: "test", save: "custom", saveDir: "out" }, undefined, undefined, context(cwd)), /invalid base64/);
   await assert.rejects(readFile(join(cwd, "out", "session-1", "image-1.png")));
+});
+
+async function harness(t, responder) {
+  const cwd = await mkdtemp(join(tmpdir(), "imagegen-contract-"));
+  t.after(() => rm(cwd, { recursive: true, force: true }));
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  const calls = [];
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, ...init });
+    return responder(url, init);
+  };
+  const tool = createTool();
+  return {
+    cwd, calls, tool,
+    run: (params = {}, signal, onUpdate, ctx = context(cwd)) =>
+      tool.execute("call", { prompt: "test", save: "none", ...params }, signal, onUpdate, ctx),
+  };
+}
+
+function imageEvent(extra = {}) {
+  return { type: "response.output_item.done", item: {
+    type: "image_generation_call", id: "image-1", status: "completed", result: PNG.toString("base64"), ...extra,
+  } };
+}
+
+function streamEvents(events, { crlf = false, fragment = false, close = true, cancel = () => {} } = {}) {
+  const newline = crlf ? "\r\n" : "\n";
+  const bytes = Buffer.from(events.map(event => `data: ${JSON.stringify(event)}${newline}${newline}`).join(""));
+  return new Response(new ReadableStream({
+    start(controller) {
+      if (fragment) for (let i = 0; i < bytes.length; i++) controller.enqueue(bytes.subarray(i, i + 1));
+      else controller.enqueue(bytes);
+      if (close) controller.close();
+    },
+    cancel,
+  }));
+}
+
+test("tool sends an honest Pi User-Agent, blocks redirects, and retains the subscription route", async (t) => {
+  const h = await harness(t, () => sseResponse());
+  await h.run();
+  assert.equal(h.calls[0].url, "https://chatgpt.com/backend-api/codex/responses");
+  assert.equal(h.calls[0].headers["User-Agent"], "pi-codex-image-gen");
+  assert.equal(h.calls[0].headers.originator, "pi");
+  assert.equal(h.calls[0].redirect, "error");
+  assert.ok(h.calls[0].signal instanceof AbortSignal);
+});
+
+test("tool handles fragmented CRLF events and reports backend metadata and progress", async (t) => {
+  let cancelled = false;
+  const h = await harness(t, () => streamEvents([
+    { type: "response.image_generation_call.in_progress" },
+    { type: "response.image_generation_call.generating" },
+    imageEvent({ size: "1254x1254", quality: "low", background: "opaque", output_format: "png" }),
+    { type: "response.completed", response: { usage: {
+      total_tokens: 10, input_tokens_details: { cached_tokens: 4 }, private_data: "DO_NOT_COPY",
+    } } },
+  ], { crlf: true, fragment: true, close: false, cancel: () => { cancelled = true; } }));
+  const updates = [];
+  const result = await h.run({}, undefined, update => updates.push(update));
+  assert.deepEqual(result.details.reportedImage, {
+    size: "1254x1254", quality: "low", background: "opaque", outputFormat: "png",
+  });
+  assert.equal(result.details.backendImageModel, "unknown");
+  assert.equal(result.details.byteCount, PNG.length);
+  assert.match(result.content[0].text, /Backend-reported size: 1254x1254/);
+  assert.ok(updates.some(update => update.details?.stage === "generating"));
+  assert.deepEqual(result.details.usage, { total_tokens: 10, input_tokens_details: { cached_tokens: 4 } });
+  assert.equal(cancelled, true);
+});
+
+test("tool accepts completion-only image output and only records a model when explicitly reported", async (t) => {
+  const h = await harness(t, () => streamEvents([
+    { type: "response.completed", response: { output: [
+      imageEvent({ model: "gpt-image-2.5-flare", background: "transparent" }).item,
+    ] } },
+  ]));
+  const result = await h.run();
+  assert.equal(result.details.backendImageModel, "gpt-image-2.5-flare");
+  assert.equal(result.details.reportedImage.background, "transparent");
+});
+
+test("tool rejects incomplete, failed, malformed, and multiple-image streams without retrying", async (t) => {
+  for (const events of [
+    [imageEvent()],
+    [imageEvent(), { type: "response.incomplete" }],
+    [imageEvent({ status: "failed" }), { type: "response.completed" }],
+    [imageEvent(), imageEvent({ id: "image-2" }), { type: "response.completed" }],
+    [{ type: "error", message: jwt() }],
+  ]) {
+    await t.test(JSON.stringify(events.map(event => event.type)), async (t) => {
+      const h = await harness(t, () => streamEvents(events));
+      await assert.rejects(h.run(), error => !error.message.includes(jwt()));
+      assert.equal(h.calls.length, 1);
+    });
+  }
+  const h = await harness(t, () => new Response(`data: invalid-${jwt()}\n\n`));
+  await assert.rejects(h.run(), error => /invalid stream event/.test(error.message) && !error.message.includes(jwt()));
+  assert.equal(h.calls.length, 1);
+});
+
+test("tool classifies Cloudflare, auth, quota, and moderation failures without exposing response bodies", async (t) => {
+  for (const [status, error, headers, message] of [
+    [403, "PRIVATE_HTML", { "cf-mitigated": "challenge" }, /Cloudflare/],
+    [401, "PRIVATE_AUTH", {}, /login/],
+    [429, { error: { code: "insufficient_quota", message: jwt() } }, {}, /quota/],
+    [429, { error: { type: "usage_limit_reached", message: jwt() } }, {}, /quota/],
+    [429, { error: { type: "image_generation_user_error", message: jwt() } }, {}, /Review the prompt/],
+  ]) {
+    await t.test(String(status) + String(message), async (t) => {
+      const h = await harness(t, () => new Response(JSON.stringify(error), { status, headers }));
+      await assert.rejects(h.run(), failure =>
+        message.test(failure.message) && !failure.message.includes(jwt()) && !failure.message.includes("PRIVATE_"));
+      assert.equal(h.calls.length, 1);
+    });
+  }
+});
+
+test("tool bounds error bodies and never echoes network exceptions", async (t) => {
+  let cancelled = false;
+  const h = await harness(t, () => new Response(new ReadableStream({
+    start(controller) { controller.enqueue(Buffer.from("PRIVATE_BODY".repeat(2000))); },
+    cancel() { cancelled = true; },
+  }), { status: 401 }));
+  await assert.rejects(h.run(), error => /401/.test(error.message) && !error.message.includes("PRIVATE_BODY"));
+  assert.equal(cancelled, true);
+  globalThis.fetch = async () => { throw new Error(jwt()); };
+  await assert.rejects(h.run(), error => /connection failed/.test(error.message) && !error.message.includes(jwt()));
+});
+
+test("tool rejects oversized streams from both declared length and streamed byte count", async (t) => {
+  const h = await harness(t, () => new Response("", { headers: { "content-length": String(MAX_RESPONSE_BYTES + 1) } }));
+  await assert.rejects(h.run(), /size limit/);
+  let cancelled = false;
+  const block = Buffer.from(":" + "x".repeat(1024 * 1024) + "\n\n");
+  globalThis.fetch = async () => new Response(new ReadableStream({
+    pull(controller) { controller.enqueue(block); },
+    cancel() { cancelled = true; },
+  }));
+  await assert.rejects(h.run(), /size limit/);
+  assert.equal(cancelled, true);
+});
+
+test("tool deadline aborts both a pending connection and a stalled stream", async (t) => {
+  for (const stalledStream of [false, true]) {
+    await t.test(stalledStream ? "stream" : "connection", async (t) => {
+      const h = await harness(t, () => stalledStream
+        ? new Response(new ReadableStream({ start() {} }))
+        : new Promise(() => {}));
+      t.mock.timers.enable({ apis: ["setTimeout"] });
+      const rejected = assert.rejects(h.run(), /timed out after 5 minutes/);
+      await new Promise(setImmediate);
+      t.mock.timers.tick(REQUEST_TIMEOUT_MS);
+      await rejected;
+      assert.equal(h.calls.length, 1);
+      assert.equal(h.calls[0].signal.aborted, true);
+    });
+  }
+});
+
+test("tool cancellation interrupts a stalled stream without another generation", async (t) => {
+  let cancelled = false;
+  const h = await harness(t, () => new Response(new ReadableStream({
+    start() {},
+    cancel() { cancelled = true; },
+  })));
+  const controller = new AbortController();
+  const rejected = assert.rejects(h.run({}, controller.signal), /aborted/);
+  await new Promise(setImmediate);
+  controller.abort();
+  await rejected;
+  assert.equal(cancelled, true);
+  assert.equal(h.calls.length, 1);
+});
+
+test("tool validates save settings, routing model, prompts, and input files before generating", async (t) => {
+  const h = await harness(t, () => { throw new Error("Must not call backend"); });
+  await assert.rejects(h.run({ save: "custom", saveDir: "" }), /save=custom/);
+  await assert.rejects(h.run({ model: "gpt-image-2.5-flare" }), /routing model/);
+  await assert.rejects(h.run({ prompt: "x".repeat(32001) }), /32,000/);
+  const large = join(h.cwd, "large.png");
+  const file = await open(large, "w");
+  await file.truncate(20 * 1024 * 1024 + 1);
+  await file.close();
+  await assert.rejects(h.run({ referencedImagePaths: [large] }), /20 MiB/);
+  await assert.rejects(h.run({ referencedImagePaths: [h.cwd] }), /regular files/);
+  await assert.rejects(h.run({ numLastImagesToInclude: 1 }, undefined, undefined,
+    context(h.cwd, [{ content: [{ type: "image", mimeType: "image/png", data: "!!!!" }] }])), /invalid base64/);
+  assert.equal(h.calls.length, 0);
+});
+
+test("tool redacts credentials from revised prompts and split response text", async (t) => {
+  const h = await harness(t, () => streamEvents([
+    imageEvent({ revised_prompt: `Prompt ${jwt()}`, id: jwt() }),
+    { type: "response.completed" },
+  ]));
+  assert.doesNotMatch(JSON.stringify(await h.run()), new RegExp(jwt().replaceAll(".", "\\.")));
+  globalThis.fetch = async () => streamEvents([
+    { type: "response.output_text.delta", delta: jwt().slice(0, 20) },
+    { type: "response.output_text.delta", delta: jwt().slice(20) },
+    { type: "response.completed" },
+  ]);
+  await assert.rejects(h.run(), error => !error.message.includes(jwt()));
+});
+
+test("tool preserves an existing image on a repeated backend image ID", async (t) => {
+  const h = await harness(t, () => sseResponse());
+  const first = await h.run({ save: "custom", saveDir: "out" });
+  await writeFile(first.details.savedPath, "USER_IMAGE");
+  const second = await h.run({ save: "custom", saveDir: "out" });
+  assert.match(second.details.saveWarning, /could not be saved/);
+  assert.equal(await readFile(first.details.savedPath, "utf8"), "USER_IMAGE");
+  assert.equal(second.content[1].type, "image");
 });

--- a/packages/pi-codex-image-gen/tests/image-generation.test.mjs
+++ b/packages/pi-codex-image-gen/tests/image-generation.test.mjs
@@ -21,7 +21,7 @@ const WEBP = Buffer.concat([Buffer.from("RIFF"), Buffer.alloc(4), Buffer.from("W
 
 function jwt() {
   const payload = Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: "account" } })).toString("base64url");
-  return `header.${payload}.signature`;
+  return `${Buffer.from('{"alg":"none"}').toString("base64url")}.${payload}.signature`;
 }
 
 function sseResponse(image = PNG.toString("base64")) {
@@ -405,6 +405,14 @@ test("tool cancellation interrupts a stalled stream without another generation",
   assert.equal(h.calls.length, 1);
 });
 
+test("tool withholds stream exceptions and does not retry an interrupted response", async (t) => {
+  const h = await harness(t, () => new Response(new ReadableStream({
+    start(controller) { controller.error(new Error(jwt())); },
+  })));
+  await assert.rejects(h.run(), error => /stream was interrupted/.test(error.message) && !error.message.includes(jwt()));
+  assert.equal(h.calls.length, 1);
+});
+
 test("tool validates save settings, routing model, prompts, and input files before generating", async (t) => {
   const h = await harness(t, () => { throw new Error("Must not call backend"); });
   await assert.rejects(h.run({ save: "custom", saveDir: "" }), /save=custom/);
@@ -433,6 +441,26 @@ test("tool redacts credentials from revised prompts and split response text", as
     { type: "response.completed" },
   ]);
   await assert.rejects(h.run(), error => !error.message.includes(jwt()));
+  globalThis.fetch = async () => streamEvents([
+    { type: "response.output_text.delta", delta: "x".repeat(3980) + " " + jwt() },
+    { type: "response.completed" },
+  ]);
+  await assert.rejects(h.run(), error => !error.message.includes(jwt().slice(0, 15)));
+});
+
+test("tool enforces decoded reference and output image limits", async (t) => {
+  const h = await harness(t, () => { throw new Error("Must not generate"); });
+  // This count shares the same base64 length as the maximum accepted input,
+  // so a pre-decode length check alone is not sufficient.
+  const input = Buffer.concat([PNG, Buffer.alloc(20 * 1024 * 1024 + 1 - PNG.length)]);
+  await assert.rejects(h.run({ numLastImagesToInclude: 1 }, undefined, undefined,
+    context(h.cwd, [{ content: [{ type: "image", mimeType: "image/png", data: input.toString("base64") }] }])), /20 MiB/);
+  assert.equal(h.calls.length, 0);
+  globalThis.fetch = async () => streamEvents([
+    imageEvent({ result: "A".repeat(Math.ceil(32 * 1024 * 1024 / 3) * 4 + 4) }),
+    { type: "response.completed" },
+  ]);
+  await assert.rejects(h.run(), /32 MiB/);
 });
 
 test("tool preserves an existing image on a repeated backend image ID", async (t) => {


### PR DESCRIPTION
## Summary
- Keep the ChatGPT subscription Responses route, existing login, routing-model default, and save modes. No paid API mode or billing fallback.
- Add an honest Pi User-Agent, generation progress, and backend-reported output metadata. Do not guess the served image model.
- Bound request time, response/error sizes, and edit inputs. Handle fragmented, stalled, and incomplete streams; suppress sensitive errors and unsafe retries; preserve existing saved files.
- Extend the existing optional API CLI for Flare/Sunburst quality and flexible sizes, documented snapshots, and native transparency. Its default remains GPT Image 2. API use still requires separate consent and billing.
- Document source evidence, live observations, limitations, and a repeatable capability test procedure.

## Live findings
- Three earlier direct requests hit Cloudflare challenges and returned no images.
- A later approved six-request subscription-only probe returned valid PNGs from the direct and Responses routes.
- Flare, Sunburst, and an invalid model name all succeeded without a served-model ID. Acceptance does **not** prove selectable image models.
- A direct `1536x1024` / `high` / `transparent` request returned `1254x1254` / `low` / `opaque`; Pillow confirmed RGB pixels without transparency.
- Successful probes used a Codex-compatible diagnostic User-Agent, a model-list warmup, and an in-memory infrastructure-cookie jar. They were not a live run of the modified extension.
- Cookie-free Node GET checks with the shipping Pi headers reached Responses method validation (405), while the direct endpoint still hit Cloudflare (403). A User-Agent is not a universal challenge fix.
- No further generation requests were made after the six-request budget was exhausted. No API-key requests were made.

## Validation
- Package typecheck and 49 tests pass, including tool-level request, stream, cancellation, quota, metadata, save, size-limit, and credential-redaction regressions.
- Root `npm run validate` passes: package policy, workspace checks/tests, dependency audit, and pack checks.
- Pi's `DefaultResourceLoader` loads the checkout and registers `codex_generate_image` without errors or image requests.
- Python helper smoke checks and 2.5 CLI dry runs pass through `uv`.
- Pack contents inspected: 24 runtime/documentation files; no tests, agent files, diagnostics, credentials, or generated images.
- Scoped lock refresh and `npm ci --dry-run` passed; no dependency/lockfile changes. `git diff --check` passes.

## Remaining limits
- No verified Flare/Sunburst selection through subscription access. No speculative subscription controls added.
- Backend-reported output settings are not independently verified model identity or pixel guarantees.
- Native transparency through the Responses route, new Responses-tool controls, and live editing were not established by these probes. A further live extension smoke test needs renewed quota approval.
- 2.5 API `input_fidelity` remains unverified; leave it unset. Documented resolutions above `2560x1440` are experimental.
- No release or version bump. Keep this PR as a draft.

## References
- [Investigation and smoke procedure](https://github.com/jvm/pi-mono/blob/adcc472/packages/pi-codex-image-gen/CONTRIBUTING.md#subscription-capability-check)
- https://developers.openai.com/api/docs/models/gpt-image-2.5-flare
- https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst
- https://developers.openai.com/api/docs/guides/image-generation.md
- https://developers.openai.com/api/docs/guides/tools-image-generation
