### PR TITLE
Fix Codex compaction sizing and release 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5068,7 +5068,7 @@
       }
     },
     "packages/pi-codex-compaction": {
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@mocito/install-telemetry": "0.1.1"

--- a/packages/pi-codex-compaction/CHANGELOG.md
+++ b/packages/pi-codex-compaction/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-09-11
+
 ### Fixed
 
 - Estimate compaction tokens separately from request bytes so long Codex sessions do not fall back merely because UTF-8 bytes exceed the token budget.

--- a/packages/pi-codex-compaction/CHANGELOG.md
+++ b/packages/pi-codex-compaction/CHANGELOG.md
@@ -6,6 +6,11 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+### Fixed
+
+- Estimate compaction tokens separately from request bytes so long Codex sessions do not fall back merely because UTF-8 bytes exceed the token budget.
+- Preserve the independent 16 MiB request ceiling, count the complete transformed envelope, and reject unavailable context limits.
+
 ## [0.1.2] - 2026-09-11
 
 ### Fixed

--- a/packages/pi-codex-compaction/CHANGELOG.md
+++ b/packages/pi-codex-compaction/CHANGELOG.md
@@ -11,6 +11,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 ### Fixed
 
 - Estimate compaction tokens separately from request bytes so long Codex sessions do not fall back merely because UTF-8 bytes exceed the token budget.
+- Respect request-transform field removals when sizing, restrict warnings to TUI mode, and distinguish preparation failures from transport failures.
 - Preserve the independent 16 MiB request ceiling, count the complete transformed envelope, and reject unavailable context limits.
 - Record safe fallback reasons and numeric size diagnostics in local custom session entries; notify when UI is available without exposing request or provider content.
 

--- a/packages/pi-codex-compaction/CHANGELOG.md
+++ b/packages/pi-codex-compaction/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 - Estimate compaction tokens separately from request bytes so long Codex sessions do not fall back merely because UTF-8 bytes exceed the token budget.
 - Preserve the independent 16 MiB request ceiling, count the complete transformed envelope, and reject unavailable context limits.
+- Record safe fallback reasons and numeric size diagnostics in local custom session entries; notify when UI is available without exposing request or provider content.
 
 ## [0.1.2] - 2026-09-11
 

--- a/packages/pi-codex-compaction/CONTRIBUTING.md
+++ b/packages/pi-codex-compaction/CONTRIBUTING.md
@@ -29,6 +29,33 @@ Before opening a pull request:
 - Preserve current-model compaction, context bounds, cancellation, HTTPS, and standard Pi fallback behavior.
 - Add a regression test when changing wire parsing, request construction, checkpoint rehydration, or model-switch fallback behavior.
 
+## Token-budget regression and smoke checks
+
+`tests/integration.test.mjs` uses the real Pi compaction hook, serializer, and
+session tree with fake credentials and mocked Responses transport. A synthetic
+long transcript must produce a remote checkpoint even when its UTF-8 bytes
+exceed the numeric token budget. Oversized input must still invoke the standard
+compactor and record a safe fallback reason. A later model request must not
+contain the diagnostic entry. No private session fixtures or live requests are
+needed for these tests.
+
+The token conversion follows Codex's ordinary JSON-item heuristic:
+[byte-to-token estimate](https://github.com/openai/codex/blob/654b0a77d0d2f81aa21f61caf7af4be88fe550bb/codex-rs/utils/string/src/truncate.rs)
+and [history sizing](https://github.com/openai/codex/blob/654b0a77d0d2f81aa21f61caf7af4be88fe550bb/codex-rs/core/src/context_manager/history.rs).
+This package keeps all serialized opaque/image bytes in its estimate instead of
+copying Codex's modality-specific discounts. Never equate bytes and tokens or
+remove the independent wire-size ceiling.
+
+For an offline replay, reconstruct a compaction's discarded history in memory,
+use fake authentication, replace `fetch` with a fixture checkpoint response,
+and call `createRemoteCompaction`. Print only sizes and the success/fallback
+code. Do not save the transcript, request, auth headers, or opaque content.
+
+For an approved live smoke test, follow the procedure in [README.md](./README.md#reference-and-smoke-test).
+Check for `fromHook: true` and `details.kind: "pi-codex-compaction"` on success.
+On fallback, inspect only the reason and counters in the custom diagnostic
+entry. Never inspect or print `encryptedContent`.
+
 ## Code of conduct
 
 This project follows the Contributor Covenant Code of Conduct.

--- a/packages/pi-codex-compaction/README.md
+++ b/packages/pi-codex-compaction/README.md
@@ -39,7 +39,7 @@ When Pi starts compaction on a supported Codex model, the extension sends a stre
 
 Compaction uses the model active when Pi triggers it. If a session switches from a larger to a smaller model, the remote request is bounded against the new model's context window and tool outputs are reduced before sending. A previous opaque checkpoint is treated as incompatible after a model, endpoint, account, or authentication-mode switch; Pi's readable previous summary is sent instead. If the full request still cannot fit, the extension leaves compaction to Pi's normal implementation.
 
-If the remote request fails, is cancelled, or returns an unexpected response, Pi's standard compaction path runs. Custom compaction instructions also use Pi's standard path because RemoteCompactionV2 has no documented custom-instructions field. The direct checkpoint request is restricted to `https://chatgpt.com`, rejects redirects, limits request/response size, and never decodes or logs `encrypted_content`. No configuration is required.
+If the remote request fails or returns an unexpected response, Pi's standard compaction path runs. Cancellation remains cancelled. Custom compaction instructions also use Pi's standard path because RemoteCompactionV2 has no documented custom-instructions field. The direct checkpoint request is restricted to `https://chatgpt.com`, rejects redirects, limits request/response size, and never decodes or logs `encrypted_content`. No configuration is required.
 
 ### Size limits
 
@@ -56,6 +56,22 @@ tool calls, and opaque checkpoints are not removed. If the remaining request
 still cannot fit, or the model's context limit is unknown, standard Pi compaction
 runs. The estimate can differ from the server's token count; a server rejection
 still uses the existing fallback.
+
+### Fallback diagnostics
+
+A fallback on a supported model records a local custom session entry with type
+`pi-codex-compaction:fallback:v1`. It contains `version: 1` and a reason:
+`custom-instructions`, `auth-unavailable`, `request-unavailable`,
+`context-window-unavailable`, `context-limit`, `request-size-limit`, or
+`remote-failed`. Size failures also include estimated tokens, token budget,
+request bytes, byte limit, and the number of tool outputs reduced.
+
+No prompt, tool content, encrypted checkpoint, account identifier, credential, or
+raw provider error is included. These entries are not sent to the model. Pi
+shows a warning when UI notifications are available; print/JSON mode gets no
+extra console output. Unsupported models and cancelled attempts do not create
+fallback diagnostics. Diagnostic storage or notification failure does not stop
+the standard compactor.
 
 ## Development
 

--- a/packages/pi-codex-compaction/README.md
+++ b/packages/pi-codex-compaction/README.md
@@ -65,13 +65,15 @@ A fallback on a supported model records a local custom session entry with type
 `context-window-unavailable`, `context-limit`, `request-size-limit`, or
 `remote-failed`. Size failures also include estimated tokens, token budget,
 request bytes, byte limit, and the number of tool outputs reduced.
+Unexpected preparation failures use `request-unavailable`; `remote-failed`
+is reserved for failures from the transport call.
 
 No prompt, tool content, encrypted checkpoint, account identifier, credential, or
 raw provider error is included. These entries are not sent to the model. Pi
-shows a warning when UI notifications are available; print/JSON mode gets no
-extra console output. Unsupported models and cancelled attempts do not create
-fallback diagnostics. Diagnostic storage or notification failure does not stop
-the standard compactor.
+shows a warning only in TUI mode when notifications are available; print, JSON,
+and RPC modes get no extra notifications or console output. Unsupported models
+and cancelled attempts do not create fallback diagnostics. Diagnostic storage
+or notification failure does not stop the standard compactor.
 
 ## Development
 
@@ -93,6 +95,7 @@ versioned `pi.events` contracts let cooperating extensions supply it:
 - `pi-codex-compaction:request:v1`: `{ ctx, messages, payload }`, after input
   assembly and before size checks. A listener can replace `payload`. This event
   is not the general `before_provider_request` chain and does not carry auth.
+  Size checks use the transformed envelope, including field removals.
 
 Other extensions' private request changes are not applied automatically.
 Unknown third-party grammar metadata needs cooperation through the tools event.

--- a/packages/pi-codex-compaction/README.md
+++ b/packages/pi-codex-compaction/README.md
@@ -9,7 +9,7 @@ Keep long Pi sessions usable on OpenAI Codex models by replacing Pi's local summ
 - Retains the normal Codex Responses request envelope, including system instructions, active tool schemas, reasoning settings, prompt-cache fields, and routing fields.
 - Persists Codex's opaque encrypted checkpoint and rehydrates it only for supported Codex requests.
 - Reuses checkpoints only for the same model, trusted endpoint, Codex account, and authentication mode.
-- Bounds input with a UTF-8-aware token estimate, trims tool output when necessary, retries transient failures, and honors cancellation.
+- Bounds input with a Codex-style UTF-8 token estimate and a separate hard byte limit, trims tool output when necessary, retries transient failures, and honors cancellation.
 - Falls back to standard Pi compaction on failure or when custom compaction instructions are requested.
 - Keeps a bounded readable transcript excerpt so switching models or providers remains usable.
 
@@ -40,6 +40,22 @@ When Pi starts compaction on a supported Codex model, the extension sends a stre
 Compaction uses the model active when Pi triggers it. If a session switches from a larger to a smaller model, the remote request is bounded against the new model's context window and tool outputs are reduced before sending. A previous opaque checkpoint is treated as incompatible after a model, endpoint, account, or authentication-mode switch; Pi's readable previous summary is sent instead. If the full request still cannot fit, the extension leaves compaction to Pi's normal implementation.
 
 If the remote request fails, is cancelled, or returns an unexpected response, Pi's standard compaction path runs. Custom compaction instructions also use Pi's standard path because RemoteCompactionV2 has no documented custom-instructions field. The direct checkpoint request is restricted to `https://chatgpt.com`, rejects redirects, limits request/response size, and never decodes or logs `encrypted_content`. No configuration is required.
+
+### Size limits
+
+Input is estimated as `ceil(UTF-8 request bytes / 4)`, with 8,192 tokens reserved
+from the active model's context window. This uses Codex's ordinary-item heuristic,
+not an exact tokenizer. The complete transformed request is counted, including
+system instructions, tool definitions, and routing fields. Opaque checkpoints
+and image data remain counted at their serialized size; they are not decoded or
+discounted. Non-ASCII text uses UTF-8 bytes, not JavaScript string length.
+
+The uncompressed request also has an independent **16 MiB hard limit**. Tool
+outputs are reduced only when one of these limits is exceeded. User messages,
+tool calls, and opaque checkpoints are not removed. If the remaining request
+still cannot fit, or the model's context limit is unknown, standard Pi compaction
+runs. The estimate can differ from the server's token count; a server rejection
+still uses the existing fallback.
 
 ## Development
 

--- a/packages/pi-codex-compaction/SECURITY.md
+++ b/packages/pi-codex-compaction/SECURITY.md
@@ -35,4 +35,18 @@ Cooperating local extensions can inspect and transform compaction inputs through
 the documented event bus before size checks. These events contain no credentials.
 They have the same trust level as other installed Pi extensions.
 
+Context sizing uses `ceil(UTF-8 serialized request bytes / 4)` with an 8,192-token
+reserve from the active model's context window. It is an estimate, not a strict
+tokenizer bound. The complete transformed envelope is counted, including opaque
+content at its serialized size. A separate 16 MiB uncompressed request limit is
+enforced before network I/O. The HTTPS, redirect, response-size, checkpoint
+compatibility, and cancellation checks remain independent of token estimation.
+
+Fallback diagnostics store only a fixed reason code and finite non-negative
+size counters in `pi-codex-compaction:fallback:v1` custom session entries.
+These local records never include credentials, account/model identifiers,
+request content, encrypted checkpoints, or raw errors, and do not enter model
+context. No external diagnostic telemetry is added. They use the existing
+session's permissions and retention policy.
+
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development and validation instructions.

--- a/packages/pi-codex-compaction/extensions/index.ts
+++ b/packages/pi-codex-compaction/extensions/index.ts
@@ -48,7 +48,7 @@ export default function piCodexCompaction(pi: ExtensionAPI): void {
       } catch {
         // Diagnostics must not prevent the standard compactor from running.
       }
-      if (ctx.hasUI) {
+      if (ctx.mode === "tui" && ctx.hasUI) {
         try {
           ctx.ui.notify(`Codex remote compaction skipped: ${FALLBACK_MESSAGES[diagnostic.reason]}. Using standard Pi compaction.`, "warning");
         } catch {
@@ -76,7 +76,9 @@ export default function piCodexCompaction(pi: ExtensionAPI): void {
       }, reportFallback);
       return compaction ? { compaction } : undefined;
     } catch {
-      reportFallback({ reason: "remote-failed" });
+      // Transport failures already have a reason; other exceptions mean the
+      // compaction request could not be prepared or processed.
+      reportFallback({ reason: "request-unavailable" });
       return undefined;
     }
   };

--- a/packages/pi-codex-compaction/extensions/index.ts
+++ b/packages/pi-codex-compaction/extensions/index.ts
@@ -7,6 +7,8 @@ import { BETA_FEATURE, getCodexAccountFingerprint } from "../src/codex-wire.js";
 import { reportInstallTelemetry } from "../src/install-telemetry.js";
 import {
   applyRemoteCompactionMarker,
+  COMPACTION_FALLBACK_ENTRY,
+  type CompactionFallback,
   createRemoteCompaction,
   findActiveRemoteCompaction,
   getCodexAuthKind,
@@ -14,12 +16,46 @@ import {
   supportsRemoteCompaction,
 } from "../src/remote-compaction.js";
 
+const FALLBACK_MESSAGES: Record<CompactionFallback["reason"], string> = {
+  "custom-instructions": "custom compaction instructions require the standard compactor",
+  "auth-unavailable": "Codex authentication is unavailable",
+  "request-unavailable": "the Codex request could not be prepared",
+  "context-window-unavailable": "the active model's context limit is unavailable",
+  "context-limit": "the estimated input exceeds the active model's token budget",
+  "request-size-limit": "the request exceeds the 16 MiB byte limit",
+  "remote-failed": "the remote request failed",
+};
+
 export default function piCodexCompaction(pi: ExtensionAPI): void {
   reportInstallTelemetry();
 
   const onBeforeCompact: ExtensionHandler<SessionBeforeCompactEvent, { compaction?: NonNullable<Awaited<ReturnType<typeof createRemoteCompaction>>> }> = async (event, ctx) => {
     if (!supportsRemoteCompaction(ctx.model)) return undefined;
 
+    let reported = false;
+    const reportFallback = (diagnostic: CompactionFallback) => {
+      if (reported || event.signal.aborted) return;
+      reported = true;
+      // No text, model/account identifiers, headers, or provider errors belong
+      // in diagnostics. Custom entries do not enter the model's context.
+      const data: Record<string, unknown> = { version: 1, reason: diagnostic.reason };
+      for (const key of ["estimatedTokens", "tokenBudget", "requestBytes", "byteLimit", "trimmedToolOutputs"] as const) {
+        const value = diagnostic[key];
+        if (typeof value === "number" && Number.isFinite(value) && value >= 0) data[key] = value;
+      }
+      try {
+        pi.appendEntry(COMPACTION_FALLBACK_ENTRY, data);
+      } catch {
+        // Diagnostics must not prevent the standard compactor from running.
+      }
+      if (ctx.hasUI) {
+        try {
+          ctx.ui.notify(`Codex remote compaction skipped: ${FALLBACK_MESSAGES[diagnostic.reason]}. Using standard Pi compaction.`, "warning");
+        } catch {
+          // Notification failure must not change compaction behavior either.
+        }
+      }
+    };
     try {
       const compaction = await createRemoteCompaction(event, ctx, () => {
         const active = new Set(pi.getActiveTools());
@@ -37,12 +73,10 @@ export default function piCodexCompaction(pi: ExtensionAPI): void {
         // and before network I/O. Never include auth in this event.
         pi.events?.emit("pi-codex-compaction:request:v1", data);
         return data.payload;
-      });
+      }, reportFallback);
       return compaction ? { compaction } : undefined;
     } catch {
-      if (!event.signal.aborted && ctx.hasUI) {
-        ctx.ui.notify("Codex remote compaction failed; using standard Pi compaction.", "warning");
-      }
+      reportFallback({ reason: "remote-failed" });
       return undefined;
     }
   };

--- a/packages/pi-codex-compaction/package.json
+++ b/packages/pi-codex-compaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-compaction",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Use OpenAI Codex RemoteCompactionV2 for supported Pi sessions.",
   "type": "module",
   "license": "MIT",

--- a/packages/pi-codex-compaction/src/codex-wire.ts
+++ b/packages/pi-codex-compaction/src/codex-wire.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-const MAX_REQUEST_BYTES = 16 * 1024 * 1024;
+export const MAX_COMPACTION_REQUEST_BYTES = 16 * 1024 * 1024;
 const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 const MAX_ENCRYPTED_CONTENT_CHARS = 2_000_000;
 const REQUEST_HEADER_TIMEOUT_MS = 30_000;
@@ -57,7 +57,7 @@ export async function requestRemoteCompactionWithUsage(
   const accountId = extractAccountId(request.apiKey);
   const headers = buildHeaders(request, accountId);
   const body = JSON.stringify(request.body);
-  if (new TextEncoder().encode(body).byteLength > MAX_REQUEST_BYTES) {
+  if (Buffer.byteLength(body, "utf8") > MAX_COMPACTION_REQUEST_BYTES) {
     throw new Error("Codex compaction request exceeded the size limit");
   }
 

--- a/packages/pi-codex-compaction/src/remote-compaction.ts
+++ b/packages/pi-codex-compaction/src/remote-compaction.ts
@@ -192,6 +192,11 @@ export async function createRemoteCompaction(
       input: boundedInput,
     },
     signal: event.signal,
+  }).catch((error: unknown) => {
+    // Only failures from the transport path receive this reason. Preparation
+    // failures are classified by the extension's outer fallback handler.
+    if (!event.signal.aborted) onFallback?.({ reason: "remote-failed" });
+    throw error;
   });
 
   const fallback = buildFallbackSummary(event.preparation, messages);
@@ -530,12 +535,12 @@ function buildCompactionRequest(
   instructions: string,
   tools: readonly unknown[],
 ): Record<string, unknown> {
-  const payload: Record<string, unknown> = requestPayload ? { ...requestPayload } : {};
-  // Measure the actual transformed envelope, including cooperating extensions'
-  // instruction/tool changes. The separate arguments are defaults only.
-  if (!("instructions" in payload)) payload.instructions = instructions;
+  // A supplied envelope is authoritative, including fields a listener removed.
+  // Separate defaults apply only to callers without a complete payload.
+  const payload: Record<string, unknown> = requestPayload
+    ? { ...requestPayload }
+    : { instructions, ...(tools.length > 0 ? { tools } : {}) };
   payload.input = input;
-  if (!("tools" in payload) && tools.length > 0) payload.tools = tools;
   return payload;
 }
 

--- a/packages/pi-codex-compaction/src/remote-compaction.ts
+++ b/packages/pi-codex-compaction/src/remote-compaction.ts
@@ -13,6 +13,17 @@ import {
 
 export const REMOTE_SUMMARY_MARKER = "[pi-codex-compaction:v1]";
 export const REMOTE_COMPACTION_KIND = "pi-codex-compaction";
+export const COMPACTION_FALLBACK_ENTRY = "pi-codex-compaction:fallback:v1";
+
+export interface CompactionFallback {
+  reason: "custom-instructions" | "auth-unavailable" | "request-unavailable" |
+    "context-window-unavailable" | "context-limit" | "request-size-limit" | "remote-failed";
+  estimatedTokens?: number;
+  tokenBudget?: number;
+  requestBytes?: number;
+  byteLimit?: number;
+  trimmedToolOutputs?: number;
+}
 
 const FALLBACK_SUMMARY_MAX_CHARS = 12_000;
 const MAX_ENCRYPTED_CONTENT_CHARS = 2_000_000;
@@ -100,6 +111,7 @@ export async function createRemoteCompaction(
   getTools: () => readonly ToolInfoLike[],
   thinkingLevel?: string,
   prepareRequest?: (payload: Record<string, unknown>, messages: readonly AgentMessage[]) => Record<string, unknown>,
+  onFallback?: (diagnostic: CompactionFallback) => void,
 ): Promise<{
   summary: string;
   firstKeptEntryId: string;
@@ -107,17 +119,22 @@ export async function createRemoteCompaction(
   details: RemoteCompactionDetails;
   usage?: Usage;
 } | undefined> {
+  if (event.signal.aborted) return undefined;
+  const skip = (reason: CompactionFallback["reason"]) => {
+    onFallback?.({ reason });
+    return undefined;
+  };
   // Pi's custom focus is part of the standard summarizer contract. The
   // Responses compaction envelope has no documented equivalent, so do not
   // silently discard it.
-  if (event.customInstructions?.trim()) return undefined;
+  if (event.customInstructions?.trim()) return skip("custom-instructions");
 
   const model = ctx.model as CodexModel | undefined;
   if (!model || !supportsRemoteCompaction(model)) return undefined;
 
   const endpoint = resolveCodexResponsesUrl(model.baseUrl);
   const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model as Model<any>);
-  if (!auth.ok || !auth.apiKey) return undefined;
+  if (!auth.ok || !auth.apiKey) return skip("auth-unavailable");
   const accountFingerprint = getCodexAccountFingerprint(auth.apiKey);
   const authKind = getCodexAuthKind(ctx.modelRegistry, model as Model<any>);
 
@@ -139,9 +156,9 @@ export async function createRemoteCompaction(
     event.signal,
     thinkingLevel,
   );
-  if (!providerPayload) return undefined;
+  if (!providerPayload) return skip("request-unavailable");
   const providerInput = providerPayload.input;
-  if (!Array.isArray(providerInput)) return undefined;
+  if (!Array.isArray(providerInput)) return skip("request-unavailable");
   const providerTools = Array.isArray(providerPayload.tools) ? providerPayload.tools : [];
 
   const input = appendCompactionItems(providerInput, event.preparation, compatiblePrevious);
@@ -154,13 +171,14 @@ export async function createRemoteCompaction(
     store: false,
     stream: true,
   });
-  if (!Array.isArray(requestBody.input)) return undefined;
+  if (!Array.isArray(requestBody.input)) return skip("request-unavailable");
   const boundedInput = boundCompactionInput(
     requestBody.input,
     instructions,
     Array.isArray(requestBody.tools) ? requestBody.tools : providerTools,
     model.contextWindow,
     requestBody,
+    onFallback,
   );
   if (!boundedInput) return undefined;
 
@@ -215,17 +233,25 @@ export function boundCompactionInput(
   tools: readonly unknown[],
   contextWindow: number,
   requestPayload?: Record<string, unknown>,
+  onLimit?: (diagnostic: CompactionFallback) => void,
 ): unknown[] | undefined {
-  if (!Number.isFinite(contextWindow) || contextWindow <= 0) return undefined;
+  if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
+    onLimit?.({ reason: "context-window-unavailable" });
+    return undefined;
+  }
   const budgetTokens = Math.max(0, Math.floor(contextWindow) - COMPACTION_RESPONSE_RESERVE_TOKENS);
   const bounded = input.map((item) => item);
   let requestBytes = serializedBytes(
     buildCompactionRequest(requestPayload, bounded, instructions, tools),
   );
-  if (!Number.isFinite(requestBytes)) return undefined;
+  if (!Number.isFinite(requestBytes)) {
+    onLimit?.({ reason: "request-unavailable" });
+    return undefined;
+  }
   const fits = () => requestBytes <= MAX_COMPACTION_REQUEST_BYTES &&
     Math.ceil(requestBytes / APPROX_BYTES_PER_TOKEN) <= budgetTokens;
   if (fits()) return bounded;
+  let trimmedToolOutputs = 0;
 
   // ponytail: trim tool outputs first; if structural content still exceeds the active model window,
   // let Pi's standard compaction path handle the request instead of inventing a lossy transcript rewrite.
@@ -240,9 +266,18 @@ export function boundCompactionInput(
     if (removedBytes <= 0) continue;
     requestBytes -= removedBytes;
     bounded[index] = replacement;
+    trimmedToolOutputs++;
     if (fits()) return bounded;
   }
 
+  onLimit?.({
+    reason: requestBytes > MAX_COMPACTION_REQUEST_BYTES ? "request-size-limit" : "context-limit",
+    estimatedTokens: Math.ceil(requestBytes / APPROX_BYTES_PER_TOKEN),
+    tokenBudget: budgetTokens,
+    requestBytes,
+    byteLimit: MAX_COMPACTION_REQUEST_BYTES,
+    trimmedToolOutputs,
+  });
   return undefined;
 }
 

--- a/packages/pi-codex-compaction/src/remote-compaction.ts
+++ b/packages/pi-codex-compaction/src/remote-compaction.ts
@@ -5,6 +5,7 @@ import { convertToLlm, serializeConversation, sessionEntryToContextMessages } fr
 import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 import {
   getCodexAccountFingerprint,
+  MAX_COMPACTION_REQUEST_BYTES,
   requestRemoteCompactionWithUsage,
   resolveCodexResponsesUrl,
   type CodexCompactionUsage,
@@ -16,6 +17,9 @@ export const REMOTE_COMPACTION_KIND = "pi-codex-compaction";
 const FALLBACK_SUMMARY_MAX_CHARS = 12_000;
 const MAX_ENCRYPTED_CONTENT_CHARS = 2_000_000;
 const COMPACTION_RESPONSE_RESERVE_TOKENS = 8_192;
+// Codex's ordinary-item estimate uses ceil(UTF-8 bytes / 4), not bytes as
+// tokens. This is a heuristic, not a tokenizer or a context-fit guarantee.
+const APPROX_BYTES_PER_TOKEN = 4;
 const TRUNCATED_TOOL_OUTPUT = "[Tool output omitted from the Codex compaction request to fit the active model context window.]";
 const PI_COMPACTION_SUMMARY_PREFIX = "The conversation history before this point was compacted into the following summary:";
 
@@ -212,15 +216,16 @@ export function boundCompactionInput(
   contextWindow: number,
   requestPayload?: Record<string, unknown>,
 ): unknown[] | undefined {
-  const budget = Math.max(1, Math.floor(contextWindow - COMPACTION_RESPONSE_RESERVE_TOKENS));
-  // A byte-level bound is conservative when the active model's tokenizer is unavailable:
-  // a token can be represented by a single UTF-8 byte, but not fewer.
-  const budgetBytes = budget;
+  if (!Number.isFinite(contextWindow) || contextWindow <= 0) return undefined;
+  const budgetTokens = Math.max(0, Math.floor(contextWindow) - COMPACTION_RESPONSE_RESERVE_TOKENS);
   const bounded = input.map((item) => item);
-  let requestBytes = estimateConservativeBytes(
+  let requestBytes = serializedBytes(
     buildCompactionRequest(requestPayload, bounded, instructions, tools),
   );
-  if (requestBytes <= budgetBytes) return bounded;
+  if (!Number.isFinite(requestBytes)) return undefined;
+  const fits = () => requestBytes <= MAX_COMPACTION_REQUEST_BYTES &&
+    Math.ceil(requestBytes / APPROX_BYTES_PER_TOKEN) <= budgetTokens;
+  if (fits()) return bounded;
 
   // ponytail: trim tool outputs first; if structural content still exceeds the active model window,
   // let Pi's standard compaction path handle the request instead of inventing a lossy transcript rewrite.
@@ -229,9 +234,13 @@ export function boundCompactionInput(
     const replacement = trimToolOutput(item);
     if (!replacement) continue;
 
-    requestBytes += estimateConservativeBytes(replacement) - estimateConservativeBytes(item);
+    const removedBytes = serializedBytes(item) - serializedBytes(replacement);
+    // A short output can be smaller than the omission notice. Never make a
+    // request larger while trying to fit either limit.
+    if (removedBytes <= 0) continue;
+    requestBytes -= removedBytes;
     bounded[index] = replacement;
-    if (requestBytes <= budgetBytes) return bounded;
+    if (fits()) return bounded;
   }
 
   return undefined;
@@ -487,9 +496,11 @@ function buildCompactionRequest(
   tools: readonly unknown[],
 ): Record<string, unknown> {
   const payload: Record<string, unknown> = requestPayload ? { ...requestPayload } : {};
-  payload.instructions = instructions;
+  // Measure the actual transformed envelope, including cooperating extensions'
+  // instruction/tool changes. The separate arguments are defaults only.
+  if (!("instructions" in payload)) payload.instructions = instructions;
   payload.input = input;
-  if (tools.length > 0 || requestPayload && "tools" in requestPayload) payload.tools = tools;
+  if (!("tools" in payload) && tools.length > 0) payload.tools = tools;
   return payload;
 }
 
@@ -510,10 +521,10 @@ function trimToolOutput(value: unknown): unknown | undefined {
   return undefined;
 }
 
-function estimateConservativeBytes(value: unknown): number {
+function serializedBytes(value: unknown): number {
   try {
     const json = JSON.stringify(value) ?? "";
-    return new TextEncoder().encode(json).byteLength;
+    return Buffer.byteLength(json, "utf8");
   } catch {
     return Number.POSITIVE_INFINITY;
   }

--- a/packages/pi-codex-compaction/tests/extension.test.mjs
+++ b/packages/pi-codex-compaction/tests/extension.test.mjs
@@ -6,6 +6,7 @@ process.env.CI = "1";
 const { default: piCodexCompaction } = await import("../extensions/index.ts");
 const {
   REMOTE_SUMMARY_MARKER,
+  MAX_COMPACTION_REQUEST_BYTES,
   applyRemoteCompactionMarker,
   boundCompactionInput,
   buildFallbackSummary,
@@ -543,9 +544,48 @@ test("reduces tool outputs before rejecting an input that cannot fit the active 
   assert.equal(boundCompactionInput([{ type: "message", content: [{ text: "a".repeat(2_000) }] }], "system", [], 1_000), undefined);
 });
 
-test("rejects token-dense input with the conservative byte bound", () => {
+test("uses UTF-8 bytes rather than UTF-16 length for the token estimate", () => {
   const input = [{ type: "message", content: [{ text: "😀".repeat(100) }] }];
   assert.equal(boundCompactionInput(input, "system", [], 8_292), undefined);
+});
+
+test("checks token boundaries separately from request bytes and rejects unknown context limits", () => {
+  const input = [{ type: "message", content: [{ text: "review this change ".repeat(20_000) }] }];
+  const requestBytes = Buffer.byteLength(JSON.stringify({ instructions: "system", input }), "utf8");
+  const estimate = Math.ceil(requestBytes / 4);
+  assert.deepEqual(boundCompactionInput(input, "system", [], estimate + 8_192), input);
+  assert.equal(boundCompactionInput(input, "system", [], estimate + 8_191), undefined);
+  for (const contextWindow of [NaN, Infinity, -Infinity, 0, -1, 8_192]) {
+    assert.equal(boundCompactionInput(input, "system", [], contextWindow), undefined);
+  }
+});
+
+test("keeps the byte ceiling even with a large token budget", async (t) => {
+  const input = [{ type: "message", content: [{ text: "x".repeat(MAX_COMPACTION_REQUEST_BYTES) }] }];
+  assert.equal(boundCompactionInput(input, "", [], 100_000_000), undefined);
+  let calls = 0;
+  t.mock.method(globalThis, "fetch", async () => { calls++; throw new Error("must not send"); });
+  await assert.rejects(requestRemoteCompaction({ model, apiKey: token, body: { input } }), /size limit/);
+  assert.equal(calls, 0);
+});
+
+test("counts the complete transformed envelope and leaves source inputs unchanged", () => {
+  const input = Object.freeze([
+    Object.freeze({ type: "function_call_output", call_id: "short", output: "OK" }),
+    Object.freeze({ type: "function_call_output", call_id: "long", output: "x".repeat(80_000) }),
+  ]);
+  const bounded = boundCompactionInput(input, "system", [], 20_000);
+  assert.equal(bounded[0], input[0]);
+  assert.match(bounded[1].output, /^\[Tool output omitted/);
+  assert.equal(input[1].output.length, 80_000);
+
+  for (const field of ["instructions", "tools", "metadata", "text"]) {
+    const payload = { input: [], [field]: "x".repeat(80_000) };
+    assert.equal(boundCompactionInput([], "small default", [], 20_000, payload), undefined, field);
+  }
+  const cyclic = {};
+  cyclic.self = cyclic;
+  assert.equal(boundCompactionInput([], "", [], 20_000, cyclic), undefined);
 });
 
 test("keeps a bounded readable fallback for model switches", () => {

--- a/packages/pi-codex-compaction/tests/extension.test.mjs
+++ b/packages/pi-codex-compaction/tests/extension.test.mjs
@@ -94,6 +94,7 @@ function makePi() {
 function makeContext(overrides = {}) {
   return {
     model,
+    mode: "tui",
     hasUI: false,
     ui: { notify() {} },
     getSystemPrompt: () => "system",
@@ -812,11 +813,14 @@ test("the hook records explicit byte-limit and unavailable-context reasons witho
   assert.equal(requests, 0);
 });
 
-test("fallback diagnostics omit custom instructions, missing auth details, and raw failures", async () => {
+test("fallback diagnostics classify preparation failures without exposing private details", async (t) => {
+  let requests = 0;
+  t.mock.method(globalThis, "fetch", async () => { requests++; throw new Error("must not send"); });
   for (const [event, context, reason] of [
     [{ customInstructions: "PRIVATE_INSTRUCTIONS" }, {}, "custom-instructions"],
     [{}, { modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: false }) } }, "auth-unavailable"],
-    [{}, { modelRegistry: { getApiKeyAndHeaders: async () => { throw new Error(token); } } }, "remote-failed"],
+    [{}, { modelRegistry: { getApiKeyAndHeaders: async () => { throw new Error(token); } } }, "request-unavailable"],
+    [{}, { getSystemPrompt: () => { throw new Error("PRIVATE_PREPARATION"); } }, "request-unavailable"],
   ]) {
     const pi = makePi();
     const result = await pi.handlers.get("session_before_compact")({
@@ -826,6 +830,50 @@ test("fallback diagnostics omit custom instructions, missing auth details, and r
     assert.deepEqual(pi.diagnostics, [{
       customType: COMPACTION_FALLBACK_ENTRY, data: { version: 1, reason },
     }]);
+  }
+  assert.equal(requests, 0);
+});
+
+test("the compaction hook sizes deleted and undefined envelope fields as transmitted", async (t) => {
+  const requests = [];
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    requests.push(JSON.parse(init.body));
+    return new Response(`data: ${JSON.stringify({
+      type: "response.completed",
+      response: { status: "completed", output: [{ type: "compaction", encrypted_content: "fixture-checkpoint" }] },
+    })}\n\n`);
+  });
+  for (const fields of [["instructions"], ["tools"], ["instructions", "tools"]]) {
+    for (const removal of ["delete", "undefined"]) {
+      const pi = makePi();
+      pi.getActiveTools = () => ["fixture"];
+      pi.getAllTools = () => [{
+        name: "fixture",
+        description: fields.includes("tools") ? "omitted schema ".repeat(8_000) : "small schema",
+        parameters: { type: "object", properties: {} },
+      }];
+      pi.events = {
+        emit(name, data) {
+          if (name !== "pi-codex-compaction:request:v1") return;
+          for (const field of fields) {
+            assert.ok(Object.hasOwn(data.payload, field));
+            if (removal === "delete") delete data.payload[field];
+            else data.payload[field] = undefined;
+          }
+        },
+      };
+      const before = requests.length;
+      const result = await pi.handlers.get("session_before_compact")({
+        preparation: preparation(), signal: new AbortController().signal,
+      }, makeContext({
+        model: { ...model, contextWindow: 20_000 },
+        getSystemPrompt: () => fields.includes("instructions") ? "omitted prompt ".repeat(8_000) : "system",
+      }));
+      assert.equal(result?.compaction?.details?.kind, "pi-codex-compaction", `${removal}: ${fields}`);
+      assert.equal(requests.length, before + 1);
+      for (const field of fields) assert.equal(Object.hasOwn(requests.at(-1), field), false);
+      assert.deepEqual(pi.diagnostics, []);
+    }
   }
 });
 
@@ -869,12 +917,17 @@ test("diagnostic write/notification failures do not stop standard fallback", asy
   assert.equal(result, undefined);
 });
 
-test("non-UI fallback records its reason without calling notification APIs", async () => {
-  const pi = makePi();
-  let notices = 0;
-  await pi.handlers.get("session_before_compact")({
-    preparation: preparation(), customInstructions: "focus", signal: new AbortController().signal,
-  }, makeContext({ hasUI: false, mode: "print", ui: { notify() { notices++; } } }));
-  assert.equal(notices, 0);
-  assert.equal(pi.diagnostics[0].data.reason, "custom-instructions");
+test("non-TUI and non-UI fallback never call notification APIs", async () => {
+  for (const mode of ["tui", "print", "json", "rpc"]) {
+    for (const hasUI of [false, true]) {
+      if (mode === "tui" && hasUI) continue;
+      const pi = makePi();
+      let notices = 0;
+      await pi.handlers.get("session_before_compact")({
+        preparation: preparation(), customInstructions: "focus", signal: new AbortController().signal,
+      }, makeContext({ hasUI, mode, ui: { notify() { notices++; } } }));
+      assert.equal(notices, 0, `${mode}, hasUI: ${hasUI}`);
+      assert.equal(pi.diagnostics[0].data.reason, "custom-instructions");
+    }
+  }
 });

--- a/packages/pi-codex-compaction/tests/extension.test.mjs
+++ b/packages/pi-codex-compaction/tests/extension.test.mjs
@@ -1,11 +1,17 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { beforeEach } from "node:test";
 
 process.env.CI = "1";
+process.env.PI_OFFLINE = "1";
+
+beforeEach((t) => {
+  t.mock.method(globalThis, "fetch", async () => { throw new Error("Unmocked network request blocked"); });
+});
 
 const { default: piCodexCompaction } = await import("../extensions/index.ts");
 const {
   REMOTE_SUMMARY_MARKER,
+  COMPACTION_FALLBACK_ENTRY,
   MAX_COMPACTION_REQUEST_BYTES,
   applyRemoteCompactionMarker,
   boundCompactionInput,
@@ -61,8 +67,13 @@ function preparation(overrides = {}) {
 
 function makePi() {
   const handlers = new Map();
+  const diagnostics = [];
   const pi = {
     handlers,
+    diagnostics,
+    appendEntry(customType, data) {
+      diagnostics.push({ customType, data });
+    },
     on(event, handler) {
       handlers.set(event, handler);
     },
@@ -588,6 +599,22 @@ test("counts the complete transformed envelope and leaves source inputs unchange
   assert.equal(boundCompactionInput([], "", [], 20_000, cyclic), undefined);
 });
 
+test("size trimming preserves opaque checkpoints, reasoning, user input, and custom-tool calls", () => {
+  const input = [
+    { type: "compaction", encrypted_content: "opaque-fixture".repeat(8_000) },
+    { type: "reasoning", encrypted_content: "reasoning-fixture".repeat(2_000) },
+    { type: "message", role: "user", content: [{ type: "input_text", text: "keep this input" }] },
+    { type: "custom_tool_call", call_id: "patch", name: "apply_patch", input: "keep this grammar input" },
+    { type: "custom_tool_call_output", call_id: "patch", output: "large fixture ".repeat(30_000) },
+    { type: "compaction_trigger" },
+  ];
+  const bounded = boundCompactionInput(input, "system", [], 100_000);
+  assert.ok(bounded);
+  for (const index of [0, 1, 2, 3, 5]) assert.equal(bounded[index], input[index]);
+  assert.match(bounded[4].output, /^\[Tool output omitted/);
+  assert.equal(input[4].output.length, "large fixture ".length * 30_000);
+});
+
 test("keeps a bounded readable fallback for model switches", () => {
   const summary = buildFallbackSummary(
     preparation({ messagesToSummarize: [{ role: "user", content: "x".repeat(50_000), timestamp: 1 }] }),
@@ -737,4 +764,117 @@ test("does not reuse a checkpoint across account, auth-mode, or model changes", 
     },
   });
   assert.equal(await pi.handlers.get("before_provider_request")({ payload }, unknownAuthMode), undefined);
+});
+
+test("the compaction hook reports safe context-limit diagnostics instead of a silent skip", async (t) => {
+  t.mock.method(globalThis, "fetch", async () => { throw new Error("must not send"); });
+  const pi = makePi();
+  const notices = [];
+  const context = makeContext({
+    model: { ...model, contextWindow: 20_000 },
+    getSystemPrompt: () => "PRIVATE_PROMPT".repeat(8_000),
+    hasUI: true,
+    ui: { notify(message, level) { notices.push({ message, level }); } },
+  });
+  const result = await pi.handlers.get("session_before_compact")({
+    preparation: preparation(), signal: new AbortController().signal,
+  }, context);
+  assert.equal(result, undefined);
+  assert.equal(pi.diagnostics.length, 1);
+  const { customType, data } = pi.diagnostics[0];
+  assert.equal(customType, COMPACTION_FALLBACK_ENTRY);
+  assert.equal(data.version, 1);
+  assert.equal(data.reason, "context-limit");
+  assert.equal(data.tokenBudget, 11_808);
+  assert.equal(data.estimatedTokens, Math.ceil(data.requestBytes / 4));
+  assert.ok(data.estimatedTokens > data.tokenBudget);
+  assert.equal(data.byteLimit, MAX_COMPACTION_REQUEST_BYTES);
+  assert.equal(data.trimmedToolOutputs, 0);
+  assert.equal(notices.length, 1);
+  assert.match(notices[0].message, /token budget.*standard Pi/);
+  assert.equal(notices[0].level, "warning");
+  assert.doesNotMatch(JSON.stringify([pi.diagnostics, notices]), /PRIVATE_PROMPT|acct_test|signature/);
+});
+
+test("the hook records explicit byte-limit and unavailable-context reasons without a request", async (t) => {
+  let requests = 0;
+  t.mock.method(globalThis, "fetch", async () => { requests++; throw new Error("must not send"); });
+  for (const [contextWindow, text, reason] of [
+    [100_000_000, "x".repeat(MAX_COMPACTION_REQUEST_BYTES), "request-size-limit"],
+    [NaN, "small", "context-window-unavailable"],
+  ]) {
+    const pi = makePi();
+    await pi.handlers.get("session_before_compact")({
+      preparation: preparation(), signal: new AbortController().signal,
+    }, makeContext({ model: { ...model, contextWindow }, getSystemPrompt: () => text }));
+    assert.equal(pi.diagnostics[0].data.reason, reason);
+  }
+  assert.equal(requests, 0);
+});
+
+test("fallback diagnostics omit custom instructions, missing auth details, and raw failures", async () => {
+  for (const [event, context, reason] of [
+    [{ customInstructions: "PRIVATE_INSTRUCTIONS" }, {}, "custom-instructions"],
+    [{}, { modelRegistry: { getApiKeyAndHeaders: async () => ({ ok: false }) } }, "auth-unavailable"],
+    [{}, { modelRegistry: { getApiKeyAndHeaders: async () => { throw new Error(token); } } }, "remote-failed"],
+  ]) {
+    const pi = makePi();
+    const result = await pi.handlers.get("session_before_compact")({
+      preparation: preparation(), signal: new AbortController().signal, ...event,
+    }, makeContext(context));
+    assert.equal(result, undefined);
+    assert.deepEqual(pi.diagnostics, [{
+      customType: COMPACTION_FALLBACK_ENTRY, data: { version: 1, reason },
+    }]);
+  }
+});
+
+test("the hook reports invalid transformed requests without exposing their payload", async () => {
+  const pi = makePi();
+  pi.events = {
+    emit(name, data) {
+      if (name === "pi-codex-compaction:request:v1") data.payload.input = "PRIVATE_PAYLOAD";
+    },
+  };
+  await pi.handlers.get("session_before_compact")({
+    preparation: preparation(), signal: new AbortController().signal,
+  }, makeContext());
+  assert.deepEqual(pi.diagnostics, [{
+    customType: COMPACTION_FALLBACK_ENTRY, data: { version: 1, reason: "request-unavailable" },
+  }]);
+});
+
+test("cancellation and unsupported models do not create fallback diagnostics", async (t) => {
+  let authCalls = 0;
+  t.mock.method(globalThis, "fetch", async () => { throw new Error("must not send"); });
+  const pi = makePi();
+  const controller = new AbortController();
+  controller.abort();
+  await pi.handlers.get("session_before_compact")({
+    preparation: preparation(), signal: controller.signal,
+  }, makeContext({ modelRegistry: { getApiKeyAndHeaders() { authCalls++; throw new Error("must not resolve auth"); } } }));
+  await pi.handlers.get("session_before_compact")({
+    preparation: preparation(), signal: new AbortController().signal,
+  }, makeContext({ model: { ...model, provider: "other" } }));
+  assert.equal(authCalls, 0);
+  assert.deepEqual(pi.diagnostics, []);
+});
+
+test("diagnostic write/notification failures do not stop standard fallback", async () => {
+  const pi = makePi();
+  pi.appendEntry = () => { throw new Error("fixture disk failure"); };
+  const result = await pi.handlers.get("session_before_compact")({
+    preparation: preparation(), customInstructions: "focus", signal: new AbortController().signal,
+  }, makeContext({ hasUI: true, ui: { notify() { throw new Error("fixture UI failure"); } } }));
+  assert.equal(result, undefined);
+});
+
+test("non-UI fallback records its reason without calling notification APIs", async () => {
+  const pi = makePi();
+  let notices = 0;
+  await pi.handlers.get("session_before_compact")({
+    preparation: preparation(), customInstructions: "focus", signal: new AbortController().signal,
+  }, makeContext({ hasUI: false, mode: "print", ui: { notify() { notices++; } } }));
+  assert.equal(notices, 0);
+  assert.equal(pi.diagnostics[0].data.reason, "custom-instructions");
 });

--- a/packages/pi-codex-compaction/tests/integration.test.mjs
+++ b/packages/pi-codex-compaction/tests/integration.test.mjs
@@ -1,12 +1,16 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { beforeEach } from "node:test";
 import { codexHarness, compactionResponse, requestBody, textResponse } from "../../../tests/codex-harness.mjs";
 
 process.env.CI = "1";
 process.env.PI_OFFLINE = "1";
+beforeEach((t) => {
+  t.mock.method(globalThis, "fetch", async () => { throw new Error("Unmocked network request blocked"); });
+});
 const { default: fast } = await import("../../pi-fast/extensions/index.ts");
 const { default: tools } = await import("../../pi-codex-tools/extensions/index.ts");
 const { default: compaction } = await import("../extensions/index.ts");
+const { COMPACTION_FALLBACK_ENTRY } = await import("../src/index.ts");
 const zeroUsage = {
   input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
@@ -99,6 +103,9 @@ test("a remote rejection uses the actual standard Pi compactor", async (t) => {
     assert.notEqual(result.details?.kind, "pi-codex-compaction");
     assert.equal(requests.length, 2);
     assert.equal(requests[1].input.some((item) => item.type === "compaction_trigger"), false);
+    assert.deepEqual(h.sessionManager.getBranch().find((entry) => entry.customType === COMPACTION_FALLBACK_ENTRY)?.data, {
+      version: 1, reason: "remote-failed",
+    });
     assert.deepEqual(h.errors, []);
   } finally { await h.close(); }
 });
@@ -128,6 +135,38 @@ test("real Pi uses remote compaction when transcript bytes exceed the token budg
     assert.ok(requests[0].input.some((item) => JSON.stringify(item).includes(oldText.slice(0, 50))));
     assert.equal(JSON.stringify(requests[0].input).includes("kept request"), false);
     assert.equal(h.sessionManager.getBranch().findLast((entry) => entry.type === "compaction").fromHook, true);
+    assert.equal(h.sessionManager.getBranch().some((entry) => entry.customType === COMPACTION_FALLBACK_ENTRY), false);
+    assert.deepEqual(h.errors, []);
+  } finally { await h.close(); }
+});
+
+test("real Pi records a size fallback and keeps its diagnostic out of later model input", async (t) => {
+  const requests = [];
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    const body = requestBody(init);
+    requests.push(body);
+    assert.equal(body.input.some((item) => item.type === "compaction_trigger"), false);
+    return textResponse("standard summary");
+  });
+  const h = await codexHarness([compaction]);
+  try {
+    await h.session.setModel({ ...h.model, contextWindow: 20_000 });
+    for (const [index, content] of ["PRIVATE_HISTORY ".repeat(6_000), "kept request"].entries()) {
+      h.sessionManager.appendMessage({ role: "user", content, timestamp: index + 1 });
+    }
+    const result = await h.session.compact();
+    assert.equal(result.summary, "standard summary");
+    assert.equal(requests.length, 1);
+    const branch = h.sessionManager.getBranch();
+    const data = branch.find((entry) => entry.customType === COMPACTION_FALLBACK_ENTRY)?.data;
+    assert.equal(data.reason, "context-limit");
+    assert.ok(data.estimatedTokens > data.tokenBudget);
+    assert.doesNotMatch(JSON.stringify(data), /PRIVATE_HISTORY|acct_fixture|test-signature/);
+    assert.equal(branch.findLast((entry) => entry.type === "compaction").fromHook, false);
+    await h.session.prompt("continue", { expandPromptTemplates: false });
+    assert.equal(requests.length, 2);
+    assert.equal(JSON.stringify(requests[1]).includes(COMPACTION_FALLBACK_ENTRY), false);
+    assert.equal(JSON.stringify(requests[1]).includes("estimatedTokens"), false);
     assert.deepEqual(h.errors, []);
   } finally { await h.close(); }
 });

--- a/packages/pi-codex-compaction/tests/integration.test.mjs
+++ b/packages/pi-codex-compaction/tests/integration.test.mjs
@@ -170,3 +170,40 @@ test("real Pi records a size fallback and keeps its diagnostic out of later mode
     assert.deepEqual(h.errors, []);
   } finally { await h.close(); }
 });
+
+test("real Pi sizes the envelope after a cooperating extension removes fields", async (t) => {
+  const requests = [];
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    const body = requestBody(init);
+    requests.push(body);
+    return body.input.some((item) => item.type === "compaction_trigger")
+      ? compactionResponse()
+      : textResponse("unexpected standard fallback");
+  });
+  const h = await codexHarness([compaction, (pi) => {
+    pi.events.on("pi-codex-compaction:tools:v1", (data) => {
+      assert.ok(data.tools.length > 0);
+      data.tools = [{ ...data.tools[0], description: "omitted schema ".repeat(8_000) }];
+    });
+    pi.events.on("pi-codex-compaction:request:v1", (data) => {
+      delete data.payload.instructions;
+      delete data.payload.tools;
+    });
+  }]);
+  try {
+    await h.session.setModel({ ...h.model, contextWindow: 20_000 });
+    for (const [index, content] of ["old request", "kept request"].entries()) {
+      h.sessionManager.appendMessage({ role: "user", content, timestamp: index + 1 });
+    }
+    const result = await h.session.compact();
+    assert.equal(result.details?.kind, "pi-codex-compaction");
+    assert.equal(requests.length, 1);
+    assert.equal(Object.hasOwn(requests[0], "instructions"), false);
+    assert.equal(Object.hasOwn(requests[0], "tools"), false);
+    assert.equal(requests[0].input.at(-1).type, "compaction_trigger");
+    assert.equal(JSON.stringify(requests[0].input).includes("kept request"), false);
+    assert.equal(h.sessionManager.getBranch().findLast((entry) => entry.type === "compaction").fromHook, true);
+    assert.equal(h.sessionManager.getBranch().some((entry) => entry.customType === COMPACTION_FALLBACK_ENTRY), false);
+    assert.deepEqual(h.errors, []);
+  } finally { await h.close(); }
+});

--- a/packages/pi-codex-compaction/tests/integration.test.mjs
+++ b/packages/pi-codex-compaction/tests/integration.test.mjs
@@ -102,3 +102,32 @@ test("a remote rejection uses the actual standard Pi compactor", async (t) => {
     assert.deepEqual(h.errors, []);
   } finally { await h.close(); }
 });
+
+test("real Pi uses remote compaction when transcript bytes exceed the token budget", async (t) => {
+  const requests = [];
+  t.mock.method(globalThis, "fetch", async (_url, init) => {
+    const body = requestBody(init);
+    requests.push(body);
+    return body.input.some((item) => item.type === "compaction_trigger")
+      ? compactionResponse()
+      : textResponse("unexpected standard fallback");
+  });
+  const h = await codexHarness([compaction]);
+  try {
+    // Synthetic history: no private session text or encrypted provider data.
+    const oldText = "Keep the implementation and regression tests consistent.\n".repeat(6_000);
+    const tokenBudget = h.model.contextWindow - 8_192;
+    assert.ok(Buffer.byteLength(oldText) > tokenBudget);
+    for (const [index, content] of [oldText, "kept request"].entries()) {
+      h.sessionManager.appendMessage({ role: "user", content, timestamp: index + 1 });
+    }
+    const result = await h.session.compact();
+    assert.equal(result.details?.kind, "pi-codex-compaction");
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].input.at(-1).type, "compaction_trigger");
+    assert.ok(requests[0].input.some((item) => JSON.stringify(item).includes(oldText.slice(0, 50))));
+    assert.equal(JSON.stringify(requests[0].input).includes("kept request"), false);
+    assert.equal(h.sessionManager.getBranch().findLast((entry) => entry.type === "compaction").fromHook, true);
+    assert.deepEqual(h.errors, []);
+  } finally { await h.close(); }
+});


### PR DESCRIPTION
## Summary
- Fix the byte/token mix-up that caused long Codex sessions to fall back to standard Pi compaction.
- Use a dependency-free UTF-8 token estimate while retaining the separate 16 MiB request limit, response reserve, complete request-envelope checks, and safe fallback.
- Record fixed fallback reason codes and numeric size counters without prompts, credentials, account identifiers, encrypted checkpoints, or raw provider errors.
- Add real Pi integration regressions and prepare patch release `pi-codex-compaction@0.1.3`.

## Validation
- Package typecheck and all 41 tests pass.
- Review regressions reproduced the removed-field sizing, non-TUI notification, and preparation-reason issues before the fixes; all pass after the fixes.
- Full repository `npm run validate` passes, including the dependency audit and pack checks.
- Scoped lock refresh and `npm ci --dry-run` pass; only the package version changes in the lockfile.
- Packed files inspected: 13 runtime/documentation files; no tests, private sessions, or diagnostic artifacts.
- Pi's loader registers all three compaction hooks.
- Offline replay of the original discarded history reaches the remote path with fake auth and mocked transport. No live compaction requests were made.
- `git diff --check` passes.

## Release
- Version and changelog: `0.1.3`, dated `2026-09-11`.
- After merge, create `pi-codex-compaction@0.1.3`; the existing GitHub release workflow publishes to npm with provenance.
- No changes to authentication, endpoints, checkpoint compatibility, or dependencies.
