### PR TITLE
Release pi-codex-image-gen 0.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5089,7 +5089,7 @@
       }
     },
     "packages/pi-codex-image-gen": {
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@mocito/install-telemetry": "0.1.1"

--- a/packages/pi-codex-image-gen/CHANGELOG.md
+++ b/packages/pi-codex-image-gen/CHANGELOG.md
@@ -6,6 +6,8 @@ This project follows the spirit of [Keep a Changelog](https://keepachangelog.com
 
 ## [Unreleased]
 
+## [0.1.13] - 2026-09-11
+
 ### Added
 
 - Report backend image metadata, generation stages, byte counts, and elapsed time without guessing the served image model.

--- a/packages/pi-codex-image-gen/package.json
+++ b/packages/pi-codex-image-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-image-gen",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Image generation and editing for Pi using your ChatGPT Codex login.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Prepare the approved patch release after #136. Update package and lockfile versions and promote Unreleased notes. Scoped lock refresh, npm ci --dry-run, full repository validation, and diff checks pass. Publishing will follow merge through the release workflow.