### PR TITLE
Fix Codex prompt monitor source path

### DIFF
--- a/.github/workflows/sync-codex-prompt.yml
+++ b/.github/workflows/sync-codex-prompt.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Fetch original prompt from Codex
         run: |
           curl -fsSL -o /tmp/codex-prompt.md \
-            "https://raw.githubusercontent.com/openai/codex/main/codex-rs/tui/prompt_for_init_command.md"
+            "https://raw.githubusercontent.com/openai/codex/main/codex-rs/tui/assets/prompt_for_init_command.md"
           if [ ! -s /tmp/codex-prompt.md ]; then
             echo "::error::Failed to fetch original prompt from Codex repo"
             exit 1
@@ -83,7 +83,7 @@ jobs:
             --body-file - <<BODY
           ## Upstream Change Detected
 
-          The original prompt in the [OpenAI Codex repository](https://github.com/openai/codex/blob/main/codex-rs/tui/prompt_for_init_command.md) has changed.
+          The original prompt in the [OpenAI Codex repository](https://github.com/openai/codex/blob/main/codex-rs/tui/assets/prompt_for_init_command.md) has changed.
 
           ### Action Required
 
@@ -91,7 +91,7 @@ jobs:
 
           ### References
 
-          - Source: https://github.com/openai/codex/blob/main/codex-rs/tui/prompt_for_init_command.md
+          - Source: https://github.com/openai/codex/blob/main/codex-rs/tui/assets/prompt_for_init_command.md
           - Local file: packages/pi-agentsmd/prompts/init.md
           - New upstream SHA-256: \`${ACTUAL_SHA256}\`
           - THIRD-PARTY-NOTICES: packages/pi-agentsmd/THIRD-PARTY-NOTICES

--- a/tests/codex-prompt-sync.test.mjs
+++ b/tests/codex-prompt-sync.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(
+  new URL("../.github/workflows/sync-codex-prompt.yml", import.meta.url),
+  "utf8",
+);
+
+test("Codex prompt monitor fetches the relocated upstream asset", () => {
+  const fetchStep = workflow.split("- name: Fetch original prompt from Codex")[1]?.split("- name:")[0];
+  assert.ok(fetchStep, "The workflow must retain the fetch step");
+  assert.match(
+    fetchStep,
+    /curl -fsSL -o \/tmp\/codex-prompt\.md \\\n\s+"https:\/\/raw\.githubusercontent\.com\/openai\/codex\/main\/codex-rs\/tui\/assets\/prompt_for_init_command\.md"/,
+  );
+});
+
+test("Codex prompt monitor issue links use the relocated upstream asset", () => {
+  const links = workflow.match(/https:\/\/github\.com\/openai\/codex\/blob\/main\/[^)\s]+/g);
+  assert.deepEqual(links, Array(2).fill(
+    "https://github.com/openai/codex/blob/main/codex-rs/tui/assets/prompt_for_init_command.md",
+  ));
+  assert.ok(!workflow.includes("tui/prompt_for_init_command.md"));
+});


### PR DESCRIPTION
## Summary
- Update the moved upstream Codex prompt URL and issue links.
- Add workflow regression tests.

## Validation
- npm run validate
- Run workflow fetch and comparison steps against the live source: unchanged SHA-256.
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated automated Codex prompt synchronization to use the prompt’s relocated upstream path.
  - Updated related issue references to point to the current prompt location.

- **Tests**
  - Added coverage confirming the workflow fetches the correct prompt path and no longer references the outdated location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->